### PR TITLE
Fix attribution guardrail for owner noreply committer

### DIFF
--- a/scripts/check-owner-attribution.sh
+++ b/scripts/check-owner-attribution.sh
@@ -53,6 +53,14 @@ is_allowed_owner_committer() {
   fi
 
   if [[ "$ALLOW_GITHUB_WEB_COMMITTER" == "1" ]]; then
+    if [[ "$committer_name" == "$EXPECTED_NAME" ]]; then
+      if [[ "$committer_email" == "${EXPECTED_NAME}@users.noreply.github.com" || "$committer_email" =~ ^[0-9]+\+${EXPECTED_NAME}@users\.noreply\.github\.com$ ]]; then
+        if is_allowed_owner_author "$author_name" "$author_email"; then
+          return 0
+        fi
+      fi
+    fi
+
     if [[ "$committer_name" == "GitHub" && "$committer_email" == "noreply@github.com" ]]; then
       if is_allowed_owner_author "$author_name" "$author_email"; then
         return 0


### PR DESCRIPTION
## Summary
- allow owner noreply committer patterns when 
- keep strict owner checks intact for author identity and non-owner committers
- resolves false failures on GitHub rebase/web merge paths

## Validation
- SKIP_LOCAL_CONFIG_CHECK=1 ALLOW_GITHUB_WEB_COMMITTER=1 bash scripts/check-owner-attribution.sh "0c6a27fbeb3a274eccab30ee54eb1aa97dc08fa2..469aac1cb78978f9d25a9f24f9576be97700d056"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation for commits submitted through web-based interfaces to ensure proper author attribution verification alongside committer checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->