### PR TITLE
ci: fix attribution guardrail for GitHub merge commits

### DIFF
--- a/.github/workflows/attribution-guardrail.yml
+++ b/.github/workflows/attribution-guardrail.yml
@@ -63,6 +63,7 @@ jobs:
           EXPECTED_GIT_NAME: jtalk22
           EXPECTED_GIT_EMAIL: james@revasser.nyc
           SKIP_LOCAL_CONFIG_CHECK: "1"
+          ALLOW_GITHUB_WEB_COMMITTER: "1"
         run: |
           bash scripts/check-owner-attribution.sh "${{ steps.commit_range.outputs.range }}"
 

--- a/scripts/check-owner-attribution.sh
+++ b/scripts/check-owner-attribution.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 EXPECTED_NAME="${EXPECTED_GIT_NAME:-jtalk22}"
 EXPECTED_EMAIL="${EXPECTED_GIT_EMAIL:-james@revasser.nyc}"
+ALLOW_GITHUB_WEB_COMMITTER="${ALLOW_GITHUB_WEB_COMMITTER:-0}"
 BANNED_REGEX='(?i)(co-authored-by|generated with|\bclaude\b|\bgpt\b|\bcopilot\b|\bgemini\b|\bai\b)'
 
 die() {
@@ -18,6 +19,48 @@ contains_banned_markers() {
     grep -Eiq '(Co-authored-by|Generated with|Claude|GPT|Copilot|Gemini)' <<<"$text" \
       || grep -Eiq '(^|[^[:alnum:]_])[Aa][Ii]([^[:alnum:]_]|$)' <<<"$text"
   fi
+}
+
+is_allowed_owner_author() {
+  local name="$1"
+  local email="$2"
+
+  if [[ "$name" != "$EXPECTED_NAME" ]]; then
+    return 1
+  fi
+
+  if [[ "$email" == "$EXPECTED_EMAIL" ]]; then
+    return 0
+  fi
+
+  if [[ "$ALLOW_GITHUB_WEB_COMMITTER" == "1" ]]; then
+    if [[ "$email" == "${EXPECTED_NAME}@users.noreply.github.com" || "$email" =~ ^[0-9]+\+${EXPECTED_NAME}@users\.noreply\.github\.com$ ]]; then
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+is_allowed_owner_committer() {
+  local committer_name="$1"
+  local committer_email="$2"
+  local author_name="$3"
+  local author_email="$4"
+
+  if [[ "$committer_name" == "$EXPECTED_NAME" && "$committer_email" == "$EXPECTED_EMAIL" ]]; then
+    return 0
+  fi
+
+  if [[ "$ALLOW_GITHUB_WEB_COMMITTER" == "1" ]]; then
+    if [[ "$committer_name" == "GitHub" && "$committer_email" == "noreply@github.com" ]]; then
+      if is_allowed_owner_author "$author_name" "$author_email"; then
+        return 0
+      fi
+    fi
+  fi
+
+  return 1
 }
 
 if [[ "${SKIP_LOCAL_CONFIG_CHECK:-0}" != "1" ]]; then
@@ -57,12 +100,12 @@ while IFS= read -r sha; do
   committer_email="$(git show -s --format=%ce "$sha")"
   body="$(git show -s --format=%B "$sha")"
 
-  if [[ "$author_name" != "$EXPECTED_NAME" || "$author_email" != "$EXPECTED_EMAIL" ]]; then
+  if ! is_allowed_owner_author "$author_name" "$author_email"; then
     echo "Commit $sha has author '$author_name <$author_email>' (expected '$EXPECTED_NAME <$EXPECTED_EMAIL>')." >&2
     errors=1
   fi
 
-  if [[ "$committer_name" != "$EXPECTED_NAME" || "$committer_email" != "$EXPECTED_EMAIL" ]]; then
+  if ! is_allowed_owner_committer "$committer_name" "$committer_email" "$author_name" "$author_email"; then
     echo "Commit $sha has committer '$committer_name <$committer_email>' (expected '$EXPECTED_NAME <$EXPECTED_EMAIL>')." >&2
     errors=1
   fi


### PR DESCRIPTION
## Summary
Fixes the failing `Attribution Guardrail` run on `main` after PR squash merges by allowing the GitHub web committer identity only when the author is still the expected owner account.

## Why
The current `main` commit was created by GitHub merge infrastructure (`GitHub <noreply@github.com>`, owner noreply author email), which caused the guardrail to fail even though ownership is still `jtalk22`.

## Changes
- Added guarded allow-path in `scripts/check-owner-attribution.sh`:
  - allows owner noreply author formats only when `ALLOW_GITHUB_WEB_COMMITTER=1`
  - allows GitHub web committer only when paired with owner author identity
- Set `ALLOW_GITHUB_WEB_COMMITTER=1` in `.github/workflows/attribution-guardrail.yml`

## Scope
- No runtime/API/MCP tool changes.
- CI policy behavior only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced commit attribution validation to properly recognize and process commits submitted through GitHub's web interface, improving compatibility with browser-based contribution workflows while maintaining security standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->