### PR TITLE
Registry metadata hardening: keep description within validator limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@jtalk22/slack-mcp",
   "mcpName": "io.github.jtalk22/slack-mcp-server",
   "version": "3.0.0",
-  "description": "Session-based Slack MCP for Claude and MCP clients. Local-first stdio/web with secure-default hosted HTTP in v3.",
+  "description": "Session-based Slack MCP for Claude and MCP clients: local-first workflows, secure-default HTTP.",
   "type": "module",
   "main": "src/server.js",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.jtalk22/slack-mcp-server",
   "title": "Slack MCP Server",
-  "description": "Session-based Slack MCP for Claude and MCP clients. Local-first stdio/web with secure-default hosted HTTP in v3.",
+  "description": "Session-based Slack MCP for Claude and MCP clients: local-first workflows, secure-default HTTP.",
   "websiteUrl": "https://jtalk22.github.io/slack-mcp-server/",
   "icons": [
     {


### PR DESCRIPTION
## Summary
- update `server.json` description to satisfy MCP registry max-length validation
- align `package.json` description with the same constrained string
- no runtime/CLI/tool contract changes

## Why
- `mcp-publisher validate server.json` previously failed with `expected length <= 100`
- direct metadata correction for existing `3.0.0` is blocked by duplicate-version immutability

## External tracking
- Registry maintainer request: https://github.com/modelcontextprotocol/registry/issues/1017


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project descriptions to emphasize local-first workflows and secure-default HTTP capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->