### PR TITLE
chore(deps): update @modelcontextprotocol/sdk to 1.25.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "@jtalk22/slack-mcp",
-  "version": "1.1.2",
+  "version": "1.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jtalk22/slack-mcp",
-      "version": "1.1.2",
+      "version": "1.1.9",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@modelcontextprotocol/sdk": "^1.25.2",
         "express": "^4.18.2"
       },
       "bin": {
+        "slack-mcp-http": "src/server-http.js",
         "slack-mcp-server": "src/server.js",
         "slack-mcp-web": "src/web-server.js"
       },
@@ -40,9 +41,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.1.tgz",
-      "integrity": "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ==",
+      "version": "1.25.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.2.tgz",
+      "integrity": "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.7",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@modelcontextprotocol/sdk": "^1.25.2",
     "express": "^4.18.2"
   },
   "files": [


### PR DESCRIPTION
Updates MCP SDK for latest features and fixes. Tested locally.