### PR TITLE
Fix OIDC publishing and bump to 1.0.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,5 +24,3 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jtalk22/slack-mcp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "MCP server for Slack - Access DMs, channels, and messages from Claude",
   "type": "module",
   "main": "src/server.js",


### PR DESCRIPTION
Remove NODE_AUTH_TOKEN for proper OIDC trusted publishing