### PR TITLE
fix: ignore fallback resource error in live smoke

### DIFF
--- a/scripts/browser-smoke.js
+++ b/scripts/browser-smoke.js
@@ -132,7 +132,17 @@ function normalizeErrors(errors, { allowHostedStatusFallback = false } = {}) {
     return errors;
   }
 
-  return errors.filter((entry) => !/mcp\.revasserlabs\.com\/status/.test(entry));
+  return errors.filter((entry) => {
+    if (/mcp\.revasserlabs\.com\/status/.test(entry)) {
+      return false;
+    }
+
+    if (entry === "console:Failed to load resource: net::ERR_FAILED") {
+      return false;
+    }
+
+    return true;
+  });
 }
 
 async function checkRoot(page, url, { allowHostedStatusFallback = false } = {}) {


### PR DESCRIPTION
## Summary
- ignore the generic browser console resource failure that accompanies the documented hosted-status fallback
- keep the public live smoke focused on real Pages regressions, not headless runner fetch noise

## Testing
- node scripts/browser-smoke.js
- node scripts/browser-smoke.js --mode live --base-url https://jtalk22.github.io/slack-mcp-server --retries 4 --retry-delay-ms 3000