### PR TITLE
fix: keep server metadata within registry constraints

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.jtalk22/slack-mcp-server",
   "title": "Slack MCP Server",
-  "description": "Session-based Slack access for Claude—DMs, channels, search, and threads—local-first with your existing Slack session.",
+  "description": "Session-based Slack access for Claude: DMs, channels, search, and threads via your Slack session.",
   "websiteUrl": "https://jtalk22.github.io/slack-mcp-server/public/demo.html",
   "icons": [
     {


### PR DESCRIPTION
## Summary
- shorten the `server.json` description to satisfy MCP registry validation limits
- keep local metadata aligned with the published `v2.0.0` registry entry

## Validation
- MCP registry `POST /v0.1/validate` returns `valid: true`
- registry latest endpoint resolves version `2.0.0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined the description text for improved clarity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->