### PR TITLE
chore: harden release surface operations

### DIFF
--- a/.github/workflows/attribution-guardrail.yml
+++ b/.github/workflows/attribution-guardrail.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
         node-version: [20.x, 22.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -42,10 +42,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '20.x'
           cache: 'npm'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,16 +19,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -36,7 +36,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
@@ -63,7 +63,7 @@ jobs:
           echo "$OUT" | grep -E "slack-mcp-server v${TAG_VERSION}$"
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           context: .
           push: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,10 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
@@ -48,6 +48,12 @@ jobs:
             echo "already_published=false" >> "$GITHUB_OUTPUT"
             echo "Version $VERSION not found on npm. Proceeding with publish."
           fi
+
+      - name: Verify npm publish auth
+        if: steps.npm_check.outputs.already_published != 'true'
+        run: bash scripts/check-npm-publish-auth.sh
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_SECRET_TOKEN }}
 
       - name: Publish to npm
         if: steps.npm_check.outputs.already_published != 'true'

--- a/.github/workflows/release-health.yml
+++ b/.github/workflows/release-health.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "20.x"
           cache: "npm"
@@ -55,7 +55,7 @@ jobs:
           cat output/release-health/automation-delta.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload release-health artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: release-health-${{ github.run_id }}
           path: |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npx -y @jtalk22/slack-mcp@latest --doctor
 npx -y @jtalk22/slack-mcp@latest --status
 ```
 
-[20-second demo](https://jtalk22.github.io/slack-mcp-server/public/demo-video.html) · [Interactive demo](https://jtalk22.github.io/slack-mcp-server/public/demo.html) · [Latest release notes](https://github.com/jtalk22/slack-mcp-server/releases/latest) · [Release-day runbook](docs/LAUNCH-OPS.md) · [Deployment intake](https://github.com/jtalk22/slack-mcp-server/issues/new?template=deployment-intake.md) · [Support boundaries](docs/SUPPORT-BOUNDARIES.md)
+[20-second demo](https://jtalk22.github.io/slack-mcp-server/public/demo-video.html) · [Interactive demo](https://jtalk22.github.io/slack-mcp-server/public/demo.html) · [Latest release notes](https://github.com/jtalk22/slack-mcp-server/releases/latest) · [Release-day runbook](docs/LAUNCH-OPS.md) · [Release health snapshot](docs/release-health/latest.md) · [Version parity report](docs/release-health/version-parity.md) · [Deployment intake](https://github.com/jtalk22/slack-mcp-server/issues/new?template=deployment-intake.md) · [Support boundaries](docs/SUPPORT-BOUNDARIES.md)
 
 [![Slack MCP proof surface](docs/images/demo-poster.png)](https://jtalk22.github.io/slack-mcp-server/public/demo-video.html)
 

--- a/docs/LAUNCH-OPS.md
+++ b/docs/LAUNCH-OPS.md
@@ -26,12 +26,14 @@ docker build -t slack-mcp-smoke:3.2.4 . && docker run --rm slack-mcp-smoke:3.2.4
 5. Create the GitHub Release immediately after Docker is green, using `.github/v3.2.4-release-notes.md`.
 6. Wait for `Publish to npm` to complete from the GitHub Release event.
 7. Verify npm, `npx`, and GHCR parity.
-8. Monitor MCP Registry, Glama, and Smithery/listing propagation until convergence.
+8. If MCP Registry is still stale after npm and GHCR are green, run the manual registry publish helper after `mcp-publisher login`.
+9. Monitor MCP Registry, Glama, and Smithery/listing propagation until convergence.
 
 ## Release Invariant
 
 - `docker-publish.yml` runs on tag push.
 - `publish.yml` runs on GitHub Release creation.
+- `publish.yml` now checks that the npm token belongs to a listed package owner before attempting publish.
 - Do not create the GitHub Release before Docker passes, and do not treat the tag alone as a complete release.
 
 ## Same-Day Verification Commands
@@ -44,6 +46,8 @@ docker run --rm ghcr.io/jtalk22/slack-mcp-server:3.2.4 --version
 node scripts/check-version-parity.js --allow-propagation
 node scripts/check-version-parity.js --public --allow-propagation
 node scripts/collect-release-health.js --public
+bash scripts/check-npm-publish-auth.sh
+bash scripts/publish-mcp-registry.sh server.json --validate-only
 ```
 
 ## External Discovery Checklist
@@ -92,7 +96,18 @@ Rollout/support request:
 
 3. If Docker is green but npm/registry parity is still stale after expected propagation windows:
 - record the lag in release-health
+- run `bash scripts/publish-mcp-registry.sh` after `mcp-publisher login`
 - avoid claiming convergence until `check-version-parity` is clean
+
+## Registry Sync Path
+
+Use this when npm and GHCR are already correct but MCP Registry still reports an old version or `websiteUrl`:
+
+```bash
+mcp-publisher login github
+bash scripts/publish-mcp-registry.sh
+node scripts/check-version-parity.js --allow-propagation
+```
 
 ## 24h / 48h / 72h Follow-Up
 

--- a/index.html
+++ b/index.html
@@ -110,6 +110,53 @@
       white-space: pre;
     }
 
+    .snapshot-grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+      margin-top: 4px;
+    }
+
+    .snapshot-card {
+      border: 1px solid rgba(133, 160, 222, 0.32);
+      border-radius: 14px;
+      background: rgba(8, 20, 55, 0.82);
+      padding: 14px 15px;
+      min-height: 120px;
+    }
+
+    .snapshot-label {
+      display: block;
+      font-size: 0.74rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #8fa9da;
+      margin-bottom: 8px;
+      font-weight: 600;
+    }
+
+    .snapshot-value {
+      display: block;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 1.05rem;
+      font-weight: 700;
+      color: #edf3ff;
+      margin-bottom: 8px;
+      line-height: 1.3;
+    }
+
+    .snapshot-note {
+      display: block;
+      color: var(--muted);
+      font-size: 0.84rem;
+      line-height: 1.45;
+    }
+
+    .snapshot-note a,
+    .snapshot-value a {
+      color: #9ac3ff;
+    }
+
     .stage {
       padding: 16px 24px 20px;
     }
@@ -176,10 +223,14 @@
     @media (max-width: 760px) {
       body { padding: 10px; }
       .hero, .stage, .footer { padding-left: 12px; padding-right: 12px; }
+      .snapshot-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
       .video-shell { min-height: 200px; }
       .video-controls { left: 8px; bottom: 8px; }
       .video-controls button,
       .video-controls a { padding: 6px 9px; font-size: 0.8rem; }
+    }
+    @media (max-width: 560px) {
+      .snapshot-grid { grid-template-columns: 1fr; }
     }
   </style>
 </head>
@@ -200,6 +251,31 @@ npx -y @jtalk22/slack-mcp@latest --version
 npx -y @jtalk22/slack-mcp@latest --doctor
 npx -y @jtalk22/slack-mcp@latest --status</div>
       <p class="verify" style="margin-top:12px">For rollout support, use deployment intake. Reproducible bugs and install blockers still go through standard issue triage.</p>
+    </section>
+
+    <section class="stage" style="padding-top:0">
+      <div class="snapshot-grid" aria-label="Current distribution snapshot">
+        <div class="snapshot-card">
+          <span class="snapshot-label">npm latest</span>
+          <strong class="snapshot-value" id="npmLatest">Loading...</strong>
+          <span class="snapshot-note" id="npmLatestNote">Registry dist-tag for <code>@jtalk22/slack-mcp</code>.</span>
+        </div>
+        <div class="snapshot-card">
+          <span class="snapshot-label">GitHub release</span>
+          <strong class="snapshot-value" id="releaseTag">Loading...</strong>
+          <span class="snapshot-note" id="releaseTagNote">Latest tagged release from GitHub.</span>
+        </div>
+        <div class="snapshot-card">
+          <span class="snapshot-label">Cloud health</span>
+          <strong class="snapshot-value" id="cloudHealth">Checking...</strong>
+          <span class="snapshot-note" id="cloudHealthNote">Reads the hosted <code>/health</code> endpoint when cross-origin access is available.</span>
+        </div>
+        <div class="snapshot-card">
+          <span class="snapshot-label">Operator links</span>
+          <strong class="snapshot-value"><a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/release-health/latest.md">Release health</a></strong>
+          <span class="snapshot-note"><a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/release-health/version-parity.md">Version parity</a> · <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/LAUNCH-OPS.md">Runbook</a></span>
+        </div>
+      </div>
     </section>
 
     <section class="stage">
@@ -228,6 +304,12 @@ npx -y @jtalk22/slack-mcp@latest --status</div>
     const statusEl = document.getElementById('videoStatus');
     const playBtn = document.getElementById('playBtn');
     const pauseBtn = document.getElementById('pauseBtn');
+    const npmLatestEl = document.getElementById('npmLatest');
+    const npmLatestNoteEl = document.getElementById('npmLatestNote');
+    const releaseTagEl = document.getElementById('releaseTag');
+    const releaseTagNoteEl = document.getElementById('releaseTagNote');
+    const cloudHealthEl = document.getElementById('cloudHealth');
+    const cloudHealthNoteEl = document.getElementById('cloudHealthNote');
 
     async function ensureAutoplay() {
       try {
@@ -252,7 +334,62 @@ npx -y @jtalk22/slack-mcp@latest --status</div>
       statusEl.textContent = 'Playback paused.';
     });
 
+    async function loadDistributionSnapshot() {
+      const npmPromise = fetch('https://registry.npmjs.org/@jtalk22/slack-mcp/latest')
+        .then((res) => {
+          if (!res.ok) throw new Error(`npm registry returned ${res.status}`);
+          return res.json();
+        })
+        .then((data) => {
+          npmLatestEl.textContent = `v${data.version}`;
+          npmLatestNoteEl.textContent = `Published package: ${data.name}`;
+        })
+        .catch((error) => {
+          npmLatestEl.textContent = 'Unavailable';
+          npmLatestNoteEl.textContent = `Registry lookup failed: ${error.message}`;
+        });
+
+      const releasePromise = fetch('https://api.github.com/repos/jtalk22/slack-mcp-server/releases/latest')
+        .then((res) => {
+          if (!res.ok) throw new Error(`GitHub API returned ${res.status}`);
+          return res.json();
+        })
+        .then((data) => {
+          releaseTagEl.textContent = data.tag_name || 'Unknown';
+          const publishedAt = data.published_at
+            ? new Date(data.published_at).toLocaleDateString()
+            : 'date unavailable';
+          releaseTagNoteEl.textContent = `GitHub Release published ${publishedAt}.`;
+        })
+        .catch((error) => {
+          releaseTagEl.textContent = 'Unavailable';
+          releaseTagNoteEl.textContent = `GitHub release lookup failed: ${error.message}`;
+        });
+
+      const cloudPromise = fetch('https://mcp.revasserlabs.com/health', {
+        headers: { accept: 'application/json' }
+      })
+        .then((res) => {
+          if (!res.ok) throw new Error(`Cloud health returned ${res.status}`);
+          return res.json();
+        })
+        .then((data) => {
+          cloudHealthEl.textContent = data.status || 'ok';
+          const hostedVersion = data.version ? `v${data.version}` : 'version unavailable';
+          const standardTools = data.tools && typeof data.tools.standard === 'number' ? data.tools.standard : 'n/a';
+          const aiTools = data.tools && typeof data.tools.ai_compound === 'number' ? data.tools.ai_compound : 'n/a';
+          cloudHealthNoteEl.textContent = `${hostedVersion} · ${standardTools} managed tools · ${aiTools} Team AI workflows`;
+        })
+        .catch((error) => {
+          cloudHealthEl.textContent = 'Open /health';
+          cloudHealthNoteEl.innerHTML = `Cross-origin health lookup unavailable: ${error.message}. Use <a href="https://mcp.revasserlabs.com/health">raw health JSON</a>.`;
+        });
+
+      await Promise.allSettled([npmPromise, releasePromise, cloudPromise]);
+    }
+
     ensureAutoplay();
+    loadDistributionSnapshot();
   </script>
 </body>
 </html>

--- a/scripts/check-npm-publish-auth.sh
+++ b/scripts/check-npm-publish-auth.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PACKAGE_NAME="${1:-@jtalk22/slack-mcp}"
+
+PUBLISH_USER="$(npm whoami)"
+echo "Authenticated npm user: ${PUBLISH_USER}"
+
+OWNER_LIST="$(npm owner ls "${PACKAGE_NAME}")"
+printf '%s\n' "${OWNER_LIST}"
+
+if ! printf '%s\n' "${OWNER_LIST}" | grep -Eq "^${PUBLISH_USER}[[:space:]]+<"; then
+  echo "Authenticated npm user '${PUBLISH_USER}' is not listed as an owner for ${PACKAGE_NAME}." >&2
+  exit 1
+fi
+
+echo "npm publish auth check passed for ${PACKAGE_NAME}."

--- a/scripts/check-public-surface-integrity.js
+++ b/scripts/check-public-surface-integrity.js
@@ -138,6 +138,24 @@ function main() {
       !readme.includes("16 standard tools"),
     "README must describe Cloud as 15 standard tools plus 3 AI compound tools on Team"
   );
+  check(
+    results,
+    "README operator links",
+    readme.includes("Release health snapshot") && readme.includes("Version parity report"),
+    "README should link current release-health and version-parity reports"
+  );
+
+  const marketingIndex = read("index.html");
+  check(
+    results,
+    "GitHub Pages distribution snapshot",
+    marketingIndex.includes("Current distribution snapshot") &&
+      marketingIndex.includes("npm latest") &&
+      marketingIndex.includes("GitHub release") &&
+      marketingIndex.includes("Cloud health") &&
+      marketingIndex.includes("Release health"),
+    "index.html should expose the live distribution snapshot cards and operator links"
+  );
 
   const setupGuide = read("docs/SETUP.md");
   check(

--- a/scripts/check-version-parity.js
+++ b/scripts/check-version-parity.js
@@ -188,7 +188,7 @@ async function main() {
     "",
     mcpRegistryWebsiteUrl === expectedWebsiteUrl
       ? "- MCP registry `websiteUrl` matches local metadata."
-      : "- MCP registry `websiteUrl` drift detected. Update registry metadata or re-publish metadata-bearing release to align canonical install landing URL.",
+      : "- MCP registry `websiteUrl` drift detected. Re-publish metadata-bearing release info with `bash scripts/publish-mcp-registry.sh` after `mcp-publisher login`.",
     typeof mcpRegistryDescription === "string" && mcpRegistryDescription.startsWith(expectedDescriptionPrefix)
       ? "- MCP registry description prefix matches local metadata."
       : "- MCP registry description drift detected. Align registry listing description with local `server.json` wording.",

--- a/scripts/publish-mcp-registry.sh
+++ b/scripts/publish-mcp-registry.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVER_JSON_PATH="${1:-server.json}"
+MODE="${2:-publish}"
+PUBLISHER_BIN="${MCP_PUBLISHER_BIN:-mcp-publisher}"
+
+if ! command -v "${PUBLISHER_BIN}" >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+mcp-publisher was not found in PATH.
+
+Install the official binary from:
+https://github.com/modelcontextprotocol/registry/releases/latest
+
+Then re-run:
+  MCP_PUBLISHER_BIN=/path/to/mcp-publisher bash scripts/publish-mcp-registry.sh
+EOF
+  exit 1
+fi
+
+echo "Validating ${SERVER_JSON_PATH} with ${PUBLISHER_BIN}..."
+"${PUBLISHER_BIN}" validate "${SERVER_JSON_PATH}"
+
+if [[ "${MODE}" == "--validate-only" ]]; then
+  echo "Validation-only mode enabled. Skipping registry publish."
+  exit 0
+fi
+
+cat <<'EOF'
+Publishing to MCP Registry.
+If you are not logged in yet, run one of:
+  mcp-publisher login github
+  mcp-publisher login dns --domain <domain> --private-key <key>
+  mcp-publisher login http --domain <domain> --private-key <key>
+EOF
+
+"${PUBLISHER_BIN}" publish "${SERVER_JSON_PATH}"


### PR DESCRIPTION
## Summary
- pin GitHub Actions used by CI, Docker, publish, and release-health workflows
- add npm owner preflight and MCP Registry publish helper scripts
- expose a live distribution snapshot on the public GitHub Pages surface
- link README/operator surfaces to current release-health artifacts

## Verification
- bash scripts/check-public-language.sh
- node scripts/check-public-surface-integrity.js
- bash scripts/check-npm-publish-auth.sh
- MCP_PUBLISHER_BIN=/tmp/mcp-publisher bash scripts/publish-mcp-registry.sh server.json --validate-only
- node scripts/release-preflight.js
- docker build -t slack-mcp-smoke:3.2.4 . && docker run --rm slack-mcp-smoke:3.2.4 --version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added distribution snapshot UI displaying current npm version, GitHub release information, cloud health status, and operator links.

* **Documentation**
  * Updated README with new release health and version parity report links.
  * Enhanced launch operations guide with registry sync workflows and verification commands for release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->