### PR TITLE
Token onboarding page + success flow fix

### DIFF
--- a/cloud.html
+++ b/cloud.html
@@ -967,7 +967,7 @@
           <div class="trust-label">token encryption</div>
         </div>
         <div class="trust-item">
-          <div class="trust-num">v3.0</div>
+          <div class="trust-num">v3.1</div>
           <div class="trust-label">current release</div>
         </div>
       </div>

--- a/setup.html
+++ b/setup.html
@@ -1,0 +1,964 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Connect Slack — Slack MCP Cloud</title>
+  <meta name="description" content="Connect your Slack workspace to your Slack MCP Cloud endpoint. Paste your session tokens to enable all 13 MCP tools.">
+  <meta name="robots" content="noindex">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Outfit:wght@300;400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --font-heading: "Geist", "SF Pro Display", system-ui, sans-serif;
+      --font-body: "Outfit", "Avenir", system-ui, sans-serif;
+      --font-mono: "JetBrains Mono", "SF Mono", monospace;
+      --bg: #060d1f;
+      --bg-surface: rgba(12, 22, 52, 0.72);
+      --bg-input: rgba(6, 13, 31, 0.9);
+      --border: rgba(100, 140, 220, 0.12);
+      --border-focus: rgba(100, 140, 220, 0.32);
+      --border-valid: rgba(67, 198, 185, 0.45);
+      --text: #e8eef8;
+      --text-2: #8a9bbd;
+      --text-3: #5c6d8e;
+      --teal: #43c6b9;
+      --teal-glow: rgba(67, 198, 185, 0.15);
+      --teal-deep: rgba(67, 198, 185, 0.06);
+      --red: #e85454;
+      --red-dim: rgba(232, 84, 84, 0.08);
+      --red-border: rgba(232, 84, 84, 0.3);
+      --gold: #e8b931;
+      --gold-dim: rgba(232, 185, 49, 0.06);
+      --gold-border: rgba(232, 185, 49, 0.25);
+      --rail-track: rgba(100, 140, 220, 0.08);
+    }
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+
+    body {
+      font-family: var(--font-body);
+      color: var(--text);
+      background: var(--bg);
+      min-height: 100vh;
+      overflow-x: hidden;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      background:
+        radial-gradient(ellipse 800px 500px at 10% -5%, rgba(25, 50, 110, 0.3) 0%, transparent 65%),
+        radial-gradient(ellipse 500px 350px at 90% 100%, rgba(67, 198, 185, 0.06) 0%, transparent 55%);
+      pointer-events: none;
+      z-index: 0;
+    }
+
+    .page {
+      position: relative;
+      z-index: 1;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* ── Nav ── */
+    .nav {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      max-width: 1060px;
+      margin: 0 auto;
+      padding: 18px 24px 14px;
+      width: 100%;
+    }
+
+    .nav-brand {
+      font-family: var(--font-heading);
+      font-weight: 600;
+      font-size: 1rem;
+      color: var(--text);
+      text-decoration: none;
+      letter-spacing: -0.02em;
+    }
+
+    .nav-brand span { color: var(--teal); }
+
+    .nav-links { display: flex; gap: 20px; align-items: center; }
+
+    .nav-links a {
+      color: var(--text-2);
+      text-decoration: none;
+      font-family: var(--font-heading);
+      font-size: 0.85rem;
+      font-weight: 500;
+      transition: color 0.2s;
+    }
+
+    .nav-links a:hover { color: var(--text); }
+
+    /* ── Main ── */
+    .main {
+      flex: 1;
+      display: flex;
+      align-items: flex-start;
+      justify-content: center;
+      padding: 32px 24px 80px;
+    }
+
+    .card {
+      background: var(--bg-surface);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      padding: 44px 40px 40px;
+      max-width: 620px;
+      width: 100%;
+      backdrop-filter: blur(12px);
+      animation: card-in 0.5s ease-out;
+    }
+
+    @keyframes card-in {
+      from { opacity: 0; transform: translateY(12px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    /* ── Page header ── */
+    .page-header {
+      margin-bottom: 32px;
+    }
+
+    .page-header h1 {
+      font-family: var(--font-heading);
+      font-size: 1.65rem;
+      font-weight: 700;
+      letter-spacing: -0.03em;
+      line-height: 1.15;
+      margin-bottom: 8px;
+    }
+
+    .page-header p {
+      color: var(--text-2);
+      font-size: 0.92rem;
+      line-height: 1.5;
+      font-weight: 300;
+    }
+
+    /* ── Step rail ── */
+    .steps {
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+    }
+
+    .step {
+      display: grid;
+      grid-template-columns: 32px 1fr;
+      gap: 16px;
+      position: relative;
+    }
+
+    .step-rail {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    .step-dot {
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      border: 2px solid var(--border-focus);
+      background: var(--bg);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+      font-weight: 500;
+      color: var(--text-3);
+      flex-shrink: 0;
+      transition: all 0.35s ease;
+      position: relative;
+      z-index: 2;
+    }
+
+    .step.active .step-dot {
+      border-color: var(--teal);
+      color: var(--teal);
+      box-shadow: 0 0 12px var(--teal-glow), 0 0 24px rgba(67, 198, 185, 0.06);
+    }
+
+    .step.done .step-dot {
+      border-color: var(--teal);
+      background: var(--teal);
+      color: var(--bg);
+    }
+
+    .step-line {
+      width: 2px;
+      flex: 1;
+      background: var(--rail-track);
+      min-height: 16px;
+      transition: background 0.35s ease;
+    }
+
+    .step.done .step-line {
+      background: rgba(67, 198, 185, 0.25);
+    }
+
+    .step-content {
+      padding-bottom: 28px;
+    }
+
+    .step:last-child .step-content {
+      padding-bottom: 0;
+    }
+
+    .step:last-child .step-line {
+      display: none;
+    }
+
+    .step-title {
+      font-family: var(--font-heading);
+      font-size: 0.95rem;
+      font-weight: 600;
+      margin-bottom: 6px;
+      line-height: 32px;
+      letter-spacing: -0.01em;
+    }
+
+    .step-desc {
+      color: var(--text-2);
+      font-size: 0.88rem;
+      line-height: 1.55;
+      font-weight: 300;
+    }
+
+    .step-desc strong {
+      color: var(--text);
+      font-weight: 500;
+    }
+
+    .step-desc code {
+      font-family: var(--font-mono);
+      font-size: 0.78rem;
+      background: rgba(6, 13, 31, 0.7);
+      border: 1px solid var(--border);
+      padding: 1px 6px;
+      border-radius: 4px;
+      color: var(--teal);
+    }
+
+    /* ── Instruction box ── */
+    .instruction-box {
+      margin-top: 12px;
+      background: rgba(6, 13, 31, 0.6);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 14px 16px;
+      font-size: 0.84rem;
+      line-height: 1.6;
+      color: var(--text-2);
+    }
+
+    .instruction-box ol {
+      list-style: none;
+      counter-reset: inst;
+      padding: 0;
+    }
+
+    .instruction-box li {
+      counter-increment: inst;
+      padding: 4px 0 4px 28px;
+      position: relative;
+    }
+
+    .instruction-box li::before {
+      content: counter(inst) ".";
+      position: absolute;
+      left: 0;
+      color: var(--teal);
+      font-family: var(--font-mono);
+      font-size: 0.76rem;
+      font-weight: 500;
+      line-height: 1.6;
+    }
+
+    .instruction-box li strong {
+      color: var(--text);
+      font-weight: 500;
+    }
+
+    /* ── Form fields ── */
+    .form-group {
+      margin-top: 16px;
+    }
+
+    .form-label {
+      display: block;
+      font-family: var(--font-heading);
+      font-size: 0.78rem;
+      font-weight: 600;
+      color: var(--text-2);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 6px;
+    }
+
+    .form-input {
+      width: 100%;
+      padding: 12px 14px;
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      color: var(--text);
+      font-family: var(--font-mono);
+      font-size: 0.84rem;
+      outline: none;
+      transition: border-color 0.25s ease, box-shadow 0.25s ease;
+      -webkit-appearance: none;
+    }
+
+    .form-input::placeholder {
+      color: var(--text-3);
+    }
+
+    .form-input:focus {
+      border-color: var(--border-focus);
+      box-shadow: 0 0 0 3px rgba(100, 140, 220, 0.06);
+    }
+
+    .form-input.valid {
+      border-color: var(--border-valid);
+      box-shadow: 0 0 0 3px var(--teal-deep);
+    }
+
+    .form-input.invalid {
+      border-color: var(--red-border);
+      box-shadow: 0 0 0 3px var(--red-dim);
+    }
+
+    .form-hint {
+      margin-top: 5px;
+      font-size: 0.78rem;
+      color: var(--text-3);
+      font-weight: 300;
+    }
+
+    .form-hint.error {
+      color: var(--red);
+    }
+
+    /* ── Mode selector ── */
+    .mode-selector {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 10px;
+      margin-top: 12px;
+    }
+
+    .mode-option {
+      position: relative;
+      cursor: pointer;
+    }
+
+    .mode-option input {
+      position: absolute;
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+
+    .mode-card {
+      display: block;
+      padding: 14px 16px;
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      transition: all 0.25s ease;
+    }
+
+    .mode-option input:checked + .mode-card {
+      border-color: var(--teal);
+      background: var(--teal-deep);
+      box-shadow: 0 0 0 1px var(--teal), 0 0 12px var(--teal-glow);
+    }
+
+    .mode-card:hover {
+      border-color: var(--border-focus);
+    }
+
+    .mode-name {
+      font-family: var(--font-heading);
+      font-size: 0.88rem;
+      font-weight: 600;
+      margin-bottom: 4px;
+      letter-spacing: -0.01em;
+    }
+
+    .mode-desc {
+      font-size: 0.78rem;
+      color: var(--text-2);
+      line-height: 1.45;
+      font-weight: 300;
+    }
+
+    /* ── Consent checkbox ── */
+    .consent-row {
+      display: none;
+      align-items: flex-start;
+      gap: 10px;
+      margin-top: 14px;
+      padding: 12px 14px;
+      background: var(--gold-dim);
+      border: 1px solid var(--gold-border);
+      border-radius: 10px;
+    }
+
+    .consent-row.visible {
+      display: flex;
+    }
+
+    .consent-row input[type="checkbox"] {
+      margin-top: 2px;
+      accent-color: var(--teal);
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
+    }
+
+    .consent-label {
+      font-size: 0.82rem;
+      color: var(--gold);
+      line-height: 1.45;
+      font-weight: 400;
+    }
+
+    /* ── Connect button ── */
+    .connect-btn {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      width: 100%;
+      margin-top: 20px;
+      padding: 14px 24px;
+      background: var(--teal);
+      color: var(--bg);
+      border: none;
+      border-radius: 12px;
+      font-family: var(--font-heading);
+      font-size: 0.95rem;
+      font-weight: 600;
+      letter-spacing: -0.01em;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .connect-btn:hover:not(:disabled) {
+      background: #4fd4c7;
+      box-shadow: 0 4px 20px var(--teal-glow);
+      transform: translateY(-1px);
+    }
+
+    .connect-btn:active:not(:disabled) {
+      transform: translateY(0);
+    }
+
+    .connect-btn:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+
+    .connect-btn.loading {
+      opacity: 0.85;
+      cursor: wait;
+    }
+
+    .connect-btn .spinner {
+      display: none;
+      width: 18px;
+      height: 18px;
+      border: 2px solid rgba(6, 13, 31, 0.3);
+      border-top-color: var(--bg);
+      border-radius: 50%;
+      animation: spin 0.7s linear infinite;
+    }
+
+    .connect-btn.loading .spinner {
+      display: block;
+    }
+
+    .connect-btn.loading .btn-label {
+      display: none;
+    }
+
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+
+    /* ── Success state ── */
+    .success-panel {
+      display: none;
+      animation: reveal 0.5s ease-out;
+    }
+
+    .success-panel.visible {
+      display: block;
+    }
+
+    @keyframes reveal {
+      from { opacity: 0; transform: translateY(10px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    .success-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 16px;
+      background: var(--teal-deep);
+      border: 1px solid var(--border-valid);
+      border-radius: 999px;
+      margin-bottom: 20px;
+    }
+
+    .success-badge .check {
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      background: var(--teal);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .success-badge .check svg {
+      width: 12px;
+      height: 12px;
+      color: var(--bg);
+    }
+
+    .success-badge span {
+      font-family: var(--font-heading);
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: var(--teal);
+    }
+
+    .success-detail {
+      background: rgba(6, 13, 31, 0.6);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 16px;
+      margin-bottom: 20px;
+    }
+
+    .detail-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 6px 0;
+    }
+
+    .detail-row + .detail-row {
+      border-top: 1px solid var(--border);
+    }
+
+    .detail-key {
+      font-size: 0.82rem;
+      color: var(--text-2);
+      font-weight: 400;
+    }
+
+    .detail-value {
+      font-family: var(--font-mono);
+      font-size: 0.82rem;
+      color: var(--text);
+      font-weight: 500;
+    }
+
+    .next-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      color: var(--teal);
+      text-decoration: none;
+      font-family: var(--font-heading);
+      font-size: 0.9rem;
+      font-weight: 600;
+      transition: gap 0.2s ease;
+    }
+
+    .next-link:hover {
+      gap: 10px;
+    }
+
+    .next-link svg {
+      width: 16px;
+      height: 16px;
+    }
+
+    /* ── Error state ── */
+    .error-box {
+      display: none;
+      margin-top: 14px;
+      padding: 12px 16px;
+      background: var(--red-dim);
+      border: 1px solid var(--red-border);
+      border-radius: 10px;
+      font-size: 0.84rem;
+      color: var(--red);
+      line-height: 1.5;
+    }
+
+    .error-box.visible {
+      display: block;
+      animation: reveal 0.3s ease-out;
+    }
+
+    /* ── Footer ── */
+    .foot {
+      max-width: 1060px;
+      margin: 0 auto;
+      padding: 20px 24px 32px;
+      border-top: 1px solid var(--border);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 12px;
+      font-size: 0.82rem;
+      color: var(--text-3);
+      width: 100%;
+    }
+
+    .foot a {
+      color: var(--teal);
+      text-decoration: none;
+    }
+
+    /* ── Responsive ── */
+    @media (max-width: 640px) {
+      .card { padding: 28px 18px 28px; }
+      .nav { padding: 14px 16px; }
+      .nav-links a:not(:last-child) { display: none; }
+      .mode-selector { grid-template-columns: 1fr; }
+      .foot { flex-direction: column; text-align: center; }
+      .detail-row { flex-direction: column; align-items: flex-start; gap: 2px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <nav class="nav">
+      <a href="cloud.html" class="nav-brand">slack<span>/</span>mcp</a>
+      <div class="nav-links">
+        <a href="https://github.com/jtalk22/slack-mcp-server">GitHub</a>
+        <a href="cloud.html">Cloud</a>
+      </div>
+    </nav>
+
+    <div class="main">
+      <div class="card">
+        <!-- ── Setup form ── -->
+        <div id="setupForm">
+          <div class="page-header">
+            <h1>Connect your Slack workspace</h1>
+            <p>Paste your Slack session tokens to activate your Cloud endpoint. Takes about 2 minutes.</p>
+          </div>
+
+          <div class="steps">
+            <!-- Step 1: API Key -->
+            <div class="step active" id="step1">
+              <div class="step-rail">
+                <div class="step-dot">1</div>
+                <div class="step-line"></div>
+              </div>
+              <div class="step-content">
+                <div class="step-title">Your API key</div>
+                <div class="step-desc">Paste the bearer token you received after checkout.</div>
+                <div class="form-group">
+                  <label class="form-label" for="apiKey">Bearer Token</label>
+                  <input type="text" id="apiKey" class="form-input" placeholder="stmh_..." autocomplete="off" spellcheck="false">
+                  <div class="form-hint" id="apiKeyHint">Starts with <code>stmh_</code></div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Step 2: Get Slack tokens -->
+            <div class="step" id="step2">
+              <div class="step-rail">
+                <div class="step-dot">2</div>
+                <div class="step-line"></div>
+              </div>
+              <div class="step-content">
+                <div class="step-title">Get your Slack tokens</div>
+                <div class="step-desc">Open Slack in your browser and extract two values from DevTools.</div>
+                <div class="instruction-box">
+                  <ol>
+                    <li>Go to <strong>app.slack.com</strong> in Chrome/Edge and sign in</li>
+                    <li>Open DevTools: <code>F12</code> or <code>Cmd+Option+I</code></li>
+                    <li>Go to <strong>Application</strong> tab &rarr; <strong>Cookies</strong> &rarr; <strong>https://app.slack.com</strong></li>
+                    <li>Find cookie named <strong>d</strong> &mdash; its value starts with <code>xoxd-</code>. Copy the full value.</li>
+                    <li>Go to the <strong>Console</strong> tab, type: <code>document.cookie.match(/xoxc-[^;]+/)?.[0]</code> and press Enter. Copy the result.</li>
+                  </ol>
+                </div>
+              </div>
+            </div>
+
+            <!-- Step 3: Paste tokens -->
+            <div class="step" id="step3">
+              <div class="step-rail">
+                <div class="step-dot">3</div>
+                <div class="step-line"></div>
+              </div>
+              <div class="step-content">
+                <div class="step-title">Paste your tokens</div>
+                <div class="step-desc">Paste the two values you copied from Slack.</div>
+                <div class="form-group">
+                  <label class="form-label" for="slackToken">Slack Token (xoxc-)</label>
+                  <input type="text" id="slackToken" class="form-input" placeholder="xoxc-..." autocomplete="off" spellcheck="false">
+                  <div class="form-hint" id="slackTokenHint">From Console &mdash; starts with <code>xoxc-</code></div>
+                </div>
+                <div class="form-group">
+                  <label class="form-label" for="slackCookie">Slack Cookie (xoxd-)</label>
+                  <input type="text" id="slackCookie" class="form-input" placeholder="xoxd-..." autocomplete="off" spellcheck="false">
+                  <div class="form-hint" id="slackCookieHint">From Cookies &mdash; starts with <code>xoxd-</code></div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Step 4: Storage mode -->
+            <div class="step" id="step4">
+              <div class="step-rail">
+                <div class="step-dot">4</div>
+                <div class="step-line"></div>
+              </div>
+              <div class="step-content">
+                <div class="step-title">Storage mode</div>
+                <div class="step-desc">Choose how your Slack credentials are stored on the server.</div>
+                <div class="mode-selector">
+                  <label class="mode-option">
+                    <input type="radio" name="mode" value="persistent" checked>
+                    <div class="mode-card">
+                      <div class="mode-name">Persistent</div>
+                      <div class="mode-desc">Encrypted at rest (AES-256-GCM). Survives server restarts. Recommended.</div>
+                    </div>
+                  </label>
+                  <label class="mode-option">
+                    <input type="radio" name="mode" value="ephemeral">
+                    <div class="mode-card">
+                      <div class="mode-name">Ephemeral</div>
+                      <div class="mode-desc">In-memory only. Cleared on server restart. Re-connect required after.</div>
+                    </div>
+                  </label>
+                </div>
+                <div class="consent-row visible" id="consentRow">
+                  <input type="checkbox" id="consentCheck">
+                  <label class="consent-label" for="consentCheck">I consent to encrypted storage of my Slack tokens on the server. Tokens are encrypted with AES-256-GCM and can be deleted at any time.</label>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <button type="button" class="connect-btn" id="connectBtn" disabled>
+            <span class="spinner"></span>
+            <span class="btn-label">Connect Workspace</span>
+          </button>
+
+          <div class="error-box" id="errorBox"></div>
+        </div>
+
+        <!-- ── Success state ── -->
+        <div class="success-panel" id="successPanel">
+          <div class="success-badge">
+            <div class="check">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="20 6 9 17 4 12"/>
+              </svg>
+            </div>
+            <span>Workspace connected</span>
+          </div>
+
+          <div class="page-header">
+            <h1>You're all set.</h1>
+            <p>Your Slack workspace is connected. All MCP tools are now active on your Cloud endpoint.</p>
+          </div>
+
+          <div class="success-detail">
+            <div class="detail-row">
+              <span class="detail-key">Workspace</span>
+              <span class="detail-value" id="successTeam">—</span>
+            </div>
+            <div class="detail-row">
+              <span class="detail-key">User</span>
+              <span class="detail-value" id="successUser">—</span>
+            </div>
+            <div class="detail-row">
+              <span class="detail-key">Mode</span>
+              <span class="detail-value" id="successMode">—</span>
+            </div>
+            <div class="detail-row">
+              <span class="detail-key">Status</span>
+              <span class="detail-value" style="color:var(--teal)">Connected</span>
+            </div>
+          </div>
+
+          <p style="color:var(--text-2);font-size:0.9rem;margin-bottom:16px;font-weight:300;">
+            Add the config from your checkout email to Claude, then try: <strong style="color:var(--text)">"List my Slack channels"</strong>
+          </p>
+
+          <a href="cloud.html" class="next-link">
+            Back to Cloud
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <footer class="foot">
+      <span>Slack MCP Cloud by <a href="https://github.com/jtalk22">jtalk22</a></span>
+      <span><a href="cloud.html">Pricing</a> &middot; <a href="https://github.com/jtalk22/slack-mcp-server">GitHub</a> &middot; <a href="mailto:james@revasser.nyc">Support</a></span>
+    </footer>
+  </div>
+
+  <script>
+    var API_BASE = "https://mcp.revasserlabs.com";
+
+    // Read token from URL fragment (preferred) or query param
+    var hash = window.location.hash.slice(1);
+    var params = new URLSearchParams(hash || window.location.search);
+    var prefilledToken = params.get("token") || "";
+
+    var apiKeyInput = document.getElementById("apiKey");
+    var slackTokenInput = document.getElementById("slackToken");
+    var slackCookieInput = document.getElementById("slackCookie");
+    var connectBtn = document.getElementById("connectBtn");
+    var errorBox = document.getElementById("errorBox");
+    var consentRow = document.getElementById("consentRow");
+    var consentCheck = document.getElementById("consentCheck");
+    var setupForm = document.getElementById("setupForm");
+    var successPanel = document.getElementById("successPanel");
+
+    if (prefilledToken) {
+      apiKeyInput.value = prefilledToken;
+      apiKeyInput.classList.add("valid");
+      markStep(1, "done");
+      markStep(2, "active");
+    }
+
+    // Validation
+    apiKeyInput.addEventListener("input", validateAll);
+    slackTokenInput.addEventListener("input", validateAll);
+    slackCookieInput.addEventListener("input", validateAll);
+    consentCheck.addEventListener("change", validateAll);
+
+    document.querySelectorAll('input[name="mode"]').forEach(function(r) {
+      r.addEventListener("change", function() {
+        var isPersistent = document.querySelector('input[name="mode"]:checked').value === "persistent";
+        consentRow.classList.toggle("visible", isPersistent);
+        validateAll();
+      });
+    });
+
+    function validateField(input, prefix) {
+      var val = input.value.trim();
+      if (!val) {
+        input.classList.remove("valid", "invalid");
+        return false;
+      }
+      var ok = val.startsWith(prefix);
+      input.classList.toggle("valid", ok);
+      input.classList.toggle("invalid", !ok);
+      return ok;
+    }
+
+    function validateAll() {
+      var keyOk = validateField(apiKeyInput, "stmh_");
+      var tokenOk = validateField(slackTokenInput, "xoxc-");
+      var cookieOk = validateField(slackCookieInput, "xoxd-");
+      var mode = document.querySelector('input[name="mode"]:checked').value;
+      var consentOk = mode === "ephemeral" || consentCheck.checked;
+
+      // Update step states
+      markStep(1, keyOk ? "done" : "active");
+      if (keyOk) markStep(2, (tokenOk && cookieOk) ? "done" : "active");
+      if (keyOk && tokenOk && cookieOk) markStep(3, "done");
+      if (keyOk && tokenOk && cookieOk) markStep(4, "active");
+
+      connectBtn.disabled = !(keyOk && tokenOk && cookieOk && consentOk);
+    }
+
+    function markStep(num, state) {
+      var el = document.getElementById("step" + num);
+      el.classList.remove("active", "done");
+      if (state) el.classList.add(state);
+    }
+
+    // Connect
+    connectBtn.addEventListener("click", async function() {
+      if (connectBtn.disabled) return;
+      connectBtn.classList.add("loading");
+      connectBtn.disabled = true;
+      errorBox.classList.remove("visible");
+
+      var mode = document.querySelector('input[name="mode"]:checked').value;
+      var body = {
+        mode: mode,
+        slack_token: slackTokenInput.value.trim(),
+        slack_cookie: slackCookieInput.value.trim()
+      };
+      if (mode === "persistent") {
+        body.consent_persistent_storage = true;
+      }
+
+      try {
+        var res = await fetch(API_BASE + "/api/v1/pilot/tokens/connect", {
+          method: "POST",
+          headers: {
+            "Authorization": "Bearer " + apiKeyInput.value.trim(),
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify(body)
+        });
+
+        var data = await res.json();
+
+        if (!res.ok) {
+          var msg = data.message || data.error?.message || "Connection failed. Check your tokens and try again.";
+          if (data.code === "slack_auth_failed") {
+            msg = "Slack rejected these credentials. Make sure you copied the full token and cookie from an active Slack session.";
+          } else if (data.code === "unauthorized") {
+            msg = "Invalid API key. Check the bearer token from your checkout email.";
+          }
+          throw new Error(msg);
+        }
+
+        // Success
+        markStep(4, "done");
+        document.getElementById("successTeam").textContent = data.health?.team || "Connected";
+        document.getElementById("successUser").textContent = data.health?.user || "Authenticated";
+        document.getElementById("successMode").textContent = mode.charAt(0).toUpperCase() + mode.slice(1);
+
+        setupForm.style.display = "none";
+        successPanel.classList.add("visible");
+
+      } catch (err) {
+        errorBox.textContent = err.message;
+        errorBox.classList.add("visible");
+        connectBtn.classList.remove("loading");
+        connectBtn.disabled = false;
+      }
+    });
+
+    validateAll();
+  </script>
+</body>
+</html>

--- a/success.html
+++ b/success.html
@@ -664,9 +664,10 @@
             <div class="next-steps">
               <h3>What's next</h3>
               <ol>
-                <li><strong>Copy the config above</strong> and paste it into your MCP client settings file</li>
-                <li><strong>Restart Claude Desktop</strong> or run the Claude Code command in your terminal</li>
-                <li><strong>Try it:</strong> Ask Claude to "summarize my #general channel" to test AI tools</li>
+                <li><strong>Copy your API key above</strong> &mdash; store it securely, it's shown once</li>
+                <li><strong>Connect your Slack workspace</strong> &mdash; <a id="setupLink" href="setup.html" style="color:var(--accent);font-weight:600">Set up Slack credentials &rarr;</a></li>
+                <li><strong>Add to Claude</strong> &mdash; paste the config above into your MCP client settings</li>
+                <li><strong>Try it:</strong> Ask Claude to "list my Slack channels" to verify</li>
               </ol>
             </div>
           </div>
@@ -759,8 +760,14 @@
       var desktopConfig = JSON.stringify(data.config.claude_desktop, null, 2);
       document.getElementById("configDesktop").textContent = desktopConfig;
 
-      var codeCmd = 'claude mcp add slack-mcp-cloud \\\n  --transport sse \\\n  --url "' + data.endpoint + '" \\\n  --header "Authorization: Bearer ' + data.access_token + '"';
+      var codeCmd = 'claude mcp add slack-mcp-cloud \\\n  --transport http \\\n  --url "' + data.endpoint + '" \\\n  --header "Authorization: Bearer ' + data.access_token + '"';
       document.getElementById("configCode").textContent = codeCmd;
+
+      // Populate setup link with bearer token (fragment, not query — keeps token out of server logs)
+      var setupLink = document.getElementById("setupLink");
+      if (setupLink) {
+        setupLink.href = "setup.html#token=" + encodeURIComponent(data.access_token);
+      }
     }
 
     function showError(msg) {


### PR DESCRIPTION
## Summary

- **setup.html** — Guided wizard for connecting Slack workspace credentials after checkout. Four-step flow with live input validation, mode selector (persistent/ephemeral), consent checkbox, and real-time API connection with workspace verification.
- **success.html** — Reorder "What's next" to route through credential setup before attempting MCP tool use. Fix Claude Code transport from `sse` to `http`. Auto-populate setup link with bearer token via URL fragment.
- **cloud.html** — Fix stale version badge (v3.0 → v3.1).

## Context

After Stripe checkout, users receive a bearer token but cannot use MCP tools until Slack credentials (xoxc-/xoxd-) are submitted via `POST /api/v1/pilot/tokens/connect`. Previously there was no UI for this step — users would configure Claude, try a tool, and get `token_not_connected`. This PR closes that gap.

CORS and rate limiting deployed to the hosted worker separately.

## Test plan

- [ ] Open setup.html with `#token=stmh_test` — verify token pre-fills and validates
- [ ] Paste invalid prefixes — verify red validation borders
- [ ] Paste valid xoxc-/xoxd- prefixes — verify green borders and step progression
- [ ] Toggle between Persistent/Ephemeral modes — verify consent checkbox visibility
- [ ] Verify cloud.html trust badge shows v3.1
- [ ] Verify success.html "What's next" includes setup link as step 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added onboarding flow for connecting Slack workspace to the MCP Cloud endpoint.

* **Documentation**
  * Updated "What's next" guidance with new setup steps for API key storage and workspace configuration.
  * Updated test action from summarizing channels to listing Slack channels.
  * Updated Trust section version display to v3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->