### PR TITLE
Add npm publish workflow for trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Adds GitHub Actions workflow for automated npm publishing with provenance.

## What this does
- Triggers on GitHub Release creation
- Publishes to npm with `--provenance` flag for supply chain security
- Uses npm trusted publishing (OIDC)

## Setup required
After merging, configure npm trusted publishing at:
https://www.npmjs.com/package/@jtalk22/slack-mcp/access

- Repository: `https://github.com/jtalk22/slack-mcp-server`
- Workflow filename: `publish.yml`