### PR TITLE
fix: security hardening, XSS prevention, npm optimization, v3.1.0 docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Fix GitHub language detection — mark HTML pages as non-source
+*.html linguist-documentation
+cloud.html linguist-vendored
+setup.html linguist-vendored
+success.html linguist-vendored
+privacy.html linguist-vendored
+index.html linguist-vendored
+public/*.html linguist-documentation

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-# Exclude heavy media and operational artifacts from npm package payload.
-docs/videos/*
-docs/images/*.gif
-docs/release-health/*
-docs/LAUNCH-COPY-v2.0.0.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-03-10
+
+### Added
+- **Cloud product surface** — `cloud.html` landing page with Solo ($19/mo) and Team ($49/mo) Stripe checkout
+- **Post-checkout key delivery** — `success.html` polls for provisioned access tokens, shows config with copy-to-clipboard
+- **Homepage Cloud CTA** — `index.html` links to Cloud page
+- **README Cloud section** — pricing table and Cloud link
+- **Revenue Protection** — plan-based tool gating, D1 rate limit persistence, timing-safe admin auth
+- **OAuth 2.1 + PKCE S256** — MCP Registry remote endpoint at `mcp.revasserlabs.com/oauth/mcp`
+- **MCP Registry v3.1.0 published** with `remotes` section
+
+### Security
+- XSS fix: conversation names, user names, and channel names now escaped in web dashboard
+- Shell injection fix: Keychain functions use `execFileSync` with array args instead of string interpolation
+- Undefined param fix: `null`/`undefined` values no longer sent as literal `"undefined"` to Slack API
+- JSON parse guard: non-JSON Slack responses now throw descriptive error instead of crashing
+- `formatTimestamp` guards against NaN/undefined input
+
+### Compatibility
+- No MCP tool renames or removals. All 11 local tools unchanged.
+- Cloud adds 2 AI compound tools (team plan only): `slack_channel_summary`, `slack_extract_action_items`
+
+## [3.0.0] - 2026-02-28
+
+### Changed
+- **Hosted `/mcp` now requires auth** — `Authorization: Bearer` header mandatory for HTTP transport
+- **CORS allowlisting** — hosted endpoint requires `SLACK_MCP_HTTP_ALLOWED_ORIGINS`
+- Structured auth/CORS error responses for missing token config, invalid bearer, and denied origin
+- Publish payload reduced by curating packaged files
+
+### Added
+- Web verification checks demo media reachability
+- Worker compatibility for tool-facing contracts (`channel_id|channel`, `user_id|user`)
+
+### Breaking (Hosted Only)
+- Existing hosted deployments must set `SLACK_MCP_HTTP_AUTH_TOKEN` and `SLACK_MCP_HTTP_ALLOWED_ORIGINS` before upgrade
+- Local `stdio` and `web` paths unchanged — no migration required
+
+### Compatibility
+- No MCP tool renames or removals
+
 ## [2.0.0] - 2026-02-26
 
 ### Fixed
@@ -229,4 +270,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.0.6]: https://github.com/jtalk22/slack-mcp-server/compare/v1.0.5...v1.0.6
 [1.0.5]: https://github.com/jtalk22/slack-mcp-server/compare/v1.0.0...v1.0.5
 [1.0.0]: https://github.com/jtalk22/slack-mcp-server/releases/tag/v1.0.0
+[3.1.0]: https://github.com/jtalk22/slack-mcp-server/compare/v3.0.0...v3.1.0
+[3.0.0]: https://github.com/jtalk22/slack-mcp-server/compare/v2.0.0...v3.0.0
 [2.0.0]: https://github.com/jtalk22/slack-mcp-server/compare/v1.2.4...v2.0.0

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,6 +10,11 @@ Start here for setup, compatibility checks, operations, and support.
 - [Web API Reference](WEB-API.md)
 - [Troubleshooting](TROUBLESHOOTING.md)
 
+## Cloud
+
+- [Cloud Landing Page](https://jtalk22.github.io/slack-mcp-server/cloud.html) — Hosted MCP endpoint, $19/mo Solo, $49/mo Team
+- [Cloud Privacy Policy](https://jtalk22.github.io/slack-mcp-server/privacy.html)
+
 ## Operations
 
 - [Deployment Modes](DEPLOYMENT-MODES.md)
@@ -24,6 +29,7 @@ Start here for setup, compatibility checks, operations, and support.
 - [Launch Ops Runbook](LAUNCH-OPS.md)
 - [Capability Matrix](LAUNCH-MATRIX.md)
 - [Install Proof Block](INSTALL-PROOF.md)
+- [Release Notes (v3.1.0)](../.github/v3.1.0-release-notes.md)
 - [Release Notes (v3.0.0)](../.github/v3.0.0-release-notes.md)
 - [Communication Style](COMMUNICATION-STYLE.md)
 - [Changelog](../CHANGELOG.md)

--- a/docs/INSTALL-PROOF.md
+++ b/docs/INSTALL-PROOF.md
@@ -1,4 +1,4 @@
-# Install Proof Block (v3.0.0)
+# Install Proof Block (v3.1.0)
 
 Use this command block in release notes, HN/X/Reddit follow-ups, and issue replies.
 
@@ -9,7 +9,7 @@ npx -y @jtalk22/slack-mcp@latest --status
 ```
 
 Expected:
-- `--version` prints `slack-mcp-server v3.0.0`
+- `--version` prints `slack-mcp-server v3.1.0`
 - `--doctor` exits with:
   - `0` ready
   - `1` missing credentials

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -193,7 +193,8 @@ export async function slackAPI(method, params = {}, options = {}) {
       // so stringify any arrays/objects before encoding.
       const safeParams = {};
       for (const [key, value] of Object.entries(params)) {
-        safeParams[key] = (typeof value === "object" && value !== null)
+        if (value === undefined || value === null) continue;
+        safeParams[key] = (typeof value === "object")
           ? JSON.stringify(value)
           : String(value);
       }
@@ -228,7 +229,12 @@ export async function slackAPI(method, params = {}, options = {}) {
     throw networkError;
   }
 
-  const data = await response.json();
+  let data;
+  try {
+    data = await response.json();
+  } catch (parseError) {
+    throw new Error(`Slack API ${method} returned non-JSON (HTTP ${response.status}): ${parseError.message}`);
+  }
 
   if (!data.ok) {
     // Handle rate limiting with exponential backoff
@@ -297,7 +303,9 @@ export function getUserCacheStats() {
  * Format a Slack timestamp to ISO string
  */
 export function formatTimestamp(ts) {
-  return new Date(parseFloat(ts) * 1000).toISOString();
+  const parsed = parseFloat(ts);
+  if (!Number.isFinite(parsed)) return null;
+  return new Date(parsed * 1000).toISOString();
 }
 
 /**

--- a/lib/token-store.js
+++ b/lib/token-store.js
@@ -11,7 +11,7 @@
 import { readFileSync, writeFileSync, existsSync, renameSync, unlinkSync } from "fs";
 import { homedir, platform } from "os";
 import { join } from "path";
-import { execSync } from "child_process";
+import { execSync, execFileSync } from "child_process";
 
 const TOKEN_FILE = join(homedir(), ".slack-mcp-tokens.json");
 const KEYCHAIN_SERVICE = "slack-mcp-server";
@@ -28,8 +28,9 @@ let lastExtractionError = null;
 export function getFromKeychain(key) {
   if (!IS_MACOS) return null; // Keychain is macOS-only
   try {
-    const result = execSync(
-      `security find-generic-password -s "${KEYCHAIN_SERVICE}" -a "${key}" -w 2>/dev/null`,
+    const result = execFileSync(
+      "security",
+      ["find-generic-password", "-s", KEYCHAIN_SERVICE, "-a", key, "-w"],
       { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
     );
     return result.trim();
@@ -43,11 +44,11 @@ export function saveToKeychain(key, value) {
   try {
     // Delete existing entry
     try {
-      execSync(`security delete-generic-password -s "${KEYCHAIN_SERVICE}" -a "${key}" 2>/dev/null`, { stdio: 'pipe' });
+      execFileSync("security", ["delete-generic-password", "-s", KEYCHAIN_SERVICE, "-a", key], { stdio: 'pipe' });
     } catch (e) { /* ignore */ }
 
     // Add new entry
-    execSync(`security add-generic-password -s "${KEYCHAIN_SERVICE}" -a "${key}" -w "${value}"`, { stdio: 'pipe' });
+    execFileSync("security", ["add-generic-password", "-s", KEYCHAIN_SERVICE, "-a", key, "-w", value], { stdio: 'pipe' });
     return true;
   } catch (e) {
     return false;

--- a/package.json
+++ b/package.json
@@ -59,7 +59,11 @@
     "automation",
     "productivity"
   ],
-  "author": "jtalk22",
+  "author": {
+    "name": "James Lambert",
+    "email": "james@revasser.nyc",
+    "url": "https://github.com/jtalk22"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -79,12 +83,15 @@
   "files": [
     "src/",
     "lib/",
-    "public/",
-    "scripts/",
-    "docs/*.md",
-    "docs/assets/",
-    "docs/images/*.png",
-    "docs/images/*.svg",
+    "public/index.html",
+    "public/share.html",
+    "scripts/setup-wizard.js",
+    "scripts/token-cli.js",
+    "docs/SETUP.md",
+    "docs/API.md",
+    "docs/TROUBLESHOOTING.md",
+    "docs/assets/icon.svg",
+    "docs/assets/icon-512.png",
     "README.md",
     "LICENSE",
     "server.json",

--- a/public/demo-claude.html
+++ b/public/demo-claude.html
@@ -1239,12 +1239,12 @@
 <body>
   <div class="cta-strip">
     <div class="links">
-      <a href="https://www.npmjs.com/package/@jtalk22/slack-mcp" target="_blank" rel="noopener noreferrer">Install</a>
+      <a href="https://jtalk22.github.io/slack-mcp-server/cloud.html" target="_blank" rel="noopener noreferrer" style="background:rgba(240,194,70,0.18);border-color:rgba(240,194,70,0.45);color:#f0c246">Cloud ($19/mo)</a>
+      <a href="https://www.npmjs.com/package/@jtalk22/slack-mcp" target="_blank" rel="noopener noreferrer">npm Install</a>
       <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md" target="_blank" rel="noopener noreferrer">Setup Guide</a>
-      <a href="https://github.com/jtalk22/slack-mcp-server#30-second-compatibility-check" target="_blank" rel="noopener noreferrer">30-Second Check</a>
     </div>
     <div class="note">
-      Free local-first path with team rollout references in <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/DEPLOYMENT-MODES.md" target="_blank" rel="noopener noreferrer">Deployment Modes</a>.
+      Self-host free or <a href="https://jtalk22.github.io/slack-mcp-server/cloud.html" target="_blank" rel="noopener noreferrer">skip setup with Cloud</a> — one URL, no Docker.
     </div>
   </div>
   <header class="page-header">

--- a/public/index.html
+++ b/public/index.html
@@ -381,7 +381,7 @@
       try {
         const data = await api('/conversations?types=' + types);
         list.innerHTML = data.conversations.map(c =>
-          '<li onclick="loadHistory(\'' + c.id + '\', \'' + c.name.replace(/'/g, "\\'") + '\', this)"><div>' + c.name + '</div><div class="type">' + c.type + '</div></li>'
+          '<li onclick="loadHistory(\'' + c.id + '\', \'' + escapeHtml(c.name).replace(/'/g, "&#39;") + '\', this)"><div>' + escapeHtml(c.name) + '</div><div class="type">' + escapeHtml(c.type) + '</div></li>'
         ).join('');
       } catch (e) { list.innerHTML = '<li class="error-msg">' + e.message + '</li>'; }
     }
@@ -401,7 +401,7 @@
       const container = document.getElementById('messages');
       if (!messages || messages.length === 0) { container.innerHTML = '<div class="loading">No messages</div>'; return; }
       container.innerHTML = messages.map(m =>
-        '<div class="message"><div class="header"><span class="user">' + (m.user || m.user_id || 'Unknown') + '</span><span class="time">' + new Date(m.datetime).toLocaleString() + '</span></div><div class="text">' + escapeHtml(m.text || '') + '</div></div>'
+        '<div class="message"><div class="header"><span class="user">' + escapeHtml(m.user || m.user_id || 'Unknown') + '</span><span class="time">' + new Date(m.datetime).toLocaleString() + '</span></div><div class="text">' + escapeHtml(m.text || '') + '</div></div>'
       ).join('');
       container.scrollTop = container.scrollHeight;
     }
@@ -427,7 +427,7 @@
         const data = await api('/search?q=' + encodeURIComponent(query));
         if (data.matches && data.matches.length > 0) {
           container.innerHTML = data.matches.map(m =>
-            '<div class="message"><div class="header"><span class="user">' + (m.user || 'Unknown') + ' in #' + m.channel + '</span><span class="time">' + new Date(m.datetime).toLocaleString() + '</span></div><div class="text">' + escapeHtml(m.text || '') + '</div></div>'
+            '<div class="message"><div class="header"><span class="user">' + escapeHtml(m.user || 'Unknown') + ' in #' + escapeHtml(m.channel || '') + '</span><span class="time">' + new Date(m.datetime).toLocaleString() + '</span></div><div class="text">' + escapeHtml(m.text || '') + '</div></div>'
           ).join('');
         } else { container.innerHTML = '<div class="loading">No results found</div>'; }
       } catch (e) { container.innerHTML = '<div class="error-msg">' + e.message + '</div>'; }


### PR DESCRIPTION
## Summary

Comprehensive product quality sweep driven by 5 parallel code/site/docs/npm/competitive audit agents.

### P0 Security & Bug Fixes
- **XSS prevention**: Conversation names, user names, and channel names now escaped via `escapeHtml()` in web dashboard (3 vectors closed)
- **Shell injection**: Keychain `getFromKeychain`/`saveToKeychain` switched from `execSync` string interpolation to `execFileSync` with array args
- **Undefined params**: Form-encoded Slack API calls now skip `null`/`undefined` values instead of sending literal `"undefined"` strings
- **formatTimestamp crash**: Returns `null` for NaN/undefined input instead of throwing `RangeError`
- **JSON parse guard**: Non-JSON Slack responses (502 pages, HTML errors) now throw descriptive error

### npm Package Optimization
- **`files` field tightened**: ~3.6MB → ~200KB (18x reduction) — excludes screenshots, marketing scripts, demo HTML not needed at runtime
- **`.npmignore` deleted**: Dead code when `files` field is present
- **`author` enriched**: Now includes name, email, URL for better npm profile rendering
- **Bin permissions fixed**: `src/server-http.js` and `src/web-server.js` → 100755 in git

### Docs & GitHub
- **CHANGELOG**: Added missing v3.0.0 and v3.1.0 entries (was frozen at v2.0.0)
- **INSTALL-PROOF.md**: Version reference v3.0.0 → v3.1.0
- **INDEX.md**: Added Cloud section, v3.1.0 release notes link
- **`.gitattributes`**: Marks HTML as non-source so GitHub detects repo as JavaScript
- **v3.1.0 release published** (was draft — now `/releases/latest` points to v3.1.0)

### UI
- **demo-claude.html**: Cloud CTA added as first link in CTA strip (was missing)

## Test plan

- [ ] `npx -y @jtalk22/slack-mcp@latest --version` returns v3.1.0
- [ ] `npx -y @jtalk22/slack-mcp@latest --doctor` runs without error
- [ ] Web dashboard renders conversation list without XSS
- [ ] Keychain read/write still works after execFileSync migration
- [ ] GitHub detects repo language as JavaScript (after merge)
- [ ] `npm pack` output is ~200KB (not 3.6MB)