### PR TITLE
fix: skip attribution guardrail for Dependabot PRs

### DIFF
--- a/.github/workflows/attribution-guardrail.yml
+++ b/.github/workflows/attribution-guardrail.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   attribution:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Adds `if: github.actor != 'dependabot[bot]'` to the attribution guardrail job
- Dependabot commits are authored by `dependabot[bot]`, not the repo owner, which correctly fails the owner-attribution check
- Since Dependabot is a trusted GitHub-native bot with cryptographically signed commits, the attribution check is not meaningful for these PRs

## Context
PR #40 (tar-fs security bump) is blocked by this check. This unblocks all future Dependabot PRs.