### PR TITLE
Add cloud remote endpoint to MCP Registry

### DIFF
--- a/server.json
+++ b/server.json
@@ -17,12 +17,18 @@
     "url": "https://github.com/jtalk22/slack-mcp-server",
     "source": "github"
   },
-  "version": "3.0.0",
+  "version": "3.1.0",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.revasserlabs.com/oauth/mcp"
+    }
+  ],
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@jtalk22/slack-mcp",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- Adds `remotes` section to `server.json` declaring the cloud `streamable-http` endpoint at `https://mcp.revasserlabs.com/oauth/mcp`
- Bumps registry version to `3.1.0` to match the published npm package
- Enables OAuth 2.1 discovery for Claude Desktop and other MCP clients connecting via the cloud endpoint

## Context
The Official MCP Registry (`registry.modelcontextprotocol.io`) already has our server listed at 3 versions (1.1.8, 2.0.0, 3.0.0) — all packages-only. This adds the cloud remote so users can connect without local setup.

## Test plan
- [x] `mcp-publisher validate` passes
- [x] OAuth endpoint verified end-to-end (PKCE S256 → auth code → access token → 13 tools)
- [x] `/.well-known/oauth-authorization-server` returns valid RFC 8414 metadata
- [ ] `mcp-publisher publish` after merge (requires GitHub device auth)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slack integration support now available with token and authentication configuration options.
  * Added new remote HTTP endpoint for expanded connectivity.

* **Updates**
  * Version bumped to 3.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->