### PR TITLE
chore: minimize unsolicited review noise

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,4 @@
 reviews:
   auto_review:
     enabled: false
+  review_status: false

--- a/.github/bot-review-smoke.md
+++ b/.github/bot-review-smoke.md
@@ -1,0 +1,3 @@
+# Bot review smoke
+
+Temporary PR to verify manual-only AI review posture on main.

--- a/.github/workflows/ai-review-noise-guard.yml
+++ b/.github/workflows/ai-review-noise-guard.yml
@@ -1,0 +1,99 @@
+name: AI Review Noise Guard
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  minimize-unsolicited-ai-review:
+    if: >
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request) ||
+      github.event_name == 'pull_request_review' ||
+      github.event_name == 'pull_request_review_comment'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Minimize unsolicited AI review artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PATH: ${{ github.event_path }}
+          REPOSITORY: ${{ github.repository }}
+          OPT_IN_LABEL: manual-ai-review
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import subprocess
+          import sys
+
+          BOT_AUTHORS = {
+              "gemini-code-assist",
+              "coderabbitai",
+              "chatgpt-codex-connector",
+              "chatgpt-codex-connector[bot]",
+          }
+
+          with open(os.environ["EVENT_PATH"], "r", encoding="utf-8") as handle:
+              event = json.load(handle)
+
+          event_name = os.environ["EVENT_NAME"]
+          repository = os.environ["REPOSITORY"]
+          opt_in_label = os.environ["OPT_IN_LABEL"]
+
+          if event_name == "issue_comment":
+              if not event.get("issue", {}).get("pull_request"):
+                  print("Issue comment is not on a pull request.")
+                  sys.exit(0)
+              subject = event["comment"]
+              pr_number = event["issue"]["number"]
+          elif event_name == "pull_request_review":
+              subject = event["review"]
+              pr_number = event["pull_request"]["number"]
+          elif event_name == "pull_request_review_comment":
+              subject = event["comment"]
+              pr_number = event["pull_request"]["number"]
+          else:
+              print(f"Unsupported event: {event_name}")
+              sys.exit(0)
+
+          author = subject["user"]["login"]
+          node_id = subject.get("node_id")
+
+          if author not in BOT_AUTHORS:
+              print(f"Author {author} is not managed by this guard.")
+              sys.exit(0)
+
+          if not node_id:
+              print("Event payload did not include a node_id.")
+              sys.exit(1)
+
+          labels_raw = subprocess.check_output(
+              ["gh", "api", f"repos/{repository}/issues/{pr_number}/labels"],
+              text=True,
+          )
+          labels = {label["name"] for label in json.loads(labels_raw)}
+
+          if opt_in_label in labels:
+              print(f"Label {opt_in_label} present; leaving AI review artifact visible.")
+              sys.exit(0)
+
+          mutation = (
+              "mutation($id:ID!) { "
+              "minimizeComment(input:{subjectId:$id,classifier:OUTDATED}) { "
+              "minimizedComment { isMinimized minimizedReason } "
+              "} }"
+          )
+
+          subprocess.check_call(
+              ["gh", "api", "graphql", "-f", f"query={mutation}", "-f", f"id={node_id}"]
+          )
+          print(f"Minimized unsolicited AI review artifact from {author} on PR #{pr_number}.")
+          PY

--- a/docs/COMMUNICATION-STYLE.md
+++ b/docs/COMMUNICATION-STYLE.md
@@ -12,6 +12,7 @@ Use this guide for release notes, issue replies, and changelog entries.
 6. Release titles use `vX.Y.Z — <concrete operational outcome>`.
 7. Public artifacts are maintainer-reviewed and maintainer-authored.
 8. GitHub is for self-host bugs, docs fixes, and releases; managed support belongs on hosted surfaces.
+9. If a PR needs AI review, add the `manual-ai-review` label before invoking the bot explicitly.
 
 ## Public Authorship Policy
 


### PR DESCRIPTION
## Why
- gemini-code-assist still auto-posts summary noise from organization settings
- coderabbit now respects manual mode, but still leaves a skip-status comment by default
- public PR history should stay founder-led and low-noise by default

## What Changed
- disabled CodeRabbit review-status comments in repo config
- added an AI review noise guard workflow that minimizes unsolicited bot comments and reviews unless the PR carries the `manual-ai-review` label
- documented the manual-review label in the communication style guide

## How Verified
- fresh PR #58 showed Gemini auto-summary still active after the base-branch config change
- CodeRabbit now reports skipped/manual mode from the base branch
- workflow YAML parses locally via Ruby `YAML.load_file`