### PR TITLE
fix: align version constants to 3.1.0 + Docker cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,7 @@ COPY smithery.yaml ./smithery.yaml
 COPY README.md ./README.md
 COPY LICENSE ./LICENSE
 
-# Environment variables for Slack auth
-ENV SLACK_TOKEN=""
-ENV SLACK_COOKIE=""
+# Runtime env (credentials passed via docker run -e)
 ENV NODE_ENV="production"
 
 # MCP servers communicate via stdio

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ npx -y @jtalk22/slack-mcp@latest --status
 
 Motion proof: [20-second mobile clip](https://jtalk22.github.io/slack-mcp-server/docs/videos/demo-claude-mobile-20s.mp4) · [Live demo walkthrough](https://jtalk22.github.io/slack-mcp-server/public/demo-video.html) · [Share card](https://jtalk22.github.io/slack-mcp-server/public/share.html)
 
-Hosted migration note: `v3.0.0` keeps local `stdio`/`web` flows unchanged; hosted `/mcp` requires `SLACK_MCP_HTTP_AUTH_TOKEN` and `SLACK_MCP_HTTP_ALLOWED_ORIGINS`.
+Hosted migration note: `v3.1.0` keeps local `stdio`/`web` flows unchanged; hosted `/mcp` requires `SLACK_MCP_HTTP_AUTH_TOKEN` and `SLACK_MCP_HTTP_ALLOWED_ORIGINS`.
 
 Maintainer/operator: `jtalk22` (`james@revasser.nyc`)  
 Release: [`v3.1.0`](https://github.com/jtalk22/slack-mcp-server/releases/tag/v3.1.0) · Notes: [v3.1.0 notes](https://github.com/jtalk22/slack-mcp-server/blob/main/.github/v3.1.0-release-notes.md) · Support: [deployment intake](https://github.com/jtalk22/slack-mcp-server/issues/new?template=deployment-intake.md)
 
 If this saved you setup time, consider starring the repo. Maintenance support: [GitHub Sponsors](https://github.com/sponsors/jtalk22) · [Ko-fi](https://ko-fi.com/jtalk22) · [Buy Me a Coffee](https://buymeacoffee.com/jtalk22)
 
-## v3.0.0 at a Glance
+## v3.1.0 at a Glance
 
 - Hosted HTTP `/mcp` now requires bearer auth by default (`SLACK_MCP_HTTP_AUTH_TOKEN`).
 - Hosted HTTP CORS now uses explicit allowlisting (`SLACK_MCP_HTTP_ALLOWED_ORIGINS`).
@@ -388,7 +388,7 @@ npm run web
 
 ```
 ════════════════════════════════════════════════════════════
-  Slack Web API Server v3.0.0
+  Slack Web API Server v3.1.0
 ════════════════════════════════════════════════════════════
 
   Dashboard: http://localhost:3000/?key=smcp_xxxxxxxxxxxx

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jtalk22/slack-mcp",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jtalk22/slack-mcp",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/scripts/setup-wizard.js
+++ b/scripts/setup-wizard.js
@@ -23,7 +23,7 @@ import {
 } from "../lib/token-store.js";
 
 const IS_MACOS = platform() === 'darwin';
-const VERSION = "3.0.0";
+const VERSION = "3.1.0";
 const MIN_NODE_MAJOR = 20;
 const AUTH_TEST_URL = process.env.SLACK_MCP_AUTH_TEST_URL || "https://slack.com/api/auth.test";
 

--- a/src/server-http.js
+++ b/src/server-http.js
@@ -30,7 +30,7 @@ import {
 } from "../lib/handlers.js";
 
 const SERVER_NAME = "slack-mcp-server";
-const SERVER_VERSION = "3.0.0";
+const SERVER_VERSION = "3.1.0";
 const PORT = process.env.PORT || 3000;
 const HTTP_INSECURE = process.env.SLACK_MCP_HTTP_INSECURE === "1";
 const HTTP_AUTH_TOKEN = process.env.SLACK_MCP_HTTP_AUTH_TOKEN || process.env.SLACK_API_KEY || null;

--- a/src/server.js
+++ b/src/server.js
@@ -11,7 +11,7 @@
  * - Network error retry with exponential backoff
  * - Background token health monitoring
  *
- * @version 3.0.0
+ * @version 3.1.0
  */
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -48,7 +48,7 @@ const BACKGROUND_REFRESH_INTERVAL = 4 * 60 * 60 * 1000;
 
 // Package info
 const SERVER_NAME = "slack-mcp-server";
-const SERVER_VERSION = "3.0.0";
+const SERVER_VERSION = "3.1.0";
 
 // MCP Prompts - predefined prompt templates for common Slack operations
 const PROMPTS = [

--- a/src/web-server.js
+++ b/src/web-server.js
@@ -5,7 +5,7 @@
  * Exposes Slack MCP tools as REST endpoints for browser access.
  * Run alongside or instead of the MCP server for web-based access.
  *
- * @version 3.0.0
+ * @version 3.1.0
  */
 
 import express from "express";
@@ -136,7 +136,7 @@ function extractContent(result) {
 app.get("/", (req, res) => {
   res.json({
     name: "Slack Web API Server",
-    version: "3.0.0",
+    version: "3.1.0",
     status: "ok",
     code: "ok",
     message: "Web API server is running.",
@@ -337,7 +337,7 @@ async function main() {
   app.listen(PORT, '127.0.0.1', () => {
     // Print to stderr to keep logs clean (stdout reserved for JSON in some setups)
     console.error(`\n${"═".repeat(60)}`);
-    console.error(`  Slack Web API Server v3.0.0`);
+    console.error(`  Slack Web API Server v3.1.0`);
     console.error(`${"═".repeat(60)}`);
     console.error(`\n  Dashboard: http://localhost:${PORT}/?key=${API_KEY}`);
     console.error(`\n  API Key:   ${API_KEY}`);


### PR DESCRIPTION
## Summary
- Aligns all hardcoded VERSION/SERVER_VERSION constants to `3.1.0` (were `3.0.0`)
- Fixes Docker smoke test failure (CI run #34) caused by version mismatch
- Removes `ENV SLACK_TOKEN`/`SLACK_COOKIE` from Dockerfile to eliminate `SecretsUsedInArgOrEnv` buildx warning

## Files changed (7)
- `scripts/setup-wizard.js` — VERSION constant
- `src/server.js` — SERVER_VERSION + JSDoc
- `src/server-http.js` — SERVER_VERSION
- `src/web-server.js` — version string, JSDoc, console output
- `README.md` — v3.0.0 references → v3.1.0
- `Dockerfile` — removed ENV token defaults
- `package-lock.json` — regenerated

## Test plan
- [x] Docker build locally — no warnings
- [x] `docker run --rm slack-mcp-smoke:3.1.0 --version` → `slack-mcp-server v3.1.0`
- [ ] CI smoke test passes
- [ ] Docker image pushes to ghcr.io

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Removed hardcoded Slack credentials from Docker configuration; credentials must now be passed at runtime for improved security.

* **Chores**
  * Bumped application version to 3.1.0 across all components.

* **Documentation**
  * Updated documentation to clarify local-first path compatibility and MCP tool name stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->