### PR TITLE
fix: check PR author for Dependabot attribution bypass

### DIFF
--- a/.github/workflows/attribution-guardrail.yml
+++ b/.github/workflows/attribution-guardrail.yml
@@ -10,7 +10,9 @@ on:
 jobs:
   attribution:
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]')
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Fixes the Dependabot attribution bypass from PR #42
- `github.actor` changes to the API caller on branch updates (rebases), not the original PR opener
- Now also checks `github.event.pull_request.user.login` to reliably identify Dependabot PRs regardless of who triggers branch updates

## Context
After merging #42, Dependabot PRs #40 and #41 were rebased via API to pick up the workflow change. But `github.actor` was set to `jtalk22` (the API caller) instead of `dependabot[bot]`, so the bypass didn't trigger.