### PR TITLE
fix: read review-noise guard event payload from runner env

### DIFF
--- a/.github/final-review-smoke.md
+++ b/.github/final-review-smoke.md
@@ -1,0 +1,3 @@
+# Final review smoke
+
+Temporary PR to validate post-merge review-noise guard behavior.

--- a/.github/workflows/ai-review-noise-guard.yml
+++ b/.github/workflows/ai-review-noise-guard.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Minimize unsolicited AI review artifacts
         env:
           GH_TOKEN: ${{ github.token }}
-          EVENT_NAME: ${{ github.event_name }}
-          EVENT_PATH: ${{ github.event_path }}
-          REPOSITORY: ${{ github.repository }}
           OPT_IN_LABEL: manual-ai-review
         run: |
           python3 - <<'PY'
@@ -41,11 +38,11 @@ jobs:
               "chatgpt-codex-connector[bot]",
           }
 
-          with open(os.environ["EVENT_PATH"], "r", encoding="utf-8") as handle:
+          with open(os.environ["GITHUB_EVENT_PATH"], "r", encoding="utf-8") as handle:
               event = json.load(handle)
 
-          event_name = os.environ["EVENT_NAME"]
-          repository = os.environ["REPOSITORY"]
+          event_name = os.environ["GITHUB_EVENT_NAME"]
+          repository = os.environ["GITHUB_REPOSITORY"]
           opt_in_label = os.environ["OPT_IN_LABEL"]
 
           if event_name == "issue_comment":


### PR DESCRIPTION
## Why
- the new review-noise guard existed on main, but it failed because it tried to read `github.event_path` instead of the runner-provided `GITHUB_EVENT_PATH`
- that left Gemini summaries and reviews visible on validation PRs

## What Changed
- switched the guard workflow to the built-in `GITHUB_EVENT_PATH`, `GITHUB_EVENT_NAME`, and `GITHUB_REPOSITORY` environment variables
- kept the manual `manual-ai-review` label escape hatch unchanged

## How Verified
- pulled the failed workflow log from run `22956192137`
- reproduced the exact failure (`FileNotFoundError` on empty event path)
- YAML still parses locally via Ruby `YAML.load_file`