### PR TITLE
release: v3.2.0

### DIFF
--- a/.github/v3.2.0-release-notes.md
+++ b/.github/v3.2.0-release-notes.md
@@ -1,0 +1,54 @@
+## v3.2.0 — Reactions, Unreads, User Search
+
+`v3.2.0` adds 5 new tools across all three transports: emoji reactions, mark-as-read, unread inbox, and user search. Tool count moves from 11 to 16.
+
+```bash
+npx -y @jtalk22/slack-mcp@latest --version
+npx -y @jtalk22/slack-mcp@latest --doctor
+```
+
+### New Tools
+
+| Tool | Purpose |
+|------|---------|
+| `slack_add_reaction` | Add emoji reactions to messages |
+| `slack_remove_reaction` | Remove emoji reactions from messages |
+| `slack_conversations_mark` | Mark a conversation as read up to a timestamp |
+| `slack_conversations_unreads` | Priority-sorted unread inbox across all channels and DMs |
+| `slack_users_search` | Search workspace users by name, display name, or email |
+
+### What Changed
+
+- **5 new MCP tools** — reactions (add/remove), mark-as-read, unread inbox, and user search. Available on all plans including self-hosted.
+- **REST endpoints** — `POST /reactions`, `DELETE /reactions`, `POST /conversations/:id/mark`, `GET /conversations/unreads`, `GET /users/search`.
+- **server-http.js tool parity** — Hosted HTTP transport now dispatches all 16 tools (was missing 5 after PRs #30/#31).
+- **Background timer crash fix** — `setInterval` callback in server.js wrapped in try/catch to prevent unhandled rejection.
+- **Express route ordering** — `/users/search` registered before `/users/:id` to prevent "search" matching as user ID.
+
+### Who This Affects
+
+- Self-hosted users: upgrade to get 5 new tools. No breaking changes.
+- Cloud users: new tools available immediately.
+- Hosted HTTP users: critical parity fix — upgrade required to use reaction/unreads/search tools.
+
+### Contract Stability
+
+- No MCP tool names were removed or renamed.
+- All existing tool schemas unchanged. Fully backwards compatible.
+- Diagnostics remain deterministic (`--doctor`, `--status`, `--version`).
+
+### Verify Install
+
+```bash
+npx -y @jtalk22/slack-mcp@latest --version
+npx -y @jtalk22/slack-mcp@latest --doctor
+npx -y @jtalk22/slack-mcp@latest --status
+```
+
+### Support
+
+- Cloud: [jtalk22.github.io/slack-mcp-server/cloud.html](https://jtalk22.github.io/slack-mcp-server/cloud.html)
+- Deployment intake: https://github.com/jtalk22/slack-mcp-server/issues/new?template=deployment-intake.md
+- Troubleshooting: https://github.com/jtalk22/slack-mcp-server/blob/main/docs/TROUBLESHOOTING.md
+
+Maintainer/operator: `jtalk22` (`james@revasser.nyc`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2026-03-10
+
+### Added
+- **`slack_add_reaction`** — Add emoji reactions to messages
+- **`slack_remove_reaction`** — Remove emoji reactions from messages
+- **`slack_conversations_mark`** — Mark a conversation as read up to a timestamp
+- **`slack_conversations_unreads`** — Priority-sorted unread inbox across all channels and DMs
+- **`slack_users_search`** — Search workspace users by name, display name, or email
+- REST endpoints: `POST /reactions`, `DELETE /reactions`, `POST /conversations/:id/mark`, `GET /conversations/unreads`, `GET /users/search`
+
+### Fixed
+- **server-http.js tool parity** — Hosted HTTP transport now dispatches all 16 tools (was missing reactions, mark, unreads, search)
+- **Background timer crash** — `setInterval` callback in server.js wrapped in try/catch to prevent unhandled rejection
+- **Express route ordering** — `/users/search` registered before `/users/:id` to prevent "search" matching as user ID
+
+### Changed
+- Tool count: 11 → 16 across all three transports (stdio, web, hosted HTTP)
+- Cloud docs added to SETUP.md, DEPLOYMENT-MODES.md, and TROUBLESHOOTING.md
+
+### Compatibility
+- No MCP tool renames or removals. Fully backwards compatible.
+
 ## [3.1.0] - 2026-03-10
 
 ### Added
@@ -270,6 +292,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.0.6]: https://github.com/jtalk22/slack-mcp-server/compare/v1.0.5...v1.0.6
 [1.0.5]: https://github.com/jtalk22/slack-mcp-server/compare/v1.0.0...v1.0.5
 [1.0.0]: https://github.com/jtalk22/slack-mcp-server/releases/tag/v1.0.0
+[3.2.0]: https://github.com/jtalk22/slack-mcp-server/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/jtalk22/slack-mcp-server/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/jtalk22/slack-mcp-server/compare/v2.0.0...v3.0.0
 [2.0.0]: https://github.com/jtalk22/slack-mcp-server/compare/v1.2.4...v2.0.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/@jtalk22/slack-mcp)](https://www.npmjs.com/package/@jtalk22/slack-mcp)
 [![npm downloads](https://img.shields.io/npm/dm/@jtalk22/slack-mcp)](https://www.npmjs.com/package/@jtalk22/slack-mcp)
-[![MCP Registry](https://img.shields.io/badge/MCP_Registry-v3.1.0-blue)](https://registry.modelcontextprotocol.io)
+[![MCP Registry](https://img.shields.io/badge/MCP_Registry-v3.2.0-blue)](https://registry.modelcontextprotocol.io)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
 Session-based Slack MCP for Claude and MCP clients. Local-first `stdio`/`web` with secure-default hosted HTTP in v3.
@@ -25,27 +25,26 @@ Motion proof: [20-second mobile clip](https://jtalk22.github.io/slack-mcp-server
 Hosted migration note: `v3.1.0` keeps local `stdio`/`web` flows unchanged; hosted `/mcp` requires `SLACK_MCP_HTTP_AUTH_TOKEN` and `SLACK_MCP_HTTP_ALLOWED_ORIGINS`.
 
 Maintainer/operator: `jtalk22` (`james@revasser.nyc`)  
-Release: [`v3.1.0`](https://github.com/jtalk22/slack-mcp-server/releases/tag/v3.1.0) · Notes: [v3.1.0 notes](https://github.com/jtalk22/slack-mcp-server/blob/main/.github/v3.1.0-release-notes.md) · Support: [deployment intake](https://github.com/jtalk22/slack-mcp-server/issues/new?template=deployment-intake.md)
+Release: [`v3.2.0`](https://github.com/jtalk22/slack-mcp-server/releases/tag/v3.2.0) · Notes: [v3.2.0 notes](https://github.com/jtalk22/slack-mcp-server/blob/main/.github/v3.2.0-release-notes.md) · Support: [deployment intake](https://github.com/jtalk22/slack-mcp-server/issues/new?template=deployment-intake.md)
 
 If this saved you setup time, consider starring the repo. Maintenance support: [GitHub Sponsors](https://github.com/sponsors/jtalk22) · [Ko-fi](https://ko-fi.com/jtalk22) · [Buy Me a Coffee](https://buymeacoffee.com/jtalk22)
 
-## v3.1.0 at a Glance
+## v3.2.0 at a Glance
 
-- Hosted HTTP `/mcp` now requires bearer auth by default (`SLACK_MCP_HTTP_AUTH_TOKEN`).
-- Hosted HTTP CORS now uses explicit allowlisting (`SLACK_MCP_HTTP_ALLOWED_ORIGINS`).
-- Local-first paths (`stdio`, `web`) stay compatible.
-- MCP tool names stay stable (no renames/removals).
+- **16 tools** — added reactions, mark-as-read, unread inbox, and user search
+- All three transports (stdio, web, hosted HTTP) have full tool parity
+- No MCP tool renames or removals — fully backwards compatible
 
 ## Slack MCP Cloud
 
 **No token management. No Docker. No Chrome extensions. One URL and you're connected.**
 
-Skip all local setup — paste one URL into Claude and get 13 Slack tools running in under 60 seconds. Encrypted token storage on Cloudflare's global edge (300+ PoPs). The only cloud-hosted session-based Slack MCP on the market.
+Skip all local setup — paste one URL into Claude and get 16 Slack tools running in under 60 seconds. Encrypted token storage on Cloudflare's global edge (300+ PoPs). The only cloud-hosted session-based Slack MCP on the market.
 
 | Plan | Price | Includes |
 |------|-------|----------|
-| Solo | $19/mo | 10 standard tools, AES-256-GCM encrypted storage, 5K requests/mo |
-| Team | $49/mo | 13 tools (incl. AI summaries, action items, decisions), 3 workspaces, 25K requests/mo |
+| Solo | $19/mo | 16 standard tools, AES-256-GCM encrypted storage, 5K requests/mo |
+| Team | $49/mo | 16 standard + 3 AI compound tools, 3 workspaces, 25K requests/mo |
 
 [Get Your API Key](https://jtalk22.github.io/slack-mcp-server/cloud.html) — live in 60 seconds. [Privacy Policy](https://jtalk22.github.io/slack-mcp-server/privacy.html).
 
@@ -402,7 +401,7 @@ npm run web
 
 ```
 ════════════════════════════════════════════════════════════
-  Slack Web API Server v3.1.0
+  Slack Web API Server v3.2.0
 ════════════════════════════════════════════════════════════
 
   Dashboard: http://localhost:3000/?key=smcp_xxxxxxxxxxxx

--- a/cloud.html
+++ b/cloud.html
@@ -4,17 +4,17 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Slack MCP Cloud — One URL, No Setup</title>
-  <meta name="description" content="Hosted Slack MCP for Claude and any MCP client. One API key, 13 tools, encrypted token storage. No OAuth, no admin approval, no Docker.">
+  <meta name="description" content="Hosted Slack MCP for Claude and any MCP client. One API key, 16 tools, encrypted token storage. No OAuth, no admin approval, no Docker.">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Slack MCP Cloud — One URL, No Setup">
-  <meta property="og:description" content="Hosted Slack MCP for Claude. 13 tools, encrypted tokens, zero config. From $19/mo.">
+  <meta property="og:description" content="Hosted Slack MCP for Claude. 16 tools, encrypted tokens, zero config. From $19/mo.">
   <meta property="og:url" content="https://jtalk22.github.io/slack-mcp-server/cloud.html">
   <meta property="og:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
   <meta property="og:image:width" content="1280">
   <meta property="og:image:height" content="640">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Slack MCP Cloud — One URL, No Setup">
-  <meta name="twitter:description" content="Hosted Slack MCP for Claude. 13 tools, encrypted tokens, zero config. From $19/mo.">
+  <meta name="twitter:description" content="Hosted Slack MCP for Claude. 16 tools, encrypted tokens, zero config. From $19/mo.">
   <meta name="twitter:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -768,7 +768,7 @@
     <!-- 3. Standard Tools -->
     <section class="section">
       <div class="section-header fade-up">
-        <h2>10 Slack tools, ready to use</h2>
+        <h2>16 Slack tools, ready to use</h2>
         <p>Everything you need for full Slack access from Claude. Every plan, including self-hosted.</p>
       </div>
       <div class="tools-list fade-up">
@@ -840,6 +840,48 @@
           <div>
             <div class="tool-name">slack_token_status</div>
             <div class="tool-desc">Check token health</div>
+          </div>
+        </div>
+        <div class="tool-item">
+          <span class="tool-arrow">&rarr;</span>
+          <div>
+            <div class="tool-name">slack_refresh_tokens</div>
+            <div class="tool-desc">Auto-refresh credentials</div>
+          </div>
+        </div>
+        <div class="tool-item">
+          <span class="tool-arrow">&rarr;</span>
+          <div>
+            <div class="tool-name">slack_add_reaction</div>
+            <div class="tool-desc">React to messages</div>
+          </div>
+        </div>
+        <div class="tool-item">
+          <span class="tool-arrow">&rarr;</span>
+          <div>
+            <div class="tool-name">slack_remove_reaction</div>
+            <div class="tool-desc">Remove reactions</div>
+          </div>
+        </div>
+        <div class="tool-item">
+          <span class="tool-arrow">&rarr;</span>
+          <div>
+            <div class="tool-name">slack_conversations_mark</div>
+            <div class="tool-desc">Mark as read</div>
+          </div>
+        </div>
+        <div class="tool-item">
+          <span class="tool-arrow">&rarr;</span>
+          <div>
+            <div class="tool-name">slack_conversations_unreads</div>
+            <div class="tool-desc">Unread inbox</div>
+          </div>
+        </div>
+        <div class="tool-item">
+          <span class="tool-arrow">&rarr;</span>
+          <div>
+            <div class="tool-name">slack_users_search</div>
+            <div class="tool-desc">Search users</div>
           </div>
         </div>
       </div>
@@ -921,7 +963,7 @@
           <div class="price-amount">Free</div>
           <div class="price-desc">Full server on your machine. You manage tokens.</div>
           <ul class="price-list">
-            <li>10 MCP tools</li>
+            <li>16 MCP tools</li>
             <li>stdio + SSE transport</li>
             <li>Chrome token extraction</li>
             <li>MIT licensed</li>
@@ -934,7 +976,7 @@
           <div class="price-amount">$19 <span class="per">/mo</span></div>
           <div class="price-desc">Hosted endpoint with managed tokens. Zero maintenance.</div>
           <ul class="price-list">
-            <li>10 MCP tools</li>
+            <li>16 MCP tools</li>
             <li>Auto token refresh</li>
             <li>Encrypted storage (AES-256)</li>
             <li>1 workspace</li>
@@ -1023,7 +1065,7 @@
     <section class="section fade-up">
       <div class="trust-row">
         <div class="trust-item">
-          <div class="trust-num">v3.1</div>
+          <div class="trust-num">v3.2</div>
           <div class="trust-label">current release</div>
         </div>
         <div class="trust-item">

--- a/docs/DEPLOYMENT-MODES.md
+++ b/docs/DEPLOYMENT-MODES.md
@@ -14,8 +14,8 @@ Use this guide to choose the right operating mode before rollout.
 
 | Mode | Start Command | Best For | Auth Material | Exposure | Notes |
 |------|---------------|----------|---------------|----------|-------|
-| **Cloud** | N/A — managed | Teams, non-technical users, zero-ops | API key from checkout | `mcp.revasserlabs.com` | $19/mo Solo, $49/mo Team. 13 tools incl. AI compound tools. No Docker, no token mgmt. |
-| Local MCP (`stdio`) | `npx -y @jtalk22/slack-mcp` | Individual daily usage in Claude | `SLACK_TOKEN` + `SLACK_COOKIE` via token file/env | Local process | Lowest ops burden. Free. 11 tools. |
+| **Cloud** | N/A — managed | Teams, non-technical users, zero-ops | API key from checkout | `mcp.revasserlabs.com` | $19/mo Solo, $49/mo Team. 16 standard tools + AI compound tools on Team. No Docker, no token mgmt. |
+| Local MCP (`stdio`) | `npx -y @jtalk22/slack-mcp` | Individual daily usage in Claude | `SLACK_TOKEN` + `SLACK_COOKIE` via token file/env | Local process | Lowest ops burden. Free. 16 tools. |
 | Local Web UI (`web`) | `npx -y @jtalk22/slack-mcp web` | Browser-first usage, manual search/send | Same as above + generated API key | `localhost` by default | Useful when MCP is not available |
 | Hosted MCP (`http`) | `node src/server-http.js` | Controlled hosted integration | Env-injected Slack token/cookie + HTTP bearer token | Remote endpoint | `/mcp` is bearer-protected by default; configure CORS allowlist |
 | Smithery/Worker | `wrangler deploy` + Smithery publish flow | Registry distribution for hosted consumers | Query/env token handoff | Remote endpoint | Keep worker version parity with npm release |
@@ -27,7 +27,7 @@ No local setup required:
 1. Purchase a plan at [cloud.html](https://jtalk22.github.io/slack-mcp-server/cloud.html)
 2. Receive API key and config snippets on the success page
 3. Paste config into Claude Desktop or Claude Code
-4. All 13 tools available immediately (including AI compound tools on Team plan)
+4. All 16 standard tools available immediately (plus AI compound tools on Team plan)
 
 Cloud handles token refresh, encryption (AES-256-GCM), and rate limiting automatically.
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -29,6 +29,7 @@ Start here for setup, compatibility checks, operations, and support.
 - [Launch Ops Runbook](LAUNCH-OPS.md)
 - [Capability Matrix](LAUNCH-MATRIX.md)
 - [Install Proof Block](INSTALL-PROOF.md)
+- [Release Notes (v3.2.0)](../.github/v3.2.0-release-notes.md)
 - [Release Notes (v3.1.0)](../.github/v3.1.0-release-notes.md)
 - [Release Notes (v3.0.0)](../.github/v3.0.0-release-notes.md)
 - [Communication Style](COMMUNICATION-STYLE.md)

--- a/docs/INSTALL-PROOF.md
+++ b/docs/INSTALL-PROOF.md
@@ -1,4 +1,4 @@
-# Install Proof Block (v3.1.0)
+# Install Proof Block (v3.2.0)
 
 Use this command block in release notes, HN/X/Reddit follow-ups, and issue replies.
 
@@ -9,7 +9,7 @@ npx -y @jtalk22/slack-mcp@latest --status
 ```
 
 Expected:
-- `--version` prints `slack-mcp-server v3.1.0`
+- `--version` prints `slack-mcp-server v3.2.0`
 - `--doctor` exits with:
   - `0` ready
   - `1` missing credentials

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -6,7 +6,7 @@ If you want to skip local setup entirely, use **Slack MCP Cloud**:
 
 1. Go to [cloud.html](https://jtalk22.github.io/slack-mcp-server/cloud.html) and purchase a plan ($19/mo Solo, $49/mo Team)
 2. After checkout, you'll receive an API key and ready-to-paste config for Claude Desktop / Claude Code
-3. No Node.js, no Docker, no token management — one URL, 13 tools
+3. No Node.js, no Docker, no token management — one URL, 16 tools
 
 **Claude Desktop config (Cloud):**
 ```json

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -42,11 +42,11 @@ If `--version` fails here, the issue is install/runtime path, not Slack credenti
 
 ### Cloud Tools Not Available
 
-**Symptom:** Only seeing 10-11 tools instead of 13.
+**Symptom:** Only seeing fewer tools than expected.
 
-**Cause:** AI compound tools (`slack_channel_summary`, `slack_extract_action_items`) are Team plan only ($49/mo).
+**Cause:** AI compound tools (`slack_channel_summary`, `slack_extract_action_items`, `slack_find_decisions`) are Team plan only ($49/mo).
 
-**Solution:** Upgrade to Team plan, or use the standard 11 tools on Solo plan.
+**Solution:** Upgrade to Team plan for AI compound tools, or use the standard 16 tools available on all plans.
 
 ### Cloud Endpoint Health Check
 

--- a/docs/release-health/latest.md
+++ b/docs/release-health/latest.md
@@ -1,16 +1,16 @@
 # Public Health Snapshot
 
 - Generated: 2026-03-10T14:00:00Z
-- Cycle: `v3.1.0`
+- Cycle: `v3.2.0`
 
 ## Distribution Parity
 
 | Surface | State |
 |---|---|
-| npm `latest` | `3.1.0` |
-| GitHub latest release | `v3.1.0` |
-| Docker `latest` | `v3.1.0` |
-| MCP registry latest | `3.1.0` (pending publish) |
+| npm `latest` | `3.2.0` |
+| GitHub latest release | `v3.2.0` |
+| Docker `latest` | `v3.2.0` |
+| MCP registry latest | `3.2.0` (pending publish) |
 
 ## Public Reach (14-day GitHub window)
 

--- a/glama.json
+++ b/glama.json
@@ -1,15 +1,15 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "name": "slack-mcp-server",
-  "description": "Session-based Slack MCP for Claude and MCP clients. 13 tools: read channels, search messages, send replies, AI summaries. Cloud hosted option with encrypted storage — no Docker, no admin approval.",
+  "description": "Session-based Slack MCP for Claude and MCP clients. 16 tools: read channels, search messages, send replies, reactions, unreads, user search, AI summaries. Cloud hosted option with encrypted storage — no Docker, no admin approval.",
   "repository": "https://github.com/jtalk22/slack-mcp-server",
   "homepage": "https://jtalk22.github.io/slack-mcp-server/",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "license": "MIT",
   "maintainers": ["jtalk22"],
   "categories": ["communication", "productivity"],
   "features": {
-    "tools": 13,
+    "tools": 16,
     "resources": 2,
     "prompts": 3,
     "transports": ["stdio", "streamable-http"]

--- a/index.html
+++ b/index.html
@@ -3,17 +3,17 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Slack MCP Server v3.1.0 - Install in 30 Seconds</title>
+  <title>Slack MCP Server v3.2.0 - Install in 30 Seconds</title>
   <meta name="description" content="Session-based Slack MCP for Claude and MCP clients. Local-first stdio/web with secure-default hosted HTTP in v3.">
   <meta property="og:type" content="website">
-  <meta property="og:title" content="Slack MCP Server v3.1.0">
+  <meta property="og:title" content="Slack MCP Server v3.2.0">
   <meta property="og:description" content="Session-based Slack MCP for Claude and MCP clients. Local-first stdio/web with secure-default hosted HTTP in v3.">
   <meta property="og:url" content="https://jtalk22.github.io/slack-mcp-server/">
   <meta property="og:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
   <meta property="og:image:width" content="1280">
   <meta property="og:image:height" content="640">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Slack MCP Server v3.1.0">
+  <meta name="twitter:title" content="Slack MCP Server v3.2.0">
   <meta name="twitter:description" content="Session-based Slack MCP for Claude and MCP clients. Local-first stdio/web with secure-default hosted HTTP in v3.">
   <meta name="twitter:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -187,11 +187,11 @@
   <main class="shell">
     <section class="hero">
       <h1>Give Claude your Slack</h1>
-      <p>13 MCP tools. Read channels, search messages, send replies, get AI summaries. Self-host free or use Cloud — live in 60 seconds.</p>
+      <p>16 MCP tools. Read channels, search messages, send replies, react, manage unreads. Plus AI summaries on Cloud. Self-host free or use Cloud — live in 60 seconds.</p>
       <div class="cta-row">
         <a href="cloud.html" style="background:rgba(240,194,70,0.18);border-color:rgba(240,194,70,0.45)"><strong style="color:#f0c246">Cloud</strong> from $19/mo</a>
         <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md"><strong>Self-Host</strong> (free)</a>
-        <a href="https://github.com/jtalk22/slack-mcp-server/releases/latest"><strong>v3.1.0</strong></a>
+        <a href="https://github.com/jtalk22/slack-mcp-server/releases/latest"><strong>v3.2.0</strong></a>
         <a href="https://www.npmjs.com/package/@jtalk22/slack-mcp"><strong>npm</strong></a>
       </div>
       <div class="verify">npx -y @jtalk22/slack-mcp --setup

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jtalk22/slack-mcp",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jtalk22/slack-mcp",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jtalk22/slack-mcp",
   "mcpName": "io.github.jtalk22/slack-mcp-server",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Session-based Slack MCP for Claude and MCP clients: local-first workflows, secure-default HTTP.",
   "type": "module",
   "main": "src/server.js",

--- a/public/demo-claude.html
+++ b/public/demo-claude.html
@@ -11,20 +11,20 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="author" content="@jtalk22">
-  <title>Slack MCP Server v3.1.0 — Claude Desktop Demo</title>
-  <meta name="description" content="Give Claude your Slack. 13 MCP tools — read channels, search messages, send replies, get AI summaries. Self-host free or Cloud from $19/mo.">
+  <title>Slack MCP Server v3.2.0 — Claude Desktop Demo</title>
+  <meta name="description" content="Give Claude your Slack. 16 MCP tools — read channels, search messages, send replies, get AI summaries. Self-host free or Cloud from $19/mo.">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Slack MCP Server v3.1.0 — Claude Desktop Demo">
-  <meta property="og:description" content="Give Claude your Slack. 13 MCP tools — read channels, search messages, send replies, get AI summaries. Self-host free or Cloud from $19/mo.">
+  <meta property="og:title" content="Slack MCP Server v3.2.0 — Claude Desktop Demo">
+  <meta property="og:description" content="Give Claude your Slack. 16 MCP tools — read channels, search messages, send replies, get AI summaries. Self-host free or Cloud from $19/mo.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://jtalk22.github.io/slack-mcp-server/public/demo-claude.html">
   <meta property="og:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Slack MCP Server v3.1.0 — Claude Desktop Demo">
-  <meta name="twitter:description" content="Give Claude your Slack. 13 MCP tools — read channels, search messages, send replies, get AI summaries. Self-host free or Cloud from $19/mo.">
+  <meta name="twitter:title" content="Slack MCP Server v3.2.0 — Claude Desktop Demo">
+  <meta name="twitter:description" content="Give Claude your Slack. 16 MCP tools — read channels, search messages, send replies, get AI summaries. Self-host free or Cloud from $19/mo.">
   <meta name="twitter:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
 
   <!-- Theme -->
@@ -1250,7 +1250,7 @@
   <header class="page-header">
     <h1>
       <span>Slack MCP Server</span>
-      <span class="badge">🔧 MCP Demo v3.1.0</span>
+      <span class="badge">🔧 MCP Demo v3.2.0</span>
     </h1>
     <p>See how Claude uses MCP tools to access your Slack workspace</p>
   </header>
@@ -1322,7 +1322,7 @@
       <div class="title-logo">💬</div>
       <h1>Slack MCP Server</h1>
       <p class="title-tagline">Full Slack access for Claude Desktop</p>
-      <p class="title-version">v3.1.0 • @jtalk22</p>
+      <p class="title-version">v3.2.0 • @jtalk22</p>
     </div>
 
     <!-- Scenario Caption Overlay -->
@@ -1357,7 +1357,7 @@
       <div class="input-field">Message Claude...</div>
       <div class="tools-button">
         <span class="icon">🔨</span>
-        <span>11 tools</span>
+        <span>16 tools</span>
         <div class="tools-dropdown">
           <div class="dropdown-header">
             <span>🔨</span> Available Slack Tools

--- a/public/demo-video.html
+++ b/public/demo-video.html
@@ -3,15 +3,15 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Slack MCP Server v3.1.0 — Video Demo</title>
+  <title>Slack MCP Server v3.2.0 — Video Demo</title>
   <meta name="description" content="Give Claude your Slack. 13 MCP tools — read channels, search messages, send replies, get AI summaries. Self-host free or Cloud from $19/mo.">
   <meta property="og:type" content="website">
-  <meta property="og:title" content="Slack MCP Server v3.1.0 — Video Demo">
+  <meta property="og:title" content="Slack MCP Server v3.2.0 — Video Demo">
   <meta property="og:description" content="Give Claude your Slack. 13 MCP tools — read channels, search messages, send replies, get AI summaries. Self-host free or Cloud from $19/mo.">
   <meta property="og:url" content="https://jtalk22.github.io/slack-mcp-server/public/demo-video.html">
   <meta property="og:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Slack MCP Server v3.1.0 — Video Demo">
+  <meta name="twitter:title" content="Slack MCP Server v3.2.0 — Video Demo">
   <meta name="twitter:description" content="Give Claude your Slack. 13 MCP tools — read channels, search messages, send replies, get AI summaries. Self-host free or Cloud from $19/mo.">
   <meta name="twitter:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -171,8 +171,8 @@
 </head>
 <body>
   <div class="container">
-    <h1>Slack MCP Server <span style="font-size:0.55em;opacity:0.5;font-weight:400;vertical-align:middle">v3.1.0</span></h1>
-    <p class="subtitle">Give Claude your Slack. 13 tools — read, search, send, summarize. Self-host free or Cloud from $19/mo.</p>
+    <h1>Slack MCP Server <span style="font-size:0.55em;opacity:0.5;font-weight:400;vertical-align:middle">v3.2.0</span></h1>
+    <p class="subtitle">Give Claude your Slack. 16 tools — read, search, send, react, summarize. Self-host free or Cloud from $19/mo.</p>
     <div class="cta-strip">
       <div class="links">
         <a href="https://jtalk22.github.io/slack-mcp-server/cloud.html" target="_blank" rel="noopener noreferrer" style="background:rgba(240,194,70,0.18);border-color:rgba(240,194,70,0.45);color:#f0c246">Cloud ($19/mo)</a>

--- a/public/demo.html
+++ b/public/demo.html
@@ -3,23 +3,23 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Slack MCP Server v3.1.0 — Interactive Demo</title>
+  <title>Slack MCP Server v3.2.0 — Interactive Demo</title>
 
   <!-- Open Graph / Social Sharing -->
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://jtalk22.github.io/slack-mcp-server/public/demo.html">
-  <meta property="og:title" content="Slack MCP Server v3.1.0 — Interactive Demo">
-  <meta property="og:description" content="Give Claude your Slack. 13 MCP tools — read channels, search messages, send replies, get AI summaries. Self-host free or Cloud from $19/mo.">
+  <meta property="og:title" content="Slack MCP Server v3.2.0 — Interactive Demo">
+  <meta property="og:description" content="Give Claude your Slack. 16 MCP tools — read channels, search messages, send replies, get AI summaries. Self-host free or Cloud from $19/mo.">
   <meta property="og:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Slack MCP Server v3.1.0 — Interactive Demo">
-  <meta name="twitter:description" content="Give Claude your Slack. 13 MCP tools — read channels, search messages, send replies, get AI summaries. Self-host free or Cloud from $19/mo.">
+  <meta name="twitter:title" content="Slack MCP Server v3.2.0 — Interactive Demo">
+  <meta name="twitter:description" content="Give Claude your Slack. 16 MCP tools — read channels, search messages, send replies, get AI summaries. Self-host free or Cloud from $19/mo.">
   <meta name="twitter:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
 
   <!-- SEO -->
-  <meta name="description" content="Give Claude your Slack. 13 MCP tools — read channels, search messages, send replies, get AI summaries. Interactive demo. Self-host free or Cloud from $19/mo.">
+  <meta name="description" content="Give Claude your Slack. 16 MCP tools — read channels, search messages, send replies, get AI summaries. Interactive demo. Self-host free or Cloud from $19/mo.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">

--- a/public/index.html
+++ b/public/index.html
@@ -253,9 +253,9 @@
   </div>
 
   <div class="container">
-    <h1>Slack Web API <span style="font-size:0.55em;opacity:0.5;font-weight:400;vertical-align:middle">v3.1.0</span> <span id="status" class="status"></span></h1>
+    <h1>Slack Web API <span style="font-size:0.55em;opacity:0.5;font-weight:400;vertical-align:middle">v3.2.0</span> <span id="status" class="status"></span></h1>
     <div style="background:rgba(240,194,70,0.08);border:1px solid rgba(240,194,70,0.2);border-radius:8px;padding:8px 14px;margin-bottom:16px;display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:8px;font-size:13px;color:#d4c48a">
-      <span>Skip local setup? <strong style="color:#f0c246">Slack MCP Cloud</strong> gives you 13 tools with one URL — no tokens to manage.</span>
+      <span>Skip local setup? <strong style="color:#f0c246">Slack MCP Cloud</strong> gives you 16 tools with one URL — no tokens to manage.</span>
       <a href="https://jtalk22.github.io/slack-mcp-server/cloud.html" style="color:#f0c246;font-weight:600;text-decoration:none;white-space:nowrap" target="_blank">Learn more &rarr;</a>
     </div>
     <div class="grid">

--- a/public/share.html
+++ b/public/share.html
@@ -3,17 +3,17 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Slack MCP Server v3.1.0</title>
+  <title>Slack MCP Server v3.2.0</title>
   <meta name="description" content="Session-based Slack MCP for Claude. Local-first stdio/web with secure-default hosted HTTP in v3.">
   <meta property="og:type" content="website">
-  <meta property="og:title" content="Slack MCP Server v3.1.0">
+  <meta property="og:title" content="Slack MCP Server v3.2.0">
   <meta property="og:description" content="Session-based Slack MCP for Claude. Local-first stdio/web with secure-default hosted HTTP in v3.">
   <meta property="og:url" content="https://jtalk22.github.io/slack-mcp-server/public/share.html">
   <meta property="og:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
   <meta property="og:image:width" content="1280">
   <meta property="og:image:height" content="640">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Slack MCP Server v3.1.0">
+  <meta name="twitter:title" content="Slack MCP Server v3.2.0">
   <meta name="twitter:description" content="Session-based Slack MCP for Claude. Local-first stdio/web with secure-default hosted HTTP in v3.">
   <meta name="twitter:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
   <style>
@@ -105,7 +105,7 @@
 </head>
 <body>
   <main class="wrap">
-    <h1>Slack MCP Server v3.1.0</h1>
+    <h1>Slack MCP Server v3.2.0</h1>
     <p class="sub">Give Claude full access to your Slack. Read channels, search messages, send replies, get AI summaries. Self-host free or Cloud from $19/mo.</p>
 
     <a class="preview" href="https://github.com/jtalk22/slack-mcp-server" rel="noopener">

--- a/scripts/build-social-preview.js
+++ b/scripts/build-social-preview.js
@@ -34,7 +34,7 @@ const html = `<!doctype html>
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Slack MCP Server v3.1.0 Social Preview</title>
+  <title>Slack MCP Server v3.2.0 Social Preview</title>
   <style>
     :root {
       --bg-a: #0f1f4c;
@@ -145,7 +145,7 @@ const html = `<!doctype html>
   <main class="card">
     <header class="top">
       <span>Slack MCP Server</span>
-      <span class="pill">v3.1.0</span>
+      <span class="pill">v3.2.0</span>
     </header>
     <section class="image-frame">
       <img src="${sourceDataUri}" alt="Slack MCP live demo frame">

--- a/scripts/collect-release-health.js
+++ b/scripts/collect-release-health.js
@@ -76,7 +76,7 @@ function buildMarkdown(data) {
   lines.push(`- deployment-intake submissions (all-time): ${data.github.deploymentIntakeCount ?? "n/a"}`);
   lines.push("");
 
-  lines.push("## 14-Day Reliability Targets (v3.1.0 Cycle)");
+  lines.push("## 14-Day Reliability Targets (v3.2.0 Cycle)");
   lines.push("");
   lines.push("- weekly downloads: >= 180");
   lines.push("- qualified deployment-intake submissions: >= 2");

--- a/scripts/setup-wizard.js
+++ b/scripts/setup-wizard.js
@@ -23,7 +23,7 @@ import {
 } from "../lib/token-store.js";
 
 const IS_MACOS = platform() === 'darwin';
-const VERSION = "3.1.0";
+const VERSION = "3.2.0";
 const MIN_NODE_MAJOR = 20;
 const AUTH_TEST_URL = process.env.SLACK_MCP_AUTH_TEST_URL || "https://slack.com/api/auth.test";
 

--- a/server.json
+++ b/server.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/jtalk22/slack-mcp-server",
     "source": "github"
   },
-  "version": "3.1.0",
+  "version": "3.2.0",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
     {
       "registryType": "npm",
       "identifier": "@jtalk22/slack-mcp",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/server-http.js
+++ b/src/server-http.js
@@ -27,10 +27,15 @@ import {
   handleSendMessage,
   handleGetThread,
   handleListUsers,
+  handleAddReaction,
+  handleRemoveReaction,
+  handleConversationsMark,
+  handleConversationsUnreads,
+  handleUsersSearch,
 } from "../lib/handlers.js";
 
 const SERVER_NAME = "slack-mcp-server";
-const SERVER_VERSION = "3.1.0";
+const SERVER_VERSION = "3.2.0";
 const PORT = process.env.PORT || 3000;
 const HTTP_INSECURE = process.env.SLACK_MCP_HTTP_INSECURE === "1";
 const HTTP_AUTH_TOKEN = process.env.SLACK_MCP_HTTP_AUTH_TOKEN || process.env.SLACK_API_KEY || null;
@@ -115,6 +120,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         return await handleGetThread(args);
       case "slack_list_users":
         return await handleListUsers(args);
+      case "slack_add_reaction":
+        return await handleAddReaction(args);
+      case "slack_remove_reaction":
+        return await handleRemoveReaction(args);
+      case "slack_conversations_mark":
+        return await handleConversationsMark(args);
+      case "slack_conversations_unreads":
+        return await handleConversationsUnreads(args);
+      case "slack_users_search":
+        return await handleUsersSearch(args);
       default:
         return {
           content: [{

--- a/src/server.js
+++ b/src/server.js
@@ -11,7 +11,7 @@
  * - Network error retry with exponential backoff
  * - Background token health monitoring
  *
- * @version 3.1.0
+ * @version 3.2.0
  */
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -53,7 +53,7 @@ const BACKGROUND_REFRESH_INTERVAL = 4 * 60 * 60 * 1000;
 
 // Package info
 const SERVER_NAME = "slack-mcp-server";
-const SERVER_VERSION = "3.1.0";
+const SERVER_VERSION = "3.2.0";
 
 // MCP Prompts - predefined prompt templates for common Slack operations
 const PROMPTS = [

--- a/src/web-server.js
+++ b/src/web-server.js
@@ -5,7 +5,7 @@
  * Exposes Slack MCP tools as REST endpoints for browser access.
  * Run alongside or instead of the MCP server for web-based access.
  *
- * @version 3.1.0
+ * @version 3.2.0
  */
 
 import express from "express";
@@ -141,7 +141,7 @@ function extractContent(result) {
 app.get("/", (req, res) => {
   res.json({
     name: "Slack Web API Server",
-    version: "3.1.0",
+    version: "3.2.0",
     status: "ok",
     code: "ok",
     message: "Web API server is running.",
@@ -450,7 +450,7 @@ async function main() {
   app.listen(PORT, '127.0.0.1', () => {
     // Print to stderr to keep logs clean (stdout reserved for JSON in some setups)
     console.error(`\n${"═".repeat(60)}`);
-    console.error(`  Slack Web API Server v3.1.0`);
+    console.error(`  Slack Web API Server v3.2.0`);
     console.error(`${"═".repeat(60)}`);
     console.error(`\n  Dashboard: http://localhost:${PORT}/?key=${API_KEY}`);
     console.error(`\n  API Key:   ${API_KEY}`);


### PR DESCRIPTION
## Summary

- **5 new MCP tools**: `slack_add_reaction`, `slack_remove_reaction`, `slack_conversations_mark`, `slack_conversations_unreads`, `slack_users_search`
- **Three-transport parity**: all 16 tools dispatch correctly across stdio, web, and hosted HTTP
- **Critical fix**: `server-http.js` was missing 5 tool handlers — tools appeared in `tools/list` but calling them returned "Unknown tool"
- **Express route ordering**: `/users/search` now registered before `/users/:id` to prevent misrouting
- **Full version sweep**: 26 files updated from v3.1.0 → v3.2.0, tool counts from 11/13 → 16
- **Release notes**: `.github/v3.2.0-release-notes.md` created

## Files Changed (26)

**Core (tool parity fix):**
- `src/server-http.js` — added 5 missing handler imports + dispatch cases
- `src/server.js` — version bump + already had correct dispatch
- `src/web-server.js` — version bump + already had correct endpoints

**Config:**
- `package.json`, `package-lock.json`, `server.json`, `glama.json` — version + tool count

**Docs:**
- `CHANGELOG.md`, `README.md`, `docs/SETUP.md`, `docs/DEPLOYMENT-MODES.md`, `docs/TROUBLESHOOTING.md`, `docs/INSTALL-PROOF.md`, `docs/INDEX.md`, `docs/release-health/latest.md`

**Public HTML:**
- `index.html`, `cloud.html`, `public/index.html`, `public/demo.html`, `public/demo-claude.html`, `public/demo-video.html`, `public/share.html`

**Scripts:**
- `scripts/setup-wizard.js`, `scripts/build-social-preview.js`, `scripts/collect-release-health.js`

**New:**
- `.github/v3.2.0-release-notes.md`

## Test plan

- [ ] CI passes (attribution, lint, test Node 20.x, test Node 22.x)
- [ ] `npm start` loads 16 tools via stdio
- [ ] `npm run web` exposes all REST endpoints including `/reactions`, `/users/search`, `/conversations/unreads`
- [ ] `node src/server-http.js` dispatches all 16 tools
- [ ] Version strings show 3.2.0 in health endpoints