### PR TITLE
fix: ignore hosted status CORS fallback in live smoke

### DIFF
--- a/scripts/browser-smoke.js
+++ b/scripts/browser-smoke.js
@@ -133,10 +133,16 @@ function normalizeErrors(errors, { allowHostedStatusFallback = false } = {}) {
   }
 
   const hostedStatusFailurePattern = /requestfailed:https:\/\/mcp\.revasserlabs\.com\/status\b/;
+  const hostedStatusCorsConsolePattern =
+    /^console:Access to fetch at 'https:\/\/mcp\.revasserlabs\.com\/status'.*blocked by CORS policy/i;
   let hostedStatusConsoleBudget = errors.some((entry) => hostedStatusFailurePattern.test(entry)) ? 1 : 0;
 
   return errors.filter((entry) => {
     if (hostedStatusFailurePattern.test(entry)) {
+      return false;
+    }
+
+    if (hostedStatusCorsConsolePattern.test(entry)) {
       return false;
     }
 


### PR DESCRIPTION
## Summary
- ignore the explicit hosted /status CORS console message when the public page is already in its documented fallback state
- keep the live smoke strict for real public-page regressions
- avoid failing main on an expected GitHub-hosted browser fallback path

## Testing
- node scripts/browser-smoke.js
- node scripts/browser-smoke.js --mode live --base-url https://jtalk22.github.io/slack-mcp-server --retries 4 --retry-delay-ms 3000