### PR TITLE
fix: demo pages — v3.1.0 metadata + Cloud CTAs

### DIFF
--- a/public/demo-claude.html
+++ b/public/demo-claude.html
@@ -11,20 +11,20 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="author" content="@jtalk22">
-  <title>Slack MCP Server - Claude Desktop Demo</title>
-  <meta name="description" content="Session-based Slack access for Claude with your existing workspace permissions. Demo workflows for DMs, channels, search, and threads.">
+  <title>Slack MCP Server v3.1.0 — Claude Desktop Demo</title>
+  <meta name="description" content="Give Claude your Slack. 13 MCP tools — read channels, search messages, send replies, get AI summaries. Self-host free or Cloud from $19/mo.">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Slack MCP Server - Session-Based Slack Access Demo">
-  <meta property="og:description" content="Session-based Slack access for Claude with your existing workspace permissions. Search, thread, and messaging workflows.">
+  <meta property="og:title" content="Slack MCP Server v3.1.0 — Claude Desktop Demo">
+  <meta property="og:description" content="Give Claude your Slack. 13 MCP tools — read channels, search messages, send replies, get AI summaries. Self-host free or Cloud from $19/mo.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://jtalk22.github.io/slack-mcp-server/public/demo-claude.html">
   <meta property="og:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Slack MCP Server - Session-Based Slack Access Demo">
-  <meta name="twitter:description" content="Session-based Slack access for Claude with your existing workspace permissions. Search, thread, and messaging workflows.">
+  <meta name="twitter:title" content="Slack MCP Server v3.1.0 — Claude Desktop Demo">
+  <meta name="twitter:description" content="Give Claude your Slack. 13 MCP tools — read channels, search messages, send replies, get AI summaries. Self-host free or Cloud from $19/mo.">
   <meta name="twitter:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
 
   <!-- Theme -->

--- a/public/demo-video.html
+++ b/public/demo-video.html
@@ -3,17 +3,17 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Slack MCP Server Demo</title>
-  <meta name="description" content="Session-based Slack access for Claude with your existing workspace permissions. Video demo for DMs, channels, search, and threads.">
+  <title>Slack MCP Server v3.1.0 — Video Demo</title>
+  <meta name="description" content="Give Claude your Slack. 13 MCP tools — read channels, search messages, send replies, get AI summaries. Self-host free or Cloud from $19/mo.">
   <meta property="og:type" content="website">
-  <meta property="og:title" content="Slack MCP Server - Session-Based Slack Access Demo">
-  <meta property="og:description" content="Session-based Slack access for Claude with your existing workspace permissions. Video walkthrough for Slack workflows.">
+  <meta property="og:title" content="Slack MCP Server v3.1.0 — Video Demo">
+  <meta property="og:description" content="Give Claude your Slack. 13 MCP tools — read channels, search messages, send replies, get AI summaries. Self-host free or Cloud from $19/mo.">
   <meta property="og:url" content="https://jtalk22.github.io/slack-mcp-server/public/demo-video.html">
-  <meta property="og:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/demo-poster.png">
+  <meta property="og:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Slack MCP Server - Session-Based Slack Access Demo">
-  <meta name="twitter:description" content="Session-based Slack access for Claude with your existing workspace permissions. Video walkthrough for Slack workflows.">
-  <meta name="twitter:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/demo-poster.png">
+  <meta name="twitter:title" content="Slack MCP Server v3.1.0 — Video Demo">
+  <meta name="twitter:description" content="Give Claude your Slack. 13 MCP tools — read channels, search messages, send replies, get AI summaries. Self-host free or Cloud from $19/mo.">
+  <meta name="twitter:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
@@ -171,16 +171,16 @@
 </head>
 <body>
   <div class="container">
-    <h1>Slack MCP Server</h1>
-    <p class="subtitle">Free local-first Slack access using your existing session permissions</p>
+    <h1>Slack MCP Server <span style="font-size:0.55em;opacity:0.5;font-weight:400;vertical-align:middle">v3.1.0</span></h1>
+    <p class="subtitle">Give Claude your Slack. 13 tools — read, search, send, summarize. Self-host free or Cloud from $19/mo.</p>
     <div class="cta-strip">
       <div class="links">
-        <a href="https://www.npmjs.com/package/@jtalk22/slack-mcp" target="_blank" rel="noopener noreferrer">Install</a>
+        <a href="https://jtalk22.github.io/slack-mcp-server/cloud.html" target="_blank" rel="noopener noreferrer" style="background:rgba(240,194,70,0.18);border-color:rgba(240,194,70,0.45);color:#f0c246">Cloud ($19/mo)</a>
+        <a href="https://www.npmjs.com/package/@jtalk22/slack-mcp" target="_blank" rel="noopener noreferrer">npm Install</a>
         <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md" target="_blank" rel="noopener noreferrer">Setup Guide</a>
-        <a href="https://github.com/jtalk22/slack-mcp-server#30-second-compatibility-check" target="_blank" rel="noopener noreferrer">30-Second Check</a>
       </div>
       <div class="note">
-        Free local-first path with team rollout references in <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/DEPLOYMENT-MODES.md" target="_blank" rel="noopener noreferrer">Deployment Modes</a>.
+        Self-host free or <a href="https://jtalk22.github.io/slack-mcp-server/cloud.html" target="_blank" rel="noopener noreferrer">skip setup with Cloud</a> — one URL, no Docker.
       </div>
     </div>
 
@@ -198,7 +198,7 @@
     </div>
 
     <div class="back-link">
-      <a href="https://github.com/jtalk22/slack-mcp-server">← Back to Repository</a>
+      <a href="https://github.com/jtalk22/slack-mcp-server">GitHub</a> · <a href="https://jtalk22.github.io/slack-mcp-server/cloud.html" style="color:#f0c246;text-decoration:none;font-size:0.875rem">Cloud Pricing</a> · <a href="https://www.npmjs.com/package/@jtalk22/slack-mcp" style="color:#94a3b8;text-decoration:none;font-size:0.875rem">npm</a>
     </div>
   </div>
 

--- a/public/demo.html
+++ b/public/demo.html
@@ -3,23 +3,23 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Slack MCP Server - Interactive Demo</title>
+  <title>Slack MCP Server v3.1.0 — Interactive Demo</title>
 
   <!-- Open Graph / Social Sharing -->
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://jtalk22.github.io/slack-mcp-server/public/demo.html">
-  <meta property="og:title" content="Slack MCP Server - Session-Based Slack Access Demo">
-  <meta property="og:description" content="Session-based Slack access for Claude with your existing workspace permissions. DMs, channels, search, and threads.">
-  <meta property="og:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/demo-main.png">
+  <meta property="og:title" content="Slack MCP Server v3.1.0 — Interactive Demo">
+  <meta property="og:description" content="Give Claude your Slack. 13 MCP tools — read channels, search messages, send replies, get AI summaries. Self-host free or Cloud from $19/mo.">
+  <meta property="og:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Slack MCP Server - Session-Based Slack Access Demo">
-  <meta name="twitter:description" content="Session-based Slack access for Claude with your existing workspace permissions. DMs, channels, search, and threads.">
-  <meta name="twitter:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/demo-main.png">
+  <meta name="twitter:title" content="Slack MCP Server v3.1.0 — Interactive Demo">
+  <meta name="twitter:description" content="Give Claude your Slack. 13 MCP tools — read channels, search messages, send replies, get AI summaries. Self-host free or Cloud from $19/mo.">
+  <meta name="twitter:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
 
   <!-- SEO -->
-  <meta name="description" content="Session-based Slack access for Claude with your existing workspace permissions. Interactive demo for DMs, channels, search, and thread workflows.">
+  <meta name="description" content="Give Claude your Slack. 13 MCP tools — read channels, search messages, send replies, get AI summaries. Interactive demo. Self-host free or Cloud from $19/mo.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
@@ -742,17 +742,16 @@
 <body>
   <!-- Preview Banner -->
   <div class="preview-banner">
-    STATIC PREVIEW - No real data. Run <code>npm run web</code> for live dashboard.
-    <a href="https://github.com/jtalk22/slack-mcp-server">View on GitHub</a>
+    INTERACTIVE DEMO — simulated data. Run <code>npm run web</code> for your live workspace, or try <a href="https://jtalk22.github.io/slack-mcp-server/cloud.html" style="color:#f0c246;font-weight:600">Cloud ($19/mo)</a> for instant setup.
   </div>
   <div class="cta-strip">
     <div class="cta-links">
-      <a href="https://www.npmjs.com/package/@jtalk22/slack-mcp" target="_blank" rel="noopener noreferrer">Install</a>
+      <a href="https://jtalk22.github.io/slack-mcp-server/cloud.html" target="_blank" rel="noopener noreferrer" style="background:rgba(240,194,70,0.18);border-color:rgba(240,194,70,0.45);color:#f0c246">Cloud ($19/mo)</a>
+      <a href="https://www.npmjs.com/package/@jtalk22/slack-mcp" target="_blank" rel="noopener noreferrer">npm Install</a>
       <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md" target="_blank" rel="noopener noreferrer">Setup Guide</a>
-      <a href="https://github.com/jtalk22/slack-mcp-server#30-second-compatibility-check" target="_blank" rel="noopener noreferrer">30-Second Check</a>
     </div>
     <div class="cta-note">
-      Free local-first path with team rollout references in <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/DEPLOYMENT-MODES.md" target="_blank" rel="noopener noreferrer">Deployment Modes</a>.
+      Self-host free or <a href="https://jtalk22.github.io/slack-mcp-server/cloud.html" target="_blank" rel="noopener noreferrer">skip setup with Cloud</a> — one URL, no Docker, no admin approval.
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- **demo.html**: v3.1.0 in title/OG, Cloud CTA in banner and CTA strip (first position), updated OG image to social-preview-v3.png, benefit-focused descriptions
- **demo-video.html**: v3.1.0 in title/OG, Cloud CTA in CTA strip (first position), updated OG image, footer links expanded (GitHub + Cloud + npm)
- **demo-claude.html**: v3.1.0 in title/OG, benefit-focused descriptions matching other surfaces

## Context
All three demo pages were 10+ days stale — pre-Cloud messaging, no version numbers, old OG images. Now consistent with PRs #25-#27 improvements across landing, README, share, and Web UI pages.

## Test plan
- [ ] Verify all three pages render locally (`open public/demo.html`)
- [ ] Check OG tags with a social card validator
- [ ] Confirm Cloud CTA link works and styling is consistent