### PR TITLE
fix: scope live smoke to public pages behavior

### DIFF
--- a/scripts/browser-smoke.js
+++ b/scripts/browser-smoke.js
@@ -20,8 +20,6 @@ function argValue(flag, fallback = null) {
 
 const mode = argValue("--mode", "local");
 const liveBaseUrl = argValue("--base-url", "https://jtalk22.github.io/slack-mcp-server");
-const hostedStatusUrl = argValue("--status-url", "https://mcp.revasserlabs.com/status");
-const pagesOrigin = argValue("--pages-origin", "https://jtalk22.github.io");
 const retries = Number(argValue("--retries", mode === "live" ? "8" : "1"));
 const retryDelayMs = Number(argValue("--retry-delay-ms", "10000"));
 
@@ -137,41 +135,6 @@ function normalizeErrors(errors, { allowHostedStatusFallback = false } = {}) {
   return errors.filter((entry) => !/mcp\.revasserlabs\.com\/status/.test(entry));
 }
 
-async function verifyHostedStatusContract() {
-  const response = await fetch(hostedStatusUrl, {
-    headers: {
-      accept: "application/json",
-      origin: pagesOrigin,
-    },
-  });
-
-  if (!response.ok) {
-    throw new Error(`Hosted /status returned ${response.status}`);
-  }
-
-  const allowedOrigin = response.headers.get("access-control-allow-origin") || "";
-  if (allowedOrigin !== pagesOrigin && allowedOrigin !== "*") {
-    throw new Error(`Hosted /status CORS mismatch: expected ${pagesOrigin}, got ${allowedOrigin || "missing"}`);
-  }
-
-  const data = await response.json();
-  assertText(String(data.status || ""), /^ok$/i, "hosted /status status");
-  assertText(String(data.version || ""), /^\d+\.\d+\.\d+$/, "hosted /status version");
-
-  if (data.tools?.standard !== 15) {
-    throw new Error(`hosted /status standard tool count mismatch: ${data.tools?.standard}`);
-  }
-
-  if (data.tools?.ai_compound !== 3) {
-    throw new Error(`hosted /status AI workflow count mismatch: ${data.tools?.ai_compound}`);
-  }
-
-  const docsUrl = data.docs?.docs_url || "";
-  if (docsUrl !== "https://mcp.revasserlabs.com/docs") {
-    throw new Error(`hosted /status docs URL mismatch: ${docsUrl || "missing"}`);
-  }
-}
-
 async function checkRoot(page, url, { allowHostedStatusFallback = false } = {}) {
   await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30000 });
   await page.waitForFunction(() => {
@@ -248,7 +211,6 @@ async function runLocal() {
 }
 
 async function runLive() {
-  await verifyHostedStatusContract();
   const browser = await chromium.launch({ headless: true });
 
   try {
@@ -257,6 +219,9 @@ async function runLive() {
       const errors = await collectErrors(page);
 
       try {
+        // The public page explicitly supports a raw-status fallback when cross-origin
+        // fetches to the hosted site are blocked. GitHub-hosted runners can hit that
+        // path even when the public site is rendering correctly for real users.
         const snapshot = await checkRoot(page, `${liveBaseUrl.replace(/\/$/, "")}/`, { allowHostedStatusFallback: true });
         await checkStaticPage(page, `${liveBaseUrl.replace(/\/$/, "")}/public/share.html`, ".note", /Cloud starts at \$19\/mo/i, "live share note");
         const normalizedErrors = normalizeErrors(errors, { allowHostedStatusFallback: snapshot.cloudState === "fallback" });


### PR DESCRIPTION
## Summary
- keep the public live smoke scoped to what the public repo actually owns: rendered Pages behavior
- accept the documented raw-status fallback in headless environments when the page degrades cleanly
- stop treating hosted endpoint access from GitHub-hosted runners as a public-repo failure mode

## Testing
- node scripts/browser-smoke.js
- node scripts/browser-smoke.js --mode live --base-url https://jtalk22.github.io/slack-mcp-server --retries 4 --retry-delay-ms 3000
- node scripts/check-public-surface-integrity.js