### PR TITLE
docs: API reference for 5 new v3.2.0 tools

### DIFF
--- a/cloud.html
+++ b/cloud.html
@@ -1106,7 +1106,7 @@
         </div>
         <div class="faq-item fade-up">
           <div class="faq-q">Can I try before I pay?</div>
-          <div class="faq-a">The self-hosted server is free and includes all 10 standard tools. Cloud adds managed hosting, auto-refresh, and (on Team) AI compound tools.</div>
+          <div class="faq-a">The self-hosted server is free and includes all 16 standard tools. Cloud adds managed hosting, auto-refresh, and (on Team) AI compound tools.</div>
         </div>
         <div class="faq-item fade-up">
           <div class="faq-q">Which MCP clients are supported?</div>

--- a/docs/API.md
+++ b/docs/API.md
@@ -321,3 +321,137 @@ List all workspace users.
   ]
 }
 ```
+
+---
+
+### slack_add_reaction
+
+Add an emoji reaction to a message.
+
+**Parameters:**
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| channel_id | string | *required* | Channel or DM ID |
+| timestamp | string | *required* | Message timestamp to react to |
+| reaction | string | *required* | Emoji name without colons (e.g. `thumbsup`, `heart`, `eyes`) |
+
+**Returns:**
+```json
+{
+  "status": "added",
+  "channel": "D063M4403MW",
+  "timestamp": "1767368030.607599",
+  "reaction": "thumbsup"
+}
+```
+
+---
+
+### slack_remove_reaction
+
+Remove an emoji reaction from a message.
+
+**Parameters:**
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| channel_id | string | *required* | Channel or DM ID |
+| timestamp | string | *required* | Message timestamp |
+| reaction | string | *required* | Emoji name without colons |
+
+**Returns:**
+```json
+{
+  "status": "removed",
+  "channel": "D063M4403MW",
+  "timestamp": "1767368030.607599",
+  "reaction": "thumbsup"
+}
+```
+
+---
+
+### slack_conversations_mark
+
+Mark a conversation as read up to a specific message timestamp.
+
+**Parameters:**
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| channel_id | string | *required* | Channel or DM ID to mark as read |
+| timestamp | string | *required* | Message timestamp to mark as read up to |
+
+**Returns:**
+```json
+{
+  "status": "marked",
+  "channel": "D063M4403MW",
+  "read_up_to": "1767368030.607599"
+}
+```
+
+---
+
+### slack_conversations_unreads
+
+Get channels and DMs with unread messages, sorted by unread count (highest first).
+
+**Parameters:**
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| types | string | "im,mpim,public_channel,private_channel" | Comma-separated conversation types |
+| limit | number | 50 | Maximum conversations to return |
+
+**Returns:**
+```json
+{
+  "total_unread_conversations": 3,
+  "conversations": [
+    {
+      "id": "C05GPEVH7J9",
+      "name": "engineering",
+      "type": "public_channel",
+      "unread_count": 12,
+      "latest_ts": "1767368030.607599"
+    },
+    {
+      "id": "D063M4403MW",
+      "name": "Gwen Santos",
+      "type": "dm",
+      "unread_count": 5,
+      "latest_ts": "1767368025.123456"
+    }
+  ]
+}
+```
+
+---
+
+### slack_users_search
+
+Search workspace users by name, display name, or email. Case-insensitive partial match.
+
+**Parameters:**
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| query | string | *required* | Search term to match against name, display name, real name, or email |
+| limit | number | 20 | Maximum results to return |
+
+**Returns:**
+```json
+{
+  "query": "gwen",
+  "count": 1,
+  "total_matches": 1,
+  "users": [
+    {
+      "id": "U05GPEVH7J9",
+      "name": "gwen",
+      "real_name": "Gwen Santos",
+      "display_name": "Gwen",
+      "email": "gwen@example.com",
+      "title": "Assistant",
+      "is_admin": false
+    }
+  ]
+}
+```


### PR DESCRIPTION
## Summary

- Add API reference sections for all 5 new v3.2.0 tools to `docs/API.md`: `slack_add_reaction`, `slack_remove_reaction`, `slack_conversations_mark`, `slack_conversations_unreads`, `slack_users_search`
- Fix stale "all 10 standard tools" reference in `cloud.html` FAQ to "all 16 standard tools"

## Test plan

- [ ] CI passes
- [ ] API.md renders correctly on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated FAQ regarding self-hosted offering, increasing documented standard tools from 10 to 16.
  * Added Slack API endpoint documentation for reactions, conversations management, and user search functionality with parameters and sample payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->