### PR TITLE
fix: polish public trust surfaces

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
   <meta name="twitter:title" content="Slack MCP Server — 16 Self-Hosted Tools for Claude">
   <meta name="twitter:description" content="Give Claude your Slack. Self-host 16 tools for free, or use Cloud for 15 managed tools with support and hosted credentials.">
   <meta name="twitter:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
+  <link rel="icon" href="https://jtalk22.github.io/slack-mcp-server/docs/assets/icon-512.png" type="image/png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
@@ -251,7 +252,7 @@
 npx -y @jtalk22/slack-mcp@latest --version
 npx -y @jtalk22/slack-mcp@latest --doctor
 npx -y @jtalk22/slack-mcp@latest --status</div>
-      <p class="verify" style="margin-top:12px">For rollout support, use deployment intake. Reproducible bugs and install blockers still go through standard issue triage.</p>
+      <p class="verify" style="margin-top:12px">For rollout support, use deployment review. Reproducible bugs and install blockers still go through standard issue triage.</p>
     </section>
 
     <section class="stage" style="padding-top:0">

--- a/public/demo-video.html
+++ b/public/demo-video.html
@@ -14,6 +14,7 @@
   <meta name="twitter:title" content="Slack MCP Server — Video Demo">
   <meta name="twitter:description" content="Give Claude your Slack. 16 self-hosted tools for channels, search, replies, reactions, unread triage, and user search.">
   <meta name="twitter:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
+  <link rel="icon" href="https://jtalk22.github.io/slack-mcp-server/docs/assets/icon-512.png" type="image/png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">

--- a/public/demo.html
+++ b/public/demo.html
@@ -17,6 +17,7 @@
   <meta name="twitter:title" content="Slack MCP Server — Interactive Demo">
   <meta name="twitter:description" content="Give Claude your Slack. 16 self-hosted tools for channels, search, replies, reactions, unread triage, and user search.">
   <meta name="twitter:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
+  <link rel="icon" href="https://jtalk22.github.io/slack-mcp-server/docs/assets/icon-512.png" type="image/png">
 
   <!-- SEO -->
   <meta name="description" content="Give Claude your Slack. 16 self-hosted tools for channels, search, replies, reactions, unread triage, and user search. Interactive demo.">
@@ -752,7 +753,7 @@
       <a href="https://github.com/jtalk22/slack-mcp-server/issues/new?template=deployment-intake.md" target="_blank" rel="noopener noreferrer">Deployment Intake</a>
     </div>
     <div class="cta-note">
-      Self-host free or use <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">Cloud</a> for the managed deployment path. Use deployment intake for rollout support.
+      Self-host free or use <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">Cloud</a> for the managed deployment path. Use deployment review for rollout support.
     </div>
   </div>
 

--- a/public/share.html
+++ b/public/share.html
@@ -16,6 +16,7 @@
   <meta name="twitter:title" content="Slack MCP Server">
   <meta name="twitter:description" content="Session-based Slack MCP for Claude. Self-host 16 tools for free or use Cloud for 15 managed tools and support.">
   <meta name="twitter:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
+  <link rel="icon" href="https://jtalk22.github.io/slack-mcp-server/docs/assets/icon-512.png" type="image/png">
   <style>
     :root {
       --bg-1: #0b1436;
@@ -124,7 +125,7 @@
       <a href="https://mcp.revasserlabs.com" rel="noopener" style="background:rgba(240,194,70,0.18);border-color:rgba(240,194,70,0.45);color:#f0c246">Cloud</a>
     </div>
 
-    <p class="note"><strong>Verify in 30 seconds:</strong> <code>--version</code>, <code>--doctor</code>, <code>--status</code>. For rollout support, use deployment intake. Maintainer/operator: <code>jtalk22</code> (<code>support@revasserlabs.com</code>).</p>
+    <p class="note"><strong>Verify in 30 seconds:</strong> <code>--version</code>, <code>--doctor</code>, <code>--status</code>. For rollout support, use deployment review. Maintainer/operator: <code>jtalk22</code> (<code>support@revasserlabs.com</code>).</p>
   </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary\n- add a favicon to the GitHub Pages root and current demo/share surfaces\n- replace the last stale rollout wording on the public landing and demo/share pages\n\n## Verification\n- bash scripts/check-public-language.sh\n- node scripts/check-public-surface-integrity.js