### PR TITLE
fix: normalize bot authors in review-noise guard

### DIFF
--- a/.github/bot-review-smoke.md
+++ b/.github/bot-review-smoke.md
@@ -1,3 +1,0 @@
-# Bot review smoke
-
-Temporary PR to verify manual-only AI review posture on main.

--- a/.github/final-review-smoke.md
+++ b/.github/final-review-smoke.md
@@ -1,3 +1,0 @@
-# Final review smoke
-
-Temporary PR to validate post-merge review-noise guard behavior.

--- a/.github/workflows/ai-review-noise-guard.yml
+++ b/.github/workflows/ai-review-noise-guard.yml
@@ -35,7 +35,6 @@ jobs:
               "gemini-code-assist",
               "coderabbitai",
               "chatgpt-codex-connector",
-              "chatgpt-codex-connector[bot]",
           }
 
           with open(os.environ["GITHUB_EVENT_PATH"], "r", encoding="utf-8") as handle:
@@ -62,9 +61,10 @@ jobs:
               sys.exit(0)
 
           author = subject["user"]["login"]
+          normalized_author = author[:-5] if author.endswith("[bot]") else author
           node_id = subject.get("node_id")
 
-          if author not in BOT_AUTHORS:
+          if normalized_author not in BOT_AUTHORS:
               print(f"Author {author} is not managed by this guard.")
               sys.exit(0)
 


### PR DESCRIPTION
Why
- GitHub App event payloads can report authors with a [bot] suffix even when the visible PR surface drops it
- the public review-noise guard should normalize those variants so unsolicited Gemini or CodeRabbit artifacts get minimized reliably
- this also removes the two temporary review-smoke marker files now that the guard has a dedicated workflow

What changed
- normalize bot author logins before matching in the review-noise guard
- delete .github/bot-review-smoke.md
- delete .github/final-review-smoke.md

How verified
- workflow YAML parses cleanly
- a live PR already triggered unsolicited Gemini summary/review artifacts on this branch
- the summary artifact has already been minimized successfully on this PR, and the review artifact is being cleaned up as part of the same validation pass