### PR TITLE
Fix: use form-encoded params for Slack endpoints that require it

### DIFF
--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -30,6 +30,7 @@ const FORM_ENCODED_METHODS = new Set([
   "search.messages",
   "search.all",
   "search.files",
+  "users.info",
 ]);
 
 let lastRefreshAttempt = 0;

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -24,6 +24,14 @@ const RETRYABLE_NETWORK_ERRORS = [
   'ECONNREFUSED', 'EPIPE', 'UND_ERR_CONNECT_TIMEOUT'
 ];
 
+// Slack API methods that require form-encoded params instead of JSON
+const FORM_ENCODED_METHODS = new Set([
+  "conversations.replies",
+  "search.messages",
+  "search.all",
+  "search.files",
+]);
+
 let lastRefreshAttempt = 0;
 
 // ============ LRU Cache with TTL ============
@@ -149,14 +157,7 @@ export async function slackAPI(method, params = {}, options = {}) {
     checkTokenHealth({ error: () => {} }).catch(() => {});
   }
 
-  // Some Slack API methods require form-encoded params instead of JSON
-  const FORM_ENCODED_METHODS = [
-    "conversations.replies",
-    "search.messages",
-    "search.all",
-    "search.files",
-  ];
-  const useForm = FORM_ENCODED_METHODS.includes(method);
+  const useForm = FORM_ENCODED_METHODS.has(method);
 
   let response;
   try {
@@ -167,8 +168,16 @@ export async function slackAPI(method, params = {}, options = {}) {
 
     let body;
     if (useForm) {
+      // URLSearchParams coerces non-primitives to "[object Object]",
+      // so stringify any arrays/objects before encoding.
+      const safeParams = {};
+      for (const [key, value] of Object.entries(params)) {
+        safeParams[key] = (typeof value === "object" && value !== null)
+          ? JSON.stringify(value)
+          : String(value);
+      }
       headers["Content-Type"] = "application/x-www-form-urlencoded; charset=utf-8";
-      body = new URLSearchParams(params).toString();
+      body = new URLSearchParams(safeParams).toString();
     } else {
       headers["Content-Type"] = "application/json; charset=utf-8";
       body = JSON.stringify(params);

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -149,16 +149,35 @@ export async function slackAPI(method, params = {}, options = {}) {
     checkTokenHealth({ error: () => {} }).catch(() => {});
   }
 
+  // Some Slack API methods require form-encoded params instead of JSON
+  const FORM_ENCODED_METHODS = [
+    "conversations.replies",
+    "search.messages",
+    "search.all",
+    "search.files",
+  ];
+  const useForm = FORM_ENCODED_METHODS.includes(method);
+
   let response;
   try {
+    const headers = {
+      "Authorization": `Bearer ${creds.token}`,
+      "Cookie": `d=${creds.cookie}`,
+    };
+
+    let body;
+    if (useForm) {
+      headers["Content-Type"] = "application/x-www-form-urlencoded; charset=utf-8";
+      body = new URLSearchParams(params).toString();
+    } else {
+      headers["Content-Type"] = "application/json; charset=utf-8";
+      body = JSON.stringify(params);
+    }
+
     response = await fetch(`https://slack.com/api/${method}`, {
       method: "POST",
-      headers: {
-        "Authorization": `Bearer ${creds.token}`,
-        "Cookie": `d=${creds.cookie}`,
-        "Content-Type": "application/json; charset=utf-8",
-      },
-      body: JSON.stringify(params),
+      headers,
+      body,
     });
   } catch (networkError) {
     // Retry on network errors with exponential backoff + jitter


### PR DESCRIPTION
## Summary

- `conversations.replies`, `search.messages`, `search.all`, and `search.files` return `invalid_arguments` when called with a JSON request body
- These Slack API endpoints require `application/x-www-form-urlencoded` encoding, not `application/json`
- The fix conditionally encodes params as form data for these endpoints while keeping JSON for everything else

## How to Reproduce

Call `slack_get_thread` or `slack_search_messages` — both fail with `invalid_arguments` because the underlying `slackAPI()` function sends JSON to endpoints that only accept form-encoded params.

Confirmed via direct curl:
```bash
# This fails (JSON body):
curl -X POST https://slack.com/api/conversations.replies \
  -H "Content-Type: application/json" \
  -d '{"channel":"C123","ts":"1234567890.123456"}'

# This works (form-encoded):
curl -X POST https://slack.com/api/conversations.replies \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "channel=C123&ts=1234567890.123456"
```

## Test Plan

- [x] Verified `slack_search_messages` returns results after fix
- [x] Verified `slack_get_thread` returns thread replies after fix
- [x] Verified other endpoints (e.g. `conversations.history`, `chat.postMessage`) still work with JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved how requests are constructed for Slack interactions to increase compatibility and reliability across different API endpoints.
  * Enhanced per-request header and body handling so calls automatically use the most appropriate encoding and content type, reducing failures and improving interoperability for search and conversation-reply workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->