### PR TITLE
release: v3.2.2

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -4,7 +4,7 @@
   "description": "Session-based Slack MCP for Claude and MCP clients. 16 tools: read channels, search messages, send replies, reactions, unreads, user search, AI summaries. Cloud hosted option with encrypted storage — no Docker, no admin approval.",
   "repository": "https://github.com/jtalk22/slack-mcp-server",
   "homepage": "https://mcp.revasserlabs.com",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "license": "MIT",
   "maintainers": ["jtalk22"],
   "categories": ["communication", "productivity"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jtalk22/slack-mcp",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jtalk22/slack-mcp",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jtalk22/slack-mcp",
   "mcpName": "io.github.jtalk22/slack-mcp-server",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Session-based Slack MCP for Claude and MCP clients: local-first workflows, secure-default HTTP.",
   "type": "module",
   "main": "src/server.js",

--- a/server.json
+++ b/server.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/jtalk22/slack-mcp-server",
     "source": "github"
   },
-  "version": "3.2.1",
+  "version": "3.2.2",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
     {
       "registryType": "npm",
       "identifier": "@jtalk22/slack-mcp",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- **homepage** → `mcp.revasserlabs.com` (fixes stale npmjs.com listing)
- **server.json, glama.json** version bumped to 3.2.2
- **Lockfile** includes security patches from PR #38

## After merge
- Tag: `git tag v3.2.2 && git push origin v3.2.2`
- Publish: `npm publish --access public`
- GitHub release: `gh release create v3.2.2 --title "v3.2.2" --notes "Homepage URL fix + security patches"`

## Test plan
- [ ] `npm pack --dry-run` shows correct files
- [ ] All CI checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated from 3.2.1 to 3.2.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->