### PR TITLE
feat: v3.1.0 — Cloud checkout + README

### DIFF
--- a/.github/v3.1.0-release-notes.md
+++ b/.github/v3.1.0-release-notes.md
@@ -1,0 +1,42 @@
+## v3.1.0 — Cloud + Key Delivery
+
+`v3.1.0` adds the Cloud product surface and post-checkout key delivery page.
+
+```bash
+npx -y @jtalk22/slack-mcp@latest --version
+npx -y @jtalk22/slack-mcp@latest --doctor
+```
+
+### What Changed
+
+- **Cloud landing page** — `cloud.html` introduces Slack MCP Cloud: a hosted MCP endpoint with one URL, 13 tools, encrypted token storage, and zero local config. Solo ($19/mo) and Team ($49/mo) plans with Stripe checkout.
+- **Post-checkout key delivery** — `success.html` handles Stripe checkout completion, polls for provisioned access tokens, and shows Claude Desktop / Claude Code configuration with copy-to-clipboard.
+- **Homepage cloud CTA** — `index.html` now links to the Cloud page.
+- **README Cloud section** — Pricing table and link to the Cloud page added after the version summary.
+- No MCP tool changes. No CLI behavior changes. No breaking scope.
+
+### Who This Affects
+
+- Self-hosted users: no action required. All local paths unchanged.
+- New users: Cloud option is now visible alongside self-host options.
+
+### Contract Stability
+
+- No MCP tool names were removed or renamed.
+- Diagnostics remain deterministic (`--doctor`, `--status`, `--version`).
+
+### Verify Install
+
+```bash
+npx -y @jtalk22/slack-mcp@latest --version
+npx -y @jtalk22/slack-mcp@latest --doctor
+npx -y @jtalk22/slack-mcp@latest --status
+```
+
+### Support
+
+- Cloud: [jtalk22.github.io/slack-mcp-server/cloud.html](https://jtalk22.github.io/slack-mcp-server/cloud.html)
+- Deployment intake: https://github.com/jtalk22/slack-mcp-server/issues/new?template=deployment-intake.md
+- Troubleshooting: https://github.com/jtalk22/slack-mcp-server/blob/main/docs/TROUBLESHOOTING.md
+
+Maintainer/operator: `jtalk22` (`james@revasser.nyc`)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Motion proof: [20-second mobile clip](https://jtalk22.github.io/slack-mcp-server
 Hosted migration note: `v3.0.0` keeps local `stdio`/`web` flows unchanged; hosted `/mcp` requires `SLACK_MCP_HTTP_AUTH_TOKEN` and `SLACK_MCP_HTTP_ALLOWED_ORIGINS`.
 
 Maintainer/operator: `jtalk22` (`james@revasser.nyc`)  
-Release: [`v3.0.0`](https://github.com/jtalk22/slack-mcp-server/releases/tag/v3.0.0) · Notes: [v3.0.0 notes](https://github.com/jtalk22/slack-mcp-server/blob/main/.github/v3.0.0-release-notes.md) · Support: [deployment intake](https://github.com/jtalk22/slack-mcp-server/issues/new?template=deployment-intake.md)
+Release: [`v3.1.0`](https://github.com/jtalk22/slack-mcp-server/releases/tag/v3.1.0) · Notes: [v3.1.0 notes](https://github.com/jtalk22/slack-mcp-server/blob/main/.github/v3.1.0-release-notes.md) · Support: [deployment intake](https://github.com/jtalk22/slack-mcp-server/issues/new?template=deployment-intake.md)
 
 If this saved you setup time, consider starring the repo. Maintenance support: [GitHub Sponsors](https://github.com/sponsors/jtalk22) · [Ko-fi](https://ko-fi.com/jtalk22) · [Buy Me a Coffee](https://buymeacoffee.com/jtalk22)
 
@@ -30,6 +30,17 @@ If this saved you setup time, consider starring the repo. Maintenance support: [
 - Hosted HTTP CORS now uses explicit allowlisting (`SLACK_MCP_HTTP_ALLOWED_ORIGINS`).
 - Local-first paths (`stdio`, `web`) stay compatible.
 - MCP tool names stay stable (no renames/removals).
+
+## Slack MCP Cloud
+
+Skip all setup. One URL, 13 tools, encrypted token storage, managed on Cloudflare edge.
+
+| Plan | Price | Includes |
+|------|-------|----------|
+| Solo | $19/mo | 10 standard tools, encrypted storage, 5K requests/mo |
+| Team | $49/mo | 13 tools (incl. compound intelligence), 3 workspaces, 25K requests/mo |
+
+[Get started](https://jtalk22.github.io/slack-mcp-server/cloud.html) — no Docker, no tokens, no admin approval.
 
 ## 60-Second Hosted Migration
 

--- a/cloud.html
+++ b/cloud.html
@@ -929,7 +929,7 @@
             <li>1 workspace</li>
             <li>5,000 requests/mo</li>
           </ul>
-          <a href="#checkout-solo" class="price-btn price-btn-fill" data-plan="solo">Get Started</a>
+          <a href="https://buy.stripe.com/9B6aEXd7k4qc8Jt3jXgw000" class="price-btn price-btn-fill">Get Started</a>
         </div>
 
         <div class="price-card">
@@ -943,7 +943,7 @@
             <li>25,000 requests/mo</li>
             <li>Priority support</li>
           </ul>
-          <a href="#checkout-team" class="price-btn price-btn-gold" data-plan="team">Get Started</a>
+          <a href="https://buy.stripe.com/cNi5kD0ky6ykaRBdYBgw001" class="price-btn price-btn-gold">Get Started</a>
         </div>
       </div>
       <p class="enterprise-line fade-up">
@@ -1034,22 +1034,6 @@
       document.querySelectorAll(".fade-up").forEach(function(el) { el.classList.add("visible"); });
     }
 
-    document.querySelectorAll("[data-plan]").forEach(function(btn) {
-      btn.addEventListener("click", function(e) {
-        var href = btn.getAttribute("href");
-        if (href.startsWith("#checkout")) {
-          e.preventDefault();
-          var plan = btn.getAttribute("data-plan");
-          var price = plan === "team" ? "$49/mo" : "$19/mo";
-          window.location.href = "mailto:james@revasser.nyc?subject=Slack%20MCP%20Cloud%20-%20" +
-            encodeURIComponent(plan.charAt(0).toUpperCase() + plan.slice(1)) +
-            "%20Plan&body=" + encodeURIComponent(
-              "I'd like to subscribe to the " + plan.charAt(0).toUpperCase() + plan.slice(1) +
-              " plan (" + price + ").\n\nWorkspace domain: \nEmail: "
-            );
-        }
-      });
-    });
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,17 +3,17 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Slack MCP Server v3.0.0 - Install in 30 Seconds</title>
+  <title>Slack MCP Server v3.1.0 - Install in 30 Seconds</title>
   <meta name="description" content="Session-based Slack MCP for Claude and MCP clients. Local-first stdio/web with secure-default hosted HTTP in v3.">
   <meta property="og:type" content="website">
-  <meta property="og:title" content="Slack MCP Server v3.0.0">
+  <meta property="og:title" content="Slack MCP Server v3.1.0">
   <meta property="og:description" content="Session-based Slack MCP for Claude and MCP clients. Local-first stdio/web with secure-default hosted HTTP in v3.">
   <meta property="og:url" content="https://jtalk22.github.io/slack-mcp-server/">
   <meta property="og:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
   <meta property="og:image:width" content="1280">
   <meta property="og:image:height" content="640">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Slack MCP Server v3.0.0">
+  <meta name="twitter:title" content="Slack MCP Server v3.1.0">
   <meta name="twitter:description" content="Session-based Slack MCP for Claude and MCP clients. Local-first stdio/web with secure-default hosted HTTP in v3.">
   <meta name="twitter:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -191,7 +191,7 @@
       <div class="cta-row">
         <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md"><strong>Install</strong> (`npx --setup`)</a>
         <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/README.md#install--verify"><strong>Verify</strong> (30s commands)</a>
-        <a href="https://github.com/jtalk22/slack-mcp-server/releases/latest"><strong>Latest Release</strong> (`v3.0.0`)</a>
+        <a href="https://github.com/jtalk22/slack-mcp-server/releases/latest"><strong>Latest Release</strong> (`v3.1.0`)</a>
         <a href="cloud.html" style="background:rgba(240,194,70,0.18);border-color:rgba(240,194,70,0.45)"><strong style="color:#f0c246">Cloud</strong> (Live)</a>
       </div>
       <div class="verify">npx -y @jtalk22/slack-mcp --setup

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jtalk22/slack-mcp",
   "mcpName": "io.github.jtalk22/slack-mcp-server",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Session-based Slack MCP for Claude and MCP clients: local-first workflows, secure-default HTTP.",
   "type": "module",
   "main": "src/server.js",


### PR DESCRIPTION
## Summary

- Wires cloud.html checkout buttons to live Stripe Payment Links (Solo $19/mo, Team $49/mo)
- Removes mailto fallback JS handler — buttons now link directly to Stripe-hosted checkout
- Adds Cloud section to README with pricing table and CTA
- Bumps version 3.0.0 → 3.1.0
- Creates v3.1.0 release notes
- Updates index.html version references

## What Changed

| File | Change |
|------|--------|
| `cloud.html` | `#checkout-solo`/`#checkout-team` → `buy.stripe.com` Payment Links |
| `README.md` | New "Slack MCP Cloud" section after v3.0.0 summary |
| `package.json` | `3.0.0` → `3.1.0` |
| `index.html` | Version references `v3.0.0` → `v3.1.0` |
| `.github/v3.1.0-release-notes.md` | Release notes for v3.1.0 |

## Test plan

- [ ] Cloud page loads at GH Pages URL
- [ ] Solo "Get Started" button opens Stripe checkout at `buy.stripe.com/9B6aEX...`
- [ ] Team "Get Started" button opens Stripe checkout at `buy.stripe.com/cNi5kD...`
- [ ] README Cloud section renders correctly with pricing table
- [ ] No MCP tool or CLI behavior changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Slack MCP Cloud offering with pricing tiers (Solo/Team).
  * Added post-checkout key delivery functionality.
  * Updated pricing checkout to external Stripe integration.

* **Chores**
  * Version bumped to v3.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->