### PR TITLE
feat: mark-as-read, unreads inbox, user search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,9 @@ docker pull ghcr.io/jtalk22/slack-mcp-server:latest
 | `slack_list_users` | List workspace users |
 | `slack_add_reaction` | Add emoji reaction to a message |
 | `slack_remove_reaction` | Remove emoji reaction from a message |
+| `slack_conversations_mark` | Mark conversation as read |
+| `slack_conversations_unreads` | Get channels/DMs with unread messages |
+| `slack_users_search` | Search users by name/email |
 
 ## Token Persistence Layers
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ Instead of authenticating as a bot, this server leverages your existing Chrome s
 - **Full Export** - Conversations with threads and resolved usernames
 - **Search** - Query across your entire workspace
 - **Send Messages** - DMs or channels, with thread support
-- **User Directory** - List and search 500+ users with pagination
+- **Reactions** - Add or remove emoji reactions on any message
+- **Unreads** - Priority-sorted unread inbox across all conversations
+- **User Directory** - List, search, and look up 500+ users with pagination
 
 ### Stability
 - **Auto Token Refresh** - Extracts fresh tokens from Chrome automatically *(macOS only)*
@@ -150,6 +152,9 @@ Instead of authenticating as a bot, this server leverages your existing Chrome s
 | `slack_list_users` | List workspace users (paginated, 500+ supported) |
 | `slack_add_reaction` | Add an emoji reaction to a message |
 | `slack_remove_reaction` | Remove an emoji reaction from a message |
+| `slack_conversations_mark` | Mark a conversation as read up to a timestamp |
+| `slack_conversations_unreads` | Get channels/DMs with unread messages, priority-sorted |
+| `slack_users_search` | Search workspace users by name, display name, or email |
 
 ---
 

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -663,3 +663,113 @@ export async function handleRemoveReaction(args) {
     }]
   };
 }
+
+/**
+ * Mark conversation as read handler
+ */
+export async function handleConversationsMark(args) {
+  await slackAPI("conversations.mark", {
+    channel: args.channel_id,
+    ts: args.timestamp
+  });
+
+  return asMcpJson({
+    status: "marked",
+    channel: args.channel_id,
+    read_up_to: args.timestamp
+  });
+}
+
+/**
+ * Unread conversations handler - returns channels/DMs with unread messages
+ */
+export async function handleConversationsUnreads(args) {
+  const types = args.types || "im,mpim,public_channel,private_channel";
+  const limit = args.limit || 50;
+
+  const result = await slackAPI("conversations.list", {
+    types,
+    limit: 200,
+    exclude_archived: true
+  });
+
+  // Filter to conversations with unreads and resolve names
+  const unreads = [];
+  for (const c of (result.channels || [])) {
+    const unreadCount = c.unread_count_display || c.unread_count || 0;
+    if (unreadCount === 0) continue;
+
+    let displayName = c.name;
+    if (c.is_im && c.user) {
+      displayName = await resolveUser(c.user);
+    }
+
+    unreads.push({
+      id: c.id,
+      name: displayName,
+      type: c.is_im ? "dm" : c.is_mpim ? "group_dm" : c.is_private ? "private_channel" : "public_channel",
+      unread_count: unreadCount,
+      latest_ts: c.latest?.ts || null
+    });
+  }
+
+  // Sort by unread count descending
+  unreads.sort((a, b) => b.unread_count - a.unread_count);
+
+  return asMcpJson({
+    total_unread_conversations: unreads.length,
+    conversations: unreads.slice(0, limit)
+  });
+}
+
+/**
+ * Search users handler - client-side filter on users.list
+ */
+export async function handleUsersSearch(args) {
+  const query = (args.query || "").toLowerCase();
+  const limit = args.limit || 20;
+
+  // Fetch all users (paginated)
+  const allUsers = [];
+  let cursor;
+
+  do {
+    const result = await slackAPI("users.list", {
+      limit: 200,
+      cursor
+    });
+
+    for (const u of (result.members || [])) {
+      if (u.deleted || u.is_bot || u.id === "USLACKBOT") continue;
+
+      const searchFields = [
+        u.name,
+        u.real_name,
+        u.profile?.display_name,
+        u.profile?.email
+      ].filter(Boolean).map(s => s.toLowerCase());
+
+      if (searchFields.some(f => f.includes(query))) {
+        allUsers.push({
+          id: u.id,
+          name: u.name,
+          real_name: u.real_name,
+          display_name: u.profile?.display_name,
+          email: u.profile?.email,
+          title: u.profile?.title,
+          is_admin: u.is_admin
+        });
+      }
+    }
+
+    cursor = result.response_metadata?.next_cursor;
+    if (cursor) await sleep(100);
+  } while (cursor && allUsers.length < 500);
+
+  return asMcpJson({
+    query: args.query,
+    count: Math.min(allUsers.length, limit),
+    total_matches: allUsers.length,
+    users: allUsers.slice(0, limit)
+  });
+}

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -326,5 +326,78 @@ export const TOOLS = [
       idempotentHint: true,
       openWorldHint: true
     }
+  },
+  {
+    name: "slack_conversations_mark",
+    description: "Mark a conversation as read up to a specific message timestamp",
+    inputSchema: {
+      type: "object",
+      properties: {
+        channel_id: {
+          type: "string",
+          description: "Channel or DM ID to mark as read"
+        },
+        timestamp: {
+          type: "string",
+          description: "Message timestamp to mark as read up to (all messages at or before this are marked read)"
+        }
+      },
+      required: ["channel_id", "timestamp"]
+    },
+    annotations: {
+      title: "Mark as Read",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true
+    }
+  },
+  {
+    name: "slack_conversations_unreads",
+    description: "Get channels and DMs with unread messages, sorted by unread count (highest first)",
+    inputSchema: {
+      type: "object",
+      properties: {
+        types: {
+          type: "string",
+          description: "Comma-separated types: im, mpim, public_channel, private_channel (default all)",
+          default: "im,mpim,public_channel,private_channel"
+        },
+        limit: {
+          type: "number",
+          description: "Maximum conversations to return (default 50)"
+        }
+      }
+    },
+    annotations: {
+      title: "Unread Conversations",
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: true
+    }
+  },
+  {
+    name: "slack_users_search",
+    description: "Search workspace users by name, display name, or email. Case-insensitive partial match.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Search term to match against name, display name, real name, or email"
+        },
+        limit: {
+          type: "number",
+          description: "Maximum results to return (default 20)"
+        }
+      },
+      required: ["query"]
+    },
+    annotations: {
+      title: "Search Users",
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: true
+    }
   }
 ];

--- a/src/server.js
+++ b/src/server.js
@@ -43,6 +43,9 @@ import {
   handleListUsers,
   handleAddReaction,
   handleRemoveReaction,
+  handleConversationsMark,
+  handleConversationsUnreads,
+  handleUsersSearch,
 } from "../lib/handlers.js";
 
 // Background refresh interval (4 hours)
@@ -262,6 +265,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case "slack_remove_reaction":
         return await handleRemoveReaction(args);
+
+      case "slack_conversations_mark":
+        return await handleConversationsMark(args);
+
+      case "slack_conversations_unreads":
+        return await handleConversationsUnreads(args);
+
+      case "slack_users_search":
+        return await handleUsersSearch(args);
 
       default:
         return {

--- a/src/web-server.js
+++ b/src/web-server.js
@@ -32,6 +32,9 @@ import {
   handleListUsers,
   handleAddReaction,
   handleRemoveReaction,
+  handleConversationsMark,
+  handleConversationsUnreads,
+  handleUsersSearch,
 } from "../lib/handlers.js";
 
 const app = express();
@@ -155,6 +158,9 @@ app.get("/", (req, res) => {
       "GET  /users/:id",
       "POST /reactions",
       "DELETE /reactions",
+      "POST /conversations/:id/mark",
+      "GET  /conversations/unreads",
+      "GET  /users/search",
     ],
     docs: "Add Authorization: Bearer <api-key> header to all requests"
   });
@@ -211,6 +217,19 @@ app.get("/conversations", authenticate, async (req, res) => {
   }
 });
 
+// Get unread conversations
+app.get("/conversations/unreads", authenticate, async (req, res) => {
+  try {
+    const result = await handleConversationsUnreads({
+      types: req.query.types || "im,mpim,public_channel,private_channel",
+      limit: parseInt(req.query.limit) || 50
+    });
+    res.json(extractContent(result));
+  } catch (e) {
+    sendStructuredError(res, 500, "unreads_failed", String(e?.message || e));
+  }
+});
+
 // Get conversation history
 app.get("/conversations/:id/history", authenticate, async (req, res) => {
   try {
@@ -254,6 +273,28 @@ app.get("/conversations/:id/thread/:ts", authenticate, async (req, res) => {
     res.json(extractContent(result));
   } catch (e) {
     sendStructuredError(res, 500, "thread_fetch_failed", String(e?.message || e));
+  }
+});
+
+// Mark conversation as read
+app.post("/conversations/:id/mark", authenticate, async (req, res) => {
+  try {
+    if (!req.body.timestamp) {
+      return sendStructuredError(
+        res,
+        400,
+        "invalid_request",
+        "timestamp is required",
+        "Include timestamp in request JSON."
+      );
+    }
+    const result = await handleConversationsMark({
+      channel_id: req.params.id,
+      timestamp: req.body.timestamp
+    });
+    res.json(extractContent(result));
+  } catch (e) {
+    sendStructuredError(res, 500, "mark_failed", String(e?.message || e));
   }
 });
 
@@ -311,6 +352,28 @@ app.get("/users", authenticate, async (req, res) => {
     res.json(extractContent(result));
   } catch (e) {
     sendStructuredError(res, 500, "list_users_failed", String(e?.message || e));
+  }
+});
+
+// Search users (must be registered before /users/:id to avoid Express matching "search" as an ID)
+app.get("/users/search", authenticate, async (req, res) => {
+  try {
+    if (!req.query.q) {
+      return sendStructuredError(
+        res,
+        400,
+        "invalid_request",
+        "Query parameter 'q' is required",
+        "Set the q query string and retry."
+      );
+    }
+    const result = await handleUsersSearch({
+      query: req.query.q,
+      limit: parseInt(req.query.limit) || 20
+    });
+    res.json(extractContent(result));
+  } catch (e) {
+    sendStructuredError(res, 500, "user_search_failed", String(e?.message || e));
   }
 });
 


### PR DESCRIPTION
## Summary

Closes 3 competitive gaps identified in the korotovsky feature comparison:

- **`slack_conversations_mark`** — Mark a conversation as read up to a timestamp. Uses Slack's `conversations.mark` API.
- **`slack_conversations_unreads`** — Priority-sorted unread inbox. Returns channels/DMs with unread messages, sorted by unread count (highest first). 
- **`slack_users_search`** — Search workspace users by name, display name, or email. Client-side filter on `users.list` with case-insensitive partial matching.

All three tools are wired into both MCP (server.js) and REST (web-server.js) transports.

## Changes

| File | What |
|------|------|
| `lib/tools.js` | 3 new MCP tool definitions with annotations |
| `lib/handlers.js` | 3 new handlers (mark, unreads, users search) |
| `src/server.js` | Import + dispatch for 3 new handlers |
| `src/web-server.js` | 3 REST endpoints, route ordering fix for `/users/search` before `/users/:id` |
| `CLAUDE.md` | Tool table: +3 tools (16 total) |
| `README.md` | Tool table + Features section updated |

## Design notes

- **Route ordering**: `/users/search` registered before `/users/:id` to prevent Express matching "search" as a user ID param
- **`conversations.mark`** is idempotent — marking the same timestamp twice is a no-op
- **Unreads** uses `unread_count_display` (which Slack shows in UI) with fallback to `unread_count`
- **User search** paginates through all users then filters client-side — Slack has no server-side user search API for session tokens

## Test plan

- [ ] `node --check` passes on all 4 modified JS files
- [ ] CI passes all 4 checks
- [ ] `tools/list` returns 16 tools via MCP