### PR TITLE
chore: curate founder-led repo surfaces

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,3 @@
+reviews:
+  auto_review:
+    enabled: false

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,5 @@
+code_review:
+  disable: false
+pull_request_opened:
+  summary: false
+  code_review: false

--- a/.github/ISSUE_REPLY_TEMPLATE.md
+++ b/.github/ISSUE_REPLY_TEMPLATE.md
@@ -1,17 +1,15 @@
-Thanks for reporting this quickly.
+Thanks for flagging this.
 
 Status: fixed in `<version>`.
 
-Included:
-- <fix 1>
-- <fix 2>
+What changed:
+- `<fix 1>`
+- `<fix 2>`
 
 Verify:
-- `npx -y @jtalk22/slack-mcp --version`
-- `npx -y @jtalk22/slack-mcp --status`
-
-Install/update:
-- `npx -y @jtalk22/slack-mcp`
-- `npm i -g @jtalk22/slack-mcp@<version>`
+- `npx -y @jtalk22/slack-mcp@latest --version`
+- `npx -y @jtalk22/slack-mcp@latest --status`
 
 If it still reproduces, reply with OS, Node version, runtime mode (`stdio|web|http|worker`), and exact error output.
+
+Maintainer note: GitHub issues are for reproducible self-host bugs and docs fixes. Managed rollout, billing, and Cloud operational support live at `https://mcp.revasserlabs.com/deployment` and `https://mcp.revasserlabs.com/support`.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,28 +1,10 @@
-## Description
-Brief description of what this PR does.
+## Why
+- <problem or objective>
 
-## Type of Change
-- [ ] Bug fix (non-breaking change that fixes an issue)
-- [ ] New feature (non-breaking change that adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to change)
-- [ ] Documentation update
+## What Changed
+- <change 1>
+- <change 2>
 
-## Related Issues
-Fixes #(issue number)
-
-## Changes Made
-- Change 1
-- Change 2
-
-## Testing
-Describe how you tested these changes:
-- [ ] Tested with Claude Desktop
-- [ ] Tested with Claude Code
-- [ ] Tested with Web UI
-- [ ] Verified tokens work correctly
-
-## Checklist
-- [ ] My code follows the project's style
-- [ ] I have tested my changes locally
-- [ ] I have updated documentation if needed
-- [ ] My changes don't introduce new warnings
+## How Verified
+- <command or workflow>
+- <manual check if applicable>

--- a/.github/RELEASE_NOTES_TEMPLATE.md
+++ b/.github/RELEASE_NOTES_TEMPLATE.md
@@ -16,3 +16,9 @@ npx -y @jtalk22/slack-mcp --version
 npx -y @jtalk22/slack-mcp --setup
 npx -y @jtalk22/slack-mcp --status
 ```
+
+### Support
+- Self-host bugs and docs fixes: GitHub issues with exact version, runtime mode, and error output.
+- Managed rollout or Cloud support: `https://mcp.revasserlabs.com/deployment` and `https://mcp.revasserlabs.com/support`
+
+Maintained by James Lambert (`jtalk22`) under Revasser.

--- a/.github/v3.2.4-release-notes.md
+++ b/.github/v3.2.4-release-notes.md
@@ -12,7 +12,7 @@ npx -y @jtalk22/slack-mcp@latest --doctor
 - **Runtime version integrity** — CLI, setup wizard, HTTP transport, web mode, and Docker smoke output now derive their release version from one canonical metadata source.
 - **Public trust surfaces** — README, landing pages, share/demo pages, and current setup/troubleshooting docs now tell one consistent story: `16` self-hosted tools, `15` managed Cloud tools, and `3` Team AI workflows.
 - **Release guardrails** — CI and release preflight now enforce public-surface integrity and regression-check the Attribution Guardrail Dependabot skip logic.
-- **Support routing** — deployment intake and support boundaries are elevated across current repo-facing surfaces so rollout requests and reproducible bugs follow separate paths.
+- **Support routing** — hosted deployment review and support boundaries are elevated across current repo-facing surfaces so rollout requests and reproducible bugs follow separate paths.
 
 ### Operations
 
@@ -37,8 +37,9 @@ docker run --rm ghcr.io/jtalk22/slack-mcp-server:3.2.4 --version
 
 ### Support
 
-- Deployment intake: https://github.com/jtalk22/slack-mcp-server/issues/new?template=deployment-intake.md
+- Cloud deployment review: https://mcp.revasserlabs.com/deployment
+- Cloud support: https://mcp.revasserlabs.com/support
 - Troubleshooting: https://github.com/jtalk22/slack-mcp-server/blob/main/docs/TROUBLESHOOTING.md
 - Support boundaries: https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SUPPORT-BOUNDARIES.md
 
-Maintainer/operator: `jtalk22` (`support@revasserlabs.com`)
+Maintained by James Lambert (`jtalk22`) under Revasser.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npx -y @jtalk22/slack-mcp@latest --doctor
 npx -y @jtalk22/slack-mcp@latest --status
 ```
 
-[20-second demo](https://jtalk22.github.io/slack-mcp-server/public/demo-video.html) · [Interactive demo](https://jtalk22.github.io/slack-mcp-server/public/demo.html) · [Latest release notes](https://github.com/jtalk22/slack-mcp-server/releases/latest) · [Release-day runbook](docs/LAUNCH-OPS.md) · [Release health snapshot](docs/release-health/latest.md) · [Version parity report](docs/release-health/version-parity.md) · [Cloud deployment](https://mcp.revasserlabs.com/deployment) · [Cloud support](https://mcp.revasserlabs.com/support)
+[20-second demo](https://jtalk22.github.io/slack-mcp-server/public/demo-video.html) · [Interactive demo](https://jtalk22.github.io/slack-mcp-server/public/demo.html) · [Start here discussion](https://github.com/jtalk22/slack-mcp-server/discussions/12) · [Latest release notes](https://github.com/jtalk22/slack-mcp-server/releases/latest) · [Release-day runbook](docs/LAUNCH-OPS.md) · [Release health snapshot](docs/release-health/latest.md) · [Version parity report](docs/release-health/version-parity.md) · [Cloud deployment](https://mcp.revasserlabs.com/deployment) · [Cloud support](https://mcp.revasserlabs.com/support)
 
 [![Slack MCP proof surface](docs/images/demo-poster.png)](https://jtalk22.github.io/slack-mcp-server/public/demo-video.html)
 
@@ -61,6 +61,8 @@ Slack MCP Cloud provides 15 managed tools with hosted credential handling. Team 
 [Get Started](https://mcp.revasserlabs.com) · [Cloud Docs](https://mcp.revasserlabs.com/docs) · [Deployment Review](https://mcp.revasserlabs.com/deployment) · [Cloud Support](https://mcp.revasserlabs.com/support) · [Privacy Policy](https://mcp.revasserlabs.com/privacy)
 
 For rollout help or managed deployment review, use [Cloud deployment review](https://mcp.revasserlabs.com/deployment). Reproducible self-host bugs stay in standard issues; hosted operational questions belong on [Cloud support](https://mcp.revasserlabs.com/support).
+
+Maintained by James Lambert (`jtalk22`) under Revasser. Self-host support is best-effort; managed rollout and Cloud support stay on [mcp.revasserlabs.com](https://mcp.revasserlabs.com).
 
 ## Install & Verify (Self-Hosted)
 

--- a/docs/COMMUNICATION-STYLE.md
+++ b/docs/COMMUNICATION-STYLE.md
@@ -10,6 +10,14 @@ Use this guide for release notes, issue replies, and changelog entries.
 4. State exact versions and commands when relevant.
 5. Avoid speculative claims.
 6. Release titles use `vX.Y.Z — <concrete operational outcome>`.
+7. Public artifacts are maintainer-reviewed and maintainer-authored.
+8. GitHub is for self-host bugs, docs fixes, and releases; managed support belongs on hosted surfaces.
+
+## Public Authorship Policy
+
+- AI tooling may assist locally with drafting, checks, and implementation.
+- Public releases, issue replies, discussions, and changelog entries ship only after maintainer review.
+- Do not include tool attribution, generated-with lines, or bot-style self-reference in public copy.
 
 ## Issue Reply Template
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -22,6 +22,8 @@ Start here for setup, compatibility checks, current release operations, and supp
 ## Cloud
 
 - [Cloud Landing Page](https://mcp.revasserlabs.com) — Hosted MCP endpoint, $19/mo Solo, $49/mo Team
+- [Cloud Deployment Review](https://mcp.revasserlabs.com/deployment)
+- [Cloud Support](https://mcp.revasserlabs.com/support)
 - [Cloud Privacy Policy](https://mcp.revasserlabs.com/privacy)
 
 ## Operations
@@ -30,7 +32,6 @@ Start here for setup, compatibility checks, current release operations, and supp
 - [Cloudflare Browser Toolkit](CLOUDFLARE-BROWSER-TOOLKIT.md)
 - [Use Case Recipes](USE_CASE_RECIPES.md)
 - [Support Boundaries](SUPPORT-BOUNDARIES.md)
-- [Deployment Intake Template](../.github/ISSUE_TEMPLATE/deployment-intake.md)
 
 ## Launch and Communication Archive
 
@@ -47,7 +48,6 @@ Start here for setup, compatibility checks, current release operations, and supp
 
 - [Bug Report Template](../.github/ISSUE_TEMPLATE/bug_report.md)
 - [Feature Request Template](../.github/ISSUE_TEMPLATE/feature_request.md)
-- [Deployment Intake Template](../.github/ISSUE_TEMPLATE/deployment-intake.md)
 
 ## Historical Snapshots
 

--- a/docs/LAUNCH-OPS.md
+++ b/docs/LAUNCH-OPS.md
@@ -69,7 +69,7 @@ node scripts/browser-smoke.js --mode live --base-url https://jtalk22.github.io/s
 - Smithery listing remains reachable; if metadata lags, record a propagation note.
 - GitHub Pages landing/demo/share surfaces load with current proof and a working Cloud `/status` snapshot.
 - GitHub Pages live browser smoke workflow passes against `https://jtalk22.github.io/slack-mcp-server/`.
-- Deployment-intake routing is visible on the current repo trust surfaces.
+- Hosted deployment review routing is visible on the current repo trust surfaces.
 
 ## Monitoring Cadence
 
@@ -80,7 +80,7 @@ Track:
 - install blockers and unique reporter count
 - npm / GHCR / MCP Registry / Glama parity state
 - GitHub Release page accuracy
-- Cloudflare sessions, checkout starts, provisioned keys, deployment-intake submissions, and support load
+- Cloudflare sessions, checkout starts, provisioned keys, hosted deployment review requests, and support load
 - inbound issue/discussion severity
 
 ## Triage Rules
@@ -91,7 +91,7 @@ P1 install blocker:
 - pause promotion if multiple unique reports land
 
 Rollout/support request:
-- route teams to deployment intake
+- route teams to hosted deployment review
 - keep public issue threads for reproducible product bugs and docs corrections
 
 ## Escalation Triggers

--- a/docs/SUPPORT-BOUNDARIES.md
+++ b/docs/SUPPORT-BOUNDARIES.md
@@ -5,7 +5,7 @@ This document sets expectations for issue triage, support scope, and rollout saf
 ## Start With The Right Channel
 
 - Reproducible product bugs: open a standard bug issue with version, runtime mode, and exact error text.
-- Team rollout help or managed evaluation: open a [deployment intake](../.github/ISSUE_TEMPLATE/deployment-intake.md) before broad rollout.
+- Team rollout help or managed evaluation: use [Cloud deployment review](https://mcp.revasserlabs.com/deployment).
 - Privacy or credential-sensitive concerns: use `support@revasserlabs.com` and redact all tokens/cookies.
 
 ## In Scope
@@ -37,7 +37,7 @@ Include the following in every issue:
 - Installation/blocker bugs: initial response target within 2 business days.
 - Non-blocking bugs: initial response target within 5 business days.
 - Feature requests: triaged in backlog batches.
-- Deployment-intake reviews: best-effort prioritization based on rollout urgency and maintainer capacity.
+- Managed rollout questions: route to hosted deployment review and hosted support instead of GitHub issue threads.
 
 ## Solo Maintainer Capacity Guardrail
 
@@ -53,10 +53,12 @@ Include the following in every issue:
 
 ## Deployment Escalation Rule
 
-For team/hosted usage, open a deployment intake issue before broad rollout.
+For team/hosted usage, use [Cloud deployment review](https://mcp.revasserlabs.com/deployment) before broad rollout.
 
 ## Managed vs Self-Hosted Support Posture
 
 - Self-hosted support is best-effort and focused on reproducible product behavior, install blockers, and docs clarity.
-- Guided rollout support is routed through deployment intake so requirements, runtime target, and validation criteria are captured in one place.
+- Guided rollout support is routed through hosted deployment review so requirements, runtime target, and validation criteria stay on the product surface.
 - Public issue threads are not the place for open-ended environment consulting or workspace-specific Slack policy interpretation.
+
+Maintained by James Lambert (`jtalk22`) under Revasser.

--- a/docs/release-health/2026-03-11.md
+++ b/docs/release-health/2026-03-11.md
@@ -1,6 +1,6 @@
 # Release Health Snapshot
 
-- Generated: 2026-03-11T04:35:03.912Z
+- Generated: 2026-03-11T13:45:02.323Z
 - Repo: `jtalk22/slack-mcp-server`
 - Package: `@jtalk22/slack-mcp`
 
@@ -15,21 +15,21 @@
 - stars: 14
 - forks: 10
 - open issues: 0
-- 14d views: 529
-- 14d unique visitors: 199
-- 14d clones: 1404
-- 14d unique cloners: 285
-- deployment-intake submissions (all-time): 0
+- 14d views: 475
+- 14d unique visitors: 192
+- 14d clones: 2161
+- 14d unique cloners: 404
+- hosted deployment review requests: manual tracking
 
 ## 14-Day Reliability Targets
 
 - weekly downloads: >= 180
-- qualified deployment-intake submissions: >= 2
+- qualified hosted deployment review requests: manual
 - maintainer support load: <= 2 hours/week
 
 ## Same-Day Operator Checks
 
-- deployment-intake submissions (current all-time count): 0
+- hosted deployment review requests: manual
 - GitHub Release page: verify current release notes, verify commands, support path, and Cloud vs self-hosted split.
 - npm / npx / GHCR parity: verify after release using `npm view`, `npx --version`, and Docker `--version`.
 - MCP Registry / Glama / Smithery: confirm latest version and canonical homepage, or record propagation lag.
@@ -42,4 +42,4 @@
 - Update this snapshot daily during active release windows, then weekly.
 - GitHub traffic is an awareness signal, not the sole demand KPI, now that canonical onboarding lives at mcp.revasserlabs.com.
 - Track off-GitHub funnel metrics manually: Cloudflare sessions, checkout starts, provisioned keys, and support load.
-- Track deployment-intake quality and support load manually in issue notes.
+- Track hosted deployment review volume and support load manually.

--- a/docs/release-health/latest.md
+++ b/docs/release-health/latest.md
@@ -1,6 +1,6 @@
 # Release Health Snapshot
 
-- Generated: 2026-03-11T04:35:03.912Z
+- Generated: 2026-03-11T13:45:02.323Z
 - Repo: `jtalk22/slack-mcp-server`
 - Package: `@jtalk22/slack-mcp`
 
@@ -15,21 +15,21 @@
 - stars: 14
 - forks: 10
 - open issues: 0
-- 14d views: 529
-- 14d unique visitors: 199
-- 14d clones: 1404
-- 14d unique cloners: 285
-- deployment-intake submissions (all-time): 0
+- 14d views: 475
+- 14d unique visitors: 192
+- 14d clones: 2161
+- 14d unique cloners: 404
+- hosted deployment review requests: manual tracking
 
 ## 14-Day Reliability Targets
 
 - weekly downloads: >= 180
-- qualified deployment-intake submissions: >= 2
+- qualified hosted deployment review requests: manual
 - maintainer support load: <= 2 hours/week
 
 ## Same-Day Operator Checks
 
-- deployment-intake submissions (current all-time count): 0
+- hosted deployment review requests: manual
 - GitHub Release page: verify current release notes, verify commands, support path, and Cloud vs self-hosted split.
 - npm / npx / GHCR parity: verify after release using `npm view`, `npx --version`, and Docker `--version`.
 - MCP Registry / Glama / Smithery: confirm latest version and canonical homepage, or record propagation lag.
@@ -42,4 +42,4 @@
 - Update this snapshot daily during active release windows, then weekly.
 - GitHub traffic is an awareness signal, not the sole demand KPI, now that canonical onboarding lives at mcp.revasserlabs.com.
 - Track off-GitHub funnel metrics manually: Cloudflare sessions, checkout starts, provisioned keys, and support load.
-- Track deployment-intake quality and support load manually in issue notes.
+- Track hosted deployment review volume and support load manually.

--- a/scripts/build-release-health-delta.js
+++ b/scripts/build-release-health-delta.js
@@ -13,14 +13,12 @@ const METRICS = [
   "14d unique visitors",
   "14d clones",
   "14d unique cloners",
-  "deployment-intake submissions (all-time)",
 ];
 
 const DEFAULT_AFTER = resolve("output", "release-health", "latest.md");
 const DEFAULT_OUT = resolve("output", "release-health", "automation-delta.md");
 const TARGETS = {
   "npm downloads (last week)": { operator: ">=", value: 180 },
-  "deployment-intake submissions (all-time)": { operator: ">=", value: 2 },
 };
 
 function escapeRegex(input) {

--- a/scripts/collect-release-health.js
+++ b/scripts/collect-release-health.js
@@ -43,11 +43,6 @@ function toDateSlug(date) {
   return `${y}-${m}-${d}`;
 }
 
-function countNonPrIssues(items) {
-  if (!Array.isArray(items)) return 0;
-  return items.filter((item) => item && !item.pull_request).length;
-}
-
 function buildMarkdown(data) {
   const lines = [];
   lines.push("# Release Health Snapshot");
@@ -73,19 +68,19 @@ function buildMarkdown(data) {
   lines.push(`- 14d unique visitors: ${data.github.viewsUniques ?? "n/a"}`);
   lines.push(`- 14d clones: ${data.github.clonesCount ?? "n/a"}`);
   lines.push(`- 14d unique cloners: ${data.github.clonesUniques ?? "n/a"}`);
-  lines.push(`- deployment-intake submissions (all-time): ${data.github.deploymentIntakeCount ?? "n/a"}`);
+  lines.push("- hosted deployment review requests: manual tracking");
   lines.push("");
 
   lines.push("## 14-Day Reliability Targets");
   lines.push("");
   lines.push("- weekly downloads: >= 180");
-  lines.push("- qualified deployment-intake submissions: >= 2");
+  lines.push("- qualified hosted deployment review requests: manual");
   lines.push("- maintainer support load: <= 2 hours/week");
   lines.push("");
 
   lines.push("## Same-Day Operator Checks");
   lines.push("");
-  lines.push(`- deployment-intake submissions (current all-time count): ${data.github.deploymentIntakeCount ?? "n/a"}`);
+  lines.push("- hosted deployment review requests: manual");
   lines.push("- GitHub Release page: verify current release notes, verify commands, support path, and Cloud vs self-hosted split.");
   lines.push("- npm / npx / GHCR parity: verify after release using `npm view`, `npx --version`, and Docker `--version`.");
   lines.push("- MCP Registry / Glama / Smithery: confirm latest version and canonical homepage, or record propagation lag.");
@@ -99,7 +94,7 @@ function buildMarkdown(data) {
   lines.push("- Update this snapshot daily during active release windows, then weekly.");
   lines.push("- GitHub traffic is an awareness signal, not the sole demand KPI, now that canonical onboarding lives at mcp.revasserlabs.com.");
   lines.push("- Track off-GitHub funnel metrics manually: Cloudflare sessions, checkout starts, provisioned keys, and support load.");
-  lines.push("- Track deployment-intake quality and support load manually in issue notes.");
+  lines.push("- Track hosted deployment review volume and support load manually.");
 
   return `${lines.join("\n")}\n`;
 }
@@ -128,8 +123,6 @@ async function main() {
   const repoInfo = safeGhApi(`repos/${REPO}`) || {};
   const views = safeGhApi(`repos/${REPO}/traffic/views`) || {};
   const clones = safeGhApi(`repos/${REPO}/traffic/clones`) || {};
-  const intakeIssues = safeGhApi(`repos/${REPO}/issues?state=all&labels=deployment-intake&per_page=100`) || [];
-
   const data = {
     generatedAt,
     npm: {
@@ -145,7 +138,6 @@ async function main() {
       viewsUniques: views.uniques ?? null,
       clonesCount: clones.count ?? null,
       clonesUniques: clones.uniques ?? null,
-      deploymentIntakeCount: countNonPrIssues(intakeIssues),
     },
   };
 


### PR DESCRIPTION
## Why
- reduce public GitHub noise and make current trust/support routing founder-led
- move managed rollout/support off GitHub issue intake on current public surfaces
- make AI review bots manual-first at the repo level

## What Changed
- simplified README, templates, release notes, and support docs around self-host vs hosted routing
- added repo-level Gemini and CodeRabbit manual-first config
- refreshed release-health wording to stop referencing GitHub deployment-intake counts

## How Verified
- `node scripts/check-public-surface-integrity.js`
- `node scripts/collect-release-health.js --public`
- `bash scripts/check-public-language.sh`
- `node --check scripts/collect-release-health.js`
- `node --check scripts/build-release-health-delta.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated issue reply and pull request templates for improved clarity and structure.
  * Clarified support channels, boundaries, and routing in documentation.
  * Added maintainer attribution and support resource links throughout.
  * Standardized terminology across documentation.

* **Chores**
  * Added new configuration files for AI review tools.
  * Updated release health tracking to include manual monitoring entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->