### PR TITLE
[codex] align public trust surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![MCP Registry](https://img.shields.io/badge/MCP_Registry-listed-blue)](https://registry.modelcontextprotocol.io)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
-Give Claude your Slack. 16 self-hosted tools for channels, search, replies, reactions, unread triage, and user search. Self-host free or use Slack MCP Cloud for Claude-first managed transport, Gemini CLI support, hosted credential handling, and deployment review.
+Give Claude your Slack. 16 self-hosted tools for channels, search, replies, reactions, unread triage, and user search. Self-host free or use Slack MCP Cloud for Claude-first managed transport, Gemini CLI support, hosted credential handling, deployment review, and buyer-facing security review.
 
 ## Verify & Proof
 
@@ -16,7 +16,7 @@ npx -y @jtalk22/slack-mcp@latest --doctor
 npx -y @jtalk22/slack-mcp@latest --status
 ```
 
-[20-second demo](https://jtalk22.github.io/slack-mcp-server/public/demo-video.html) · [Interactive demo](https://jtalk22.github.io/slack-mcp-server/public/demo.html) · [Start here discussion](https://github.com/jtalk22/slack-mcp-server/discussions/12) · [Latest release notes](https://github.com/jtalk22/slack-mcp-server/releases/latest) · [Release-day runbook](docs/LAUNCH-OPS.md) · [Commercial surface map](docs/COMMERCIAL-SURFACE.md) · [Release health snapshot](docs/release-health/latest.md) · [Version parity report](docs/release-health/version-parity.md) · [Cloud deployment](https://mcp.revasserlabs.com/deployment) · [Cloud support](https://mcp.revasserlabs.com/support)
+[20-second demo](https://jtalk22.github.io/slack-mcp-server/public/demo-video.html) · [Interactive demo](https://jtalk22.github.io/slack-mcp-server/public/demo.html) · [Start here discussion](https://github.com/jtalk22/slack-mcp-server/discussions/12) · [Latest release notes](https://github.com/jtalk22/slack-mcp-server/releases/latest) · [Release-day runbook](docs/LAUNCH-OPS.md) · [Commercial surface map](docs/COMMERCIAL-SURFACE.md) · [Release health snapshot](docs/release-health/latest.md) · [Version parity report](docs/release-health/version-parity.md) · [Cloud deployment](https://mcp.revasserlabs.com/deployment) · [Cloud security](https://mcp.revasserlabs.com/security) · [Cloud support](https://mcp.revasserlabs.com/support)
 
 [![Slack MCP proof surface](docs/images/demo-poster.png)](https://jtalk22.github.io/slack-mcp-server/public/demo-video.html)
 
@@ -50,7 +50,7 @@ All tools carry [MCP safety annotations](https://modelcontextprotocol.io/specifi
 Slack MCP Cloud provides 15 managed tools with hosted credential handling. Team adds 3 AI compound workflows for summaries, action items, and decisions. Claude is the primary path; Gemini CLI is the second supported client path on the hosted endpoint.
 
 - Self-host if you want 16 tools, npm or Docker, and full operator control over runtime and tokens.
-- Use Cloud if you want one remote endpoint, hosted credential handling, deployment review, support, and a hosted account surface.
+- Use Cloud if you want one remote endpoint, hosted credential handling, deployment review, buyer-facing security review, support, and a hosted account surface.
 - Solo starts at `$19/mo`; Team is `$49/mo` and adds 3 AI workflows plus higher request capacity.
 - Turnkey Team Launch starts at `$2.5k+`; Managed Reliability starts at `$800/mo+` for teams where rollout and operational continuity matter more than raw seat count.
 
@@ -61,9 +61,9 @@ Slack MCP Cloud provides 15 managed tools with hosted credential handling. Team 
 | Turnkey Team Launch | $2.5k+ | Deployment review, rollout sequencing, client setup guidance, first-production-use path |
 | Managed Reliability | $800/mo+ | Ongoing operating review, token-health follow-up, workflow continuity support |
 
-[Pricing](https://mcp.revasserlabs.com/pricing) · [Cloud Docs](https://mcp.revasserlabs.com/docs) · [Account](https://mcp.revasserlabs.com/account) · [Deployment Review](https://mcp.revasserlabs.com/deployment) · [Cloud Support](https://mcp.revasserlabs.com/support) · [Privacy Policy](https://mcp.revasserlabs.com/privacy)
+[Pricing](https://mcp.revasserlabs.com/pricing) · [Cloud Docs](https://mcp.revasserlabs.com/docs) · [Security & Procurement](https://mcp.revasserlabs.com/security) · [Account](https://mcp.revasserlabs.com/account) · [Deployment Review](https://mcp.revasserlabs.com/deployment) · [Cloud Support](https://mcp.revasserlabs.com/support) · [Privacy Policy](https://mcp.revasserlabs.com/privacy)
 
-For rollout help or managed deployment review, use [Cloud deployment review](https://mcp.revasserlabs.com/deployment). Reproducible self-host bugs stay in standard issues; hosted operational questions belong on [Cloud support](https://mcp.revasserlabs.com/support).
+For rollout help or managed deployment review, use [Cloud deployment review](https://mcp.revasserlabs.com/deployment). For buyer-facing controls, storage, analytics, and procurement questions, use [Cloud security](https://mcp.revasserlabs.com/security). Reproducible self-host bugs stay in standard issues; hosted operational questions belong on [Cloud support](https://mcp.revasserlabs.com/support).
 
 Maintained by James Lambert (`jtalk22`) under Revasser. Self-host support is best-effort; managed rollout and Cloud support stay on [mcp.revasserlabs.com](https://mcp.revasserlabs.com).
 

--- a/docs/COMMERCIAL-SURFACE.md
+++ b/docs/COMMERCIAL-SURFACE.md
@@ -10,7 +10,7 @@ flowchart LR
     A --> C["GitHub Pages proof surface"]
     A --> D["npm package / GHCR image"]
     A --> E["MCP Registry metadata"]
-    B --> F["Hosted pricing/docs/support/deployment"]
+    B --> F["Hosted pricing/docs/security/support/deployment"]
     C --> F
     D --> G["Self-host users"]
     E --> H["Remote MCP discovery"]
@@ -66,6 +66,7 @@ That is intentional, but it means the handoff to hosted pricing/docs/deployment 
 - release-preflight is strong again
 - public Pages are generated from shared metadata
 - live Cloud status is read from hosted `/status`
+- hosted security/procurement now has a dedicated route instead of being implied across other pages
 - README now carries the self-host versus Cloud split credibly
 - MCP Registry and homepage metadata are aligned with the hosted surface
 
@@ -85,6 +86,7 @@ flowchart TD
 ```
 
 - Add more named workflow proof to the public Pages surface.
+- Keep public buyer-trust links routed to hosted `/security`, `/deployment`, and `/support`.
 - Pull hosted funnel summary into release-health whenever admin auth is available.
 - Keep README and Pages focused on trust, not feature bloat.
 - Continue reducing GitHub-side noise so public history looks operator-led.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -24,6 +24,7 @@ Start here for setup, compatibility checks, current release operations, and supp
 
 - [Cloud Landing Page](https://mcp.revasserlabs.com) — Hosted MCP endpoint, pricing, live status, and account surface
 - [Cloud Pricing](https://mcp.revasserlabs.com/pricing) — Solo, Team, Turnkey Team Launch, Managed Reliability
+- [Cloud Security](https://mcp.revasserlabs.com/security) — Buyer-facing controls, storage, analytics, and procurement summary
 - [Cloud Account](https://mcp.revasserlabs.com/account) — Usage, billing portal, reconnect state, client configs
 - [Cloud Deployment Review](https://mcp.revasserlabs.com/deployment)
 - [Cloud Support](https://mcp.revasserlabs.com/support)

--- a/docs/LAUNCH-OPS.md
+++ b/docs/LAUNCH-OPS.md
@@ -9,7 +9,7 @@ flowchart LR
     A["Public repo"] --> B["README / docs / release health"]
     A --> C["GitHub Pages proof"]
     A --> D["npm / GHCR / MCP Registry"]
-    B --> E["Hosted pricing / docs / deployment / support / account"]
+    B --> E["Hosted pricing / docs / security / deployment / support / account"]
     C --> E
     D --> F["Self-host users + remote discovery"]
 ```
@@ -66,6 +66,7 @@ bash scripts/publish-mcp-registry.sh server.json --validate-only
 curl -s https://mcp.revasserlabs.com/status
 curl -s https://mcp.revasserlabs.com/api
 curl -s https://mcp.revasserlabs.com/pricing
+curl -s https://mcp.revasserlabs.com/security
 curl -s https://mcp.revasserlabs.com/account
 curl -I -H 'Origin: https://jtalk22.github.io' https://mcp.revasserlabs.com/status
 node scripts/browser-smoke.js --mode live --base-url https://jtalk22.github.io/slack-mcp-server
@@ -79,6 +80,7 @@ node scripts/browser-smoke.js --mode live --base-url https://jtalk22.github.io/s
 - Hosted `/status` returns the deployed hosted version, tool counts, token modes, and docs/support/self-host URLs.
 - Hosted `/pricing` reflects Solo, Team, Turnkey Team Launch, and Managed Reliability.
 - Hosted `/docs` resolves to the hosted-native documentation surface, not a GitHub redirect.
+- Hosted `/security` resolves to the buyer-facing controls and procurement surface.
 - Hosted `/account` renders the authenticated usage, billing, token, and client-config surface.
 - Hosted `/use-cases/support-triage` resolves and routes to pricing or deployment review.
 - Hosted live browser smoke workflow passes against `https://mcp.revasserlabs.com/`.

--- a/glama.json
+++ b/glama.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "name": "slack-mcp-server",
-  "description": "Session-based Slack MCP for Claude and MCP clients. 16 local-first tools for channels, search, replies, reactions, unreads, and user search. Managed Cloud option available at mcp.revasserlabs.com.",
+  "description": "Session-based Slack MCP for Claude and MCP clients. 16 local-first tools for channels, search, replies, reactions, unreads, and user search. Managed Cloud option with security/procurement review lives at mcp.revasserlabs.com.",
   "repository": "https://github.com/jtalk22/slack-mcp-server",
   "homepage": "https://mcp.revasserlabs.com",
   "version": "3.2.4",

--- a/index.html
+++ b/index.html
@@ -4,17 +4,17 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Slack MCP Server - Install in 30 Seconds</title>
-  <meta name="description" content="16 self-hosted Slack MCP tools for Claude. Managed Cloud is Claude-first with Gemini CLI support, pricing, deployment review, and higher-touch rollout offers.">
+  <meta name="description" content="16 self-hosted Slack MCP tools for Claude. Managed Cloud is Claude-first with Gemini CLI support, pricing, security/procurement review, deployment review, and higher-touch rollout offers.">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Slack MCP Server — Claude-first Slack MCP, self-hosted or managed">
-  <meta property="og:description" content="Give Claude your Slack. Self-host 16 tools for free, or use Cloud for 15 managed tools, Gemini CLI support, deployment review, and hosted credentials.">
+  <meta property="og:description" content="Give Claude your Slack. Self-host 16 tools for free, or use Cloud for 15 managed tools, Gemini CLI support, security/procurement review, deployment review, and hosted credentials.">
   <meta property="og:url" content="https://jtalk22.github.io/slack-mcp-server/">
   <meta property="og:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
   <meta property="og:image:width" content="1280">
   <meta property="og:image:height" content="640">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Slack MCP Server — Claude-first Slack MCP, self-hosted or managed">
-  <meta name="twitter:description" content="Give Claude your Slack. Self-host 16 tools for free, or use Cloud for 15 managed tools, Gemini CLI support, deployment review, and hosted credentials.">
+  <meta name="twitter:description" content="Give Claude your Slack. Self-host 16 tools for free, or use Cloud for 15 managed tools, Gemini CLI support, security/procurement review, deployment review, and hosted credentials.">
   <meta name="twitter:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
   <link rel="icon" href="https://jtalk22.github.io/slack-mcp-server/docs/assets/icon-512.png" type="image/png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -311,7 +311,7 @@
 npx -y @jtalk22/slack-mcp@latest --version
 npx -y @jtalk22/slack-mcp@latest --doctor
 npx -y @jtalk22/slack-mcp@latest --status</div>
-      <p class="verify" style="margin-top:12px">For rollout support, use deployment review. Solo starts at $19/mo, Team at $49/mo, Turnkey Team Launch at $2.5k+, and Managed Reliability at $800/mo+. Reproducible bugs and install blockers still go through standard issue triage.</p>
+      <p class="verify" style="margin-top:12px">For rollout support, use deployment review. For buyer-facing controls and procurement review, use the hosted security surface. Solo starts at $19/mo, Team at $49/mo, Turnkey Team Launch at $2.5k+, and Managed Reliability at $800/mo+. Reproducible bugs and install blockers still go through standard issue triage.</p>
     </section>
 
     <section class="stage" style="padding-top:0">
@@ -361,18 +361,18 @@ npx -y @jtalk22/slack-mcp@latest --status</div>
             <li>Team: $49/mo and adds 3 AI workflows</li>
             <li>Turnkey Team Launch: from $2.5k+; Managed Reliability: from $800/mo+</li>
           </ul>
-          <p class="decision-links"><a href="https://mcp.revasserlabs.com/pricing">Pricing</a> · <a href="https://mcp.revasserlabs.com/deployment">Deployment review</a> · <a href="https://mcp.revasserlabs.com/support">Cloud support</a></p>
+          <p class="decision-links"><a href="https://mcp.revasserlabs.com/pricing">Pricing</a> · <a href="https://mcp.revasserlabs.com/deployment">Deployment review</a> · <a href="https://mcp.revasserlabs.com/security">Security</a> · <a href="https://mcp.revasserlabs.com/support">Cloud support</a></p>
         </article>
         <article class="decision-card">
           <span class="decision-label">Buyer proof</span>
           <h2>Technical trust surfaces stay public.</h2>
-          <p>The static Pages root shows npm, GitHub release, and hosted status together. The hosted site publishes <code>/status</code>, <code>/pricing</code>, <code>/docs</code>, <code>/deployment</code>, <code>/support</code>, and <code>/account</code> as the operator-facing Cloud surface.</p>
+          <p>The static Pages root shows npm, GitHub release, and hosted status together. The hosted site publishes <code>/status</code>, <code>/pricing</code>, <code>/docs</code>, <code>/security</code>, <code>/deployment</code>, <code>/support</code>, and <code>/account</code> as the operator-facing Cloud surface.</p>
           <ul>
             <li>GitHub Pages reads the hosted <code>/status</code> contract live</li>
             <li>Registry, npm, runtime parity, and hosted funnel reporting are tracked in the public reports</li>
-            <li>Rollout questions route to deployment review instead of ad hoc GitHub issues</li>
+            <li>Rollout and security questions route to hosted review surfaces instead of ad hoc GitHub issues</li>
           </ul>
-          <p class="decision-links"><a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/LAUNCH-OPS.md">Runbook</a> · <a href="https://mcp.revasserlabs.com/status">Raw status JSON</a> · <a href="https://mcp.revasserlabs.com/pricing">Plans & offers</a></p>
+          <p class="decision-links"><a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/LAUNCH-OPS.md">Runbook</a> · <a href="https://mcp.revasserlabs.com/status">Raw status JSON</a> · <a href="https://mcp.revasserlabs.com/security">Security</a> · <a href="https://mcp.revasserlabs.com/pricing">Plans & offers</a></p>
         </article>
       </div>
     </section>

--- a/lib/public-metadata.js
+++ b/lib/public-metadata.js
@@ -13,6 +13,7 @@ export const PUBLIC_METADATA = Object.freeze({
   canonicalSiteUrl: "https://mcp.revasserlabs.com",
   cloudPricingUrl: "https://mcp.revasserlabs.com/pricing",
   cloudDocsUrl: "https://mcp.revasserlabs.com/docs",
+  cloudSecurityUrl: "https://mcp.revasserlabs.com/security",
   cloudSupportUrl: "https://mcp.revasserlabs.com/support",
   cloudDeploymentUrl: "https://mcp.revasserlabs.com/deployment",
   cloudSelfHostUrl: "https://mcp.revasserlabs.com/self-host",

--- a/lib/public-pages.js
+++ b/lib/public-pages.js
@@ -57,18 +57,18 @@ function rootDecisionPanel() {
             <li>Team: ${PUBLIC_METADATA.cloudTeamPrice} and adds ${PUBLIC_METADATA.teamAiWorkflowCount} AI workflows</li>
             <li>Turnkey Team Launch: from ${PUBLIC_METADATA.cloudTurnkeyLaunchPrice}; Managed Reliability: from ${PUBLIC_METADATA.cloudManagedReliabilityPrice}</li>
           </ul>
-          <p class="decision-links"><a href="${PUBLIC_METADATA.cloudPricingUrl}">Pricing</a> · <a href="${PUBLIC_METADATA.cloudDeploymentUrl}">Deployment review</a> · <a href="${PUBLIC_METADATA.cloudSupportUrl}">Cloud support</a></p>
+          <p class="decision-links"><a href="${PUBLIC_METADATA.cloudPricingUrl}">Pricing</a> · <a href="${PUBLIC_METADATA.cloudDeploymentUrl}">Deployment review</a> · <a href="${PUBLIC_METADATA.cloudSecurityUrl}">Security</a> · <a href="${PUBLIC_METADATA.cloudSupportUrl}">Cloud support</a></p>
         </article>
         <article class="decision-card">
           <span class="decision-label">Buyer proof</span>
           <h2>Technical trust surfaces stay public.</h2>
-          <p>The static Pages root shows npm, GitHub release, and hosted status together. The hosted site publishes <code>/status</code>, <code>/pricing</code>, <code>/docs</code>, <code>/deployment</code>, <code>/support</code>, and <code>/account</code> as the operator-facing Cloud surface.</p>
+          <p>The static Pages root shows npm, GitHub release, and hosted status together. The hosted site publishes <code>/status</code>, <code>/pricing</code>, <code>/docs</code>, <code>/security</code>, <code>/deployment</code>, <code>/support</code>, and <code>/account</code> as the operator-facing Cloud surface.</p>
           <ul>
             <li>GitHub Pages reads the hosted <code>/status</code> contract live</li>
             <li>Registry, npm, runtime parity, and hosted funnel reporting are tracked in the public reports</li>
-            <li>Rollout questions route to deployment review instead of ad hoc GitHub issues</li>
+            <li>Rollout and security questions route to hosted review surfaces instead of ad hoc GitHub issues</li>
           </ul>
-          <p class="decision-links"><a href="${RUNBOOK_URL}">Runbook</a> · <a href="${PUBLIC_METADATA.cloudStatusUrl}">Raw status JSON</a> · <a href="${PUBLIC_METADATA.cloudPricingUrl}">Plans & offers</a></p>
+          <p class="decision-links"><a href="${RUNBOOK_URL}">Runbook</a> · <a href="${PUBLIC_METADATA.cloudStatusUrl}">Raw status JSON</a> · <a href="${PUBLIC_METADATA.cloudSecurityUrl}">Security</a> · <a href="${PUBLIC_METADATA.cloudPricingUrl}">Plans & offers</a></p>
         </article>
       </div>
     </section>
@@ -82,6 +82,7 @@ function shareLinks() {
       <a href="${RELEASES_URL}" rel="noopener">Latest Release</a>
       <a href="${PUBLIC_METADATA.cloudPricingUrl}" rel="noopener">Pricing</a>
       <a href="${PUBLIC_METADATA.cloudDocsUrl}" rel="noopener">Cloud Docs</a>
+      <a href="${PUBLIC_METADATA.cloudSecurityUrl}" rel="noopener">Security</a>
       <a href="${PUBLIC_METADATA.cloudDeploymentUrl}" rel="noopener">Deployment Review</a>
       <a href="${PUBLIC_METADATA.cloudSupportUrl}" rel="noopener">Cloud Support</a>
       <a href="${PUBLIC_METADATA.cloudUseCasesRootUrl}/support-triage" rel="noopener">Support Triage Use Case</a>
@@ -93,7 +94,7 @@ function shareLinks() {
 }
 
 function shareNote() {
-  return `<strong>Verify in 30 seconds:</strong> <code>--version</code>, <code>--doctor</code>, <code>--status</code>. Self-host gives ${PUBLIC_METADATA.selfHostedToolCount} tools and full operator control. Cloud starts at ${PUBLIC_METADATA.cloudSoloPrice} for ${PUBLIC_METADATA.cloudManagedToolCount} managed tools, deployment review, and support. Team at ${PUBLIC_METADATA.cloudTeamPrice} adds ${PUBLIC_METADATA.teamAiWorkflowCount} AI workflows. ${PUBLIC_METADATA.primaryClient} is the primary path; ${PUBLIC_METADATA.secondaryClient} is supported on the hosted endpoint.`;
+  return `<strong>Verify in 30 seconds:</strong> <code>--version</code>, <code>--doctor</code>, <code>--status</code>. Self-host gives ${PUBLIC_METADATA.selfHostedToolCount} tools and full operator control. Cloud starts at ${PUBLIC_METADATA.cloudSoloPrice} for ${PUBLIC_METADATA.cloudManagedToolCount} managed tools, deployment review, security/procurement review, and support. Team at ${PUBLIC_METADATA.cloudTeamPrice} adds ${PUBLIC_METADATA.teamAiWorkflowCount} AI workflows. ${PUBLIC_METADATA.primaryClient} is the primary path; ${PUBLIC_METADATA.secondaryClient} is supported on the hosted endpoint.`;
 }
 
 function demoLinks() {
@@ -103,17 +104,18 @@ function demoLinks() {
       <a href="${PUBLIC_METADATA.cloudPricingUrl}" target="_blank" rel="noopener noreferrer">Pricing</a>
       <a href="${SETUP_URL}" target="_blank" rel="noopener noreferrer">Setup Guide</a>
       <a href="${PUBLIC_METADATA.cloudDocsUrl}" target="_blank" rel="noopener noreferrer">Cloud Docs</a>
+      <a href="${PUBLIC_METADATA.cloudSecurityUrl}" target="_blank" rel="noopener noreferrer">Security</a>
       <a href="${PUBLIC_METADATA.cloudDeploymentUrl}" target="_blank" rel="noopener noreferrer">Deployment Review</a>
       <a href="${PUBLIC_METADATA.cloudSupportUrl}" target="_blank" rel="noopener noreferrer">Cloud Support</a>
     `.trim();
 }
 
 function demoNote() {
-  return `Self-host free for ${PUBLIC_METADATA.selfHostedToolCount} tools and full transport control, or use <a href="${PUBLIC_METADATA.cloudPricingUrl}" target="_blank" rel="noopener noreferrer">Cloud</a> for ${PUBLIC_METADATA.cloudManagedToolCount} managed tools, deployment review, and support. Solo starts at ${PUBLIC_METADATA.cloudSoloPrice}; Team at ${PUBLIC_METADATA.cloudTeamPrice} adds ${PUBLIC_METADATA.teamAiWorkflowCount} AI workflows. Turnkey Team Launch starts at ${PUBLIC_METADATA.cloudTurnkeyLaunchPrice}; Managed Reliability starts at ${PUBLIC_METADATA.cloudManagedReliabilityPrice}.`;
+  return `Self-host free for ${PUBLIC_METADATA.selfHostedToolCount} tools and full transport control, or use <a href="${PUBLIC_METADATA.cloudPricingUrl}" target="_blank" rel="noopener noreferrer">Cloud</a> for ${PUBLIC_METADATA.cloudManagedToolCount} managed tools, deployment review, security/procurement review, and support. Solo starts at ${PUBLIC_METADATA.cloudSoloPrice}; Team at ${PUBLIC_METADATA.cloudTeamPrice} adds ${PUBLIC_METADATA.teamAiWorkflowCount} AI workflows. Turnkey Team Launch starts at ${PUBLIC_METADATA.cloudTurnkeyLaunchPrice}; Managed Reliability starts at ${PUBLIC_METADATA.cloudManagedReliabilityPrice}.`;
 }
 
 function demoFooterLinks() {
-  return `<a href="${PUBLIC_METADATA.canonicalRepoUrl}">GitHub</a> · <a href="${PUBLIC_METADATA.cloudPricingUrl}" style="color:#f0c246;text-decoration:none;font-size:0.875rem">Cloud Plans</a> · <a href="${PUBLIC_METADATA.cloudDocsUrl}" style="color:#94a3b8;text-decoration:none;font-size:0.875rem">Cloud Docs</a> · <a href="${PUBLIC_METADATA.cloudDeploymentUrl}" style="color:#94a3b8;text-decoration:none;font-size:0.875rem">Deployment Review</a> · <a href="${PUBLIC_METADATA.cloudSupportUrl}" style="color:#94a3b8;text-decoration:none;font-size:0.875rem">Cloud Support</a> · <a href="${NPM_URL}" style="color:#94a3b8;text-decoration:none;font-size:0.875rem">npm</a>`;
+  return `<a href="${PUBLIC_METADATA.canonicalRepoUrl}">GitHub</a> · <a href="${PUBLIC_METADATA.cloudPricingUrl}" style="color:#f0c246;text-decoration:none;font-size:0.875rem">Cloud Plans</a> · <a href="${PUBLIC_METADATA.cloudDocsUrl}" style="color:#94a3b8;text-decoration:none;font-size:0.875rem">Cloud Docs</a> · <a href="${PUBLIC_METADATA.cloudSecurityUrl}" style="color:#94a3b8;text-decoration:none;font-size:0.875rem">Security</a> · <a href="${PUBLIC_METADATA.cloudDeploymentUrl}" style="color:#94a3b8;text-decoration:none;font-size:0.875rem">Deployment Review</a> · <a href="${PUBLIC_METADATA.cloudSupportUrl}" style="color:#94a3b8;text-decoration:none;font-size:0.875rem">Cloud Support</a> · <a href="${NPM_URL}" style="color:#94a3b8;text-decoration:none;font-size:0.875rem">npm</a>`;
 }
 
 function commonTokens() {
@@ -121,6 +123,7 @@ function commonTokens() {
     CANONICAL_SITE_URL: PUBLIC_METADATA.canonicalSiteUrl,
     CLOUD_PRICING_URL: PUBLIC_METADATA.cloudPricingUrl,
     CLOUD_DOCS_URL: PUBLIC_METADATA.cloudDocsUrl,
+    CLOUD_SECURITY_URL: PUBLIC_METADATA.cloudSecurityUrl,
     CLOUD_SUPPORT_URL: PUBLIC_METADATA.cloudSupportUrl,
     CLOUD_DEPLOYMENT_URL: PUBLIC_METADATA.cloudDeploymentUrl,
     CLOUD_STATUS_URL: PUBLIC_METADATA.cloudStatusUrl,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@jtalk22/slack-mcp",
   "mcpName": "io.github.jtalk22/slack-mcp-server",
   "version": "3.2.4",
-  "description": "Claude-first Slack MCP for self-hosted local workflows or managed Cloud rollout, with Gemini CLI support and secure-default HTTP.",
+  "description": "Claude-first Slack MCP for self-hosted workflows or managed Cloud rollout, with Gemini CLI support, buyer-facing security review, and secure-default HTTP.",
   "type": "module",
   "main": "src/server.js",
   "bin": {
@@ -55,7 +55,9 @@
     "mcp-server",
     "session-based",
     "claude-code",
+    "gemini-cli",
     "local-first",
+    "remote-mcp",
     "session-mirroring",
     "slack-mcp",
     "secure-by-default",

--- a/public/demo-claude.html
+++ b/public/demo-claude.html
@@ -1244,11 +1244,12 @@
       <a href="https://mcp.revasserlabs.com/pricing" target="_blank" rel="noopener noreferrer">Pricing</a>
       <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md" target="_blank" rel="noopener noreferrer">Setup Guide</a>
       <a href="https://mcp.revasserlabs.com/docs" target="_blank" rel="noopener noreferrer">Cloud Docs</a>
+      <a href="https://mcp.revasserlabs.com/security" target="_blank" rel="noopener noreferrer">Security</a>
       <a href="https://mcp.revasserlabs.com/deployment" target="_blank" rel="noopener noreferrer">Deployment Review</a>
       <a href="https://mcp.revasserlabs.com/support" target="_blank" rel="noopener noreferrer">Cloud Support</a>
     </div>
     <div class="note">
-      Self-host free for 16 tools and full transport control, or use <a href="https://mcp.revasserlabs.com/pricing" target="_blank" rel="noopener noreferrer">Cloud</a> for 15 managed tools, deployment review, and support. Solo starts at $19/mo; Team at $49/mo adds 3 AI workflows. Turnkey Team Launch starts at $2.5k+; Managed Reliability starts at $800/mo+.
+      Self-host free for 16 tools and full transport control, or use <a href="https://mcp.revasserlabs.com/pricing" target="_blank" rel="noopener noreferrer">Cloud</a> for 15 managed tools, deployment review, security/procurement review, and support. Solo starts at $19/mo; Team at $49/mo adds 3 AI workflows. Turnkey Team Launch starts at $2.5k+; Managed Reliability starts at $800/mo+.
     </div>
   </div>
   <header class="page-header">

--- a/public/demo-video.html
+++ b/public/demo-video.html
@@ -4,15 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Slack MCP Server — Video Demo</title>
-  <meta name="description" content="Give Claude your Slack. 16 self-hosted tools plus a managed Cloud path with Gemini CLI support, deployment review, and hosted credentials.">
+  <meta name="description" content="Give Claude your Slack. 16 self-hosted tools plus a managed Cloud path with Gemini CLI support, security/procurement review, deployment review, and hosted credentials.">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Slack MCP Server — Video Demo">
-  <meta property="og:description" content="Give Claude your Slack. 16 self-hosted tools plus a managed Cloud path with Gemini CLI support, deployment review, and hosted credentials.">
+  <meta property="og:description" content="Give Claude your Slack. 16 self-hosted tools plus a managed Cloud path with Gemini CLI support, security/procurement review, deployment review, and hosted credentials.">
   <meta property="og:url" content="https://jtalk22.github.io/slack-mcp-server/public/demo-video.html">
   <meta property="og:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Slack MCP Server — Video Demo">
-  <meta name="twitter:description" content="Give Claude your Slack. 16 self-hosted tools plus a managed Cloud path with Gemini CLI support, deployment review, and hosted credentials.">
+  <meta name="twitter:description" content="Give Claude your Slack. 16 self-hosted tools plus a managed Cloud path with Gemini CLI support, security/procurement review, deployment review, and hosted credentials.">
   <meta name="twitter:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
   <link rel="icon" href="https://jtalk22.github.io/slack-mcp-server/docs/assets/icon-512.png" type="image/png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -181,11 +181,12 @@
       <a href="https://mcp.revasserlabs.com/pricing" target="_blank" rel="noopener noreferrer">Pricing</a>
       <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md" target="_blank" rel="noopener noreferrer">Setup Guide</a>
       <a href="https://mcp.revasserlabs.com/docs" target="_blank" rel="noopener noreferrer">Cloud Docs</a>
+      <a href="https://mcp.revasserlabs.com/security" target="_blank" rel="noopener noreferrer">Security</a>
       <a href="https://mcp.revasserlabs.com/deployment" target="_blank" rel="noopener noreferrer">Deployment Review</a>
       <a href="https://mcp.revasserlabs.com/support" target="_blank" rel="noopener noreferrer">Cloud Support</a>
       </div>
       <div class="note">
-        Self-host free for 16 tools and full transport control, or use <a href="https://mcp.revasserlabs.com/pricing" target="_blank" rel="noopener noreferrer">Cloud</a> for 15 managed tools, deployment review, and support. Solo starts at $19/mo; Team at $49/mo adds 3 AI workflows. Turnkey Team Launch starts at $2.5k+; Managed Reliability starts at $800/mo+.
+        Self-host free for 16 tools and full transport control, or use <a href="https://mcp.revasserlabs.com/pricing" target="_blank" rel="noopener noreferrer">Cloud</a> for 15 managed tools, deployment review, security/procurement review, and support. Solo starts at $19/mo; Team at $49/mo adds 3 AI workflows. Turnkey Team Launch starts at $2.5k+; Managed Reliability starts at $800/mo+.
       </div>
     </div>
 
@@ -203,7 +204,7 @@
     </div>
 
     <div class="back-link">
-      <a href="https://github.com/jtalk22/slack-mcp-server">GitHub</a> · <a href="https://mcp.revasserlabs.com/pricing" style="color:#f0c246;text-decoration:none;font-size:0.875rem">Cloud Plans</a> · <a href="https://mcp.revasserlabs.com/docs" style="color:#94a3b8;text-decoration:none;font-size:0.875rem">Cloud Docs</a> · <a href="https://mcp.revasserlabs.com/deployment" style="color:#94a3b8;text-decoration:none;font-size:0.875rem">Deployment Review</a> · <a href="https://mcp.revasserlabs.com/support" style="color:#94a3b8;text-decoration:none;font-size:0.875rem">Cloud Support</a> · <a href="https://www.npmjs.com/package/@jtalk22/slack-mcp" style="color:#94a3b8;text-decoration:none;font-size:0.875rem">npm</a>
+      <a href="https://github.com/jtalk22/slack-mcp-server">GitHub</a> · <a href="https://mcp.revasserlabs.com/pricing" style="color:#f0c246;text-decoration:none;font-size:0.875rem">Cloud Plans</a> · <a href="https://mcp.revasserlabs.com/docs" style="color:#94a3b8;text-decoration:none;font-size:0.875rem">Cloud Docs</a> · <a href="https://mcp.revasserlabs.com/security" style="color:#94a3b8;text-decoration:none;font-size:0.875rem">Security</a> · <a href="https://mcp.revasserlabs.com/deployment" style="color:#94a3b8;text-decoration:none;font-size:0.875rem">Deployment Review</a> · <a href="https://mcp.revasserlabs.com/support" style="color:#94a3b8;text-decoration:none;font-size:0.875rem">Cloud Support</a> · <a href="https://www.npmjs.com/package/@jtalk22/slack-mcp" style="color:#94a3b8;text-decoration:none;font-size:0.875rem">npm</a>
     </div>
   </div>
 

--- a/public/demo.html
+++ b/public/demo.html
@@ -752,11 +752,12 @@
       <a href="https://mcp.revasserlabs.com/pricing" target="_blank" rel="noopener noreferrer">Pricing</a>
       <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md" target="_blank" rel="noopener noreferrer">Setup Guide</a>
       <a href="https://mcp.revasserlabs.com/docs" target="_blank" rel="noopener noreferrer">Cloud Docs</a>
+      <a href="https://mcp.revasserlabs.com/security" target="_blank" rel="noopener noreferrer">Security</a>
       <a href="https://mcp.revasserlabs.com/deployment" target="_blank" rel="noopener noreferrer">Deployment Review</a>
       <a href="https://mcp.revasserlabs.com/support" target="_blank" rel="noopener noreferrer">Cloud Support</a>
     </div>
     <div class="cta-note">
-      Self-host free for 16 tools and full transport control, or use <a href="https://mcp.revasserlabs.com/pricing" target="_blank" rel="noopener noreferrer">Cloud</a> for 15 managed tools, deployment review, and support. Solo starts at $19/mo; Team at $49/mo adds 3 AI workflows. Turnkey Team Launch starts at $2.5k+; Managed Reliability starts at $800/mo+.
+      Self-host free for 16 tools and full transport control, or use <a href="https://mcp.revasserlabs.com/pricing" target="_blank" rel="noopener noreferrer">Cloud</a> for 15 managed tools, deployment review, security/procurement review, and support. Solo starts at $19/mo; Team at $49/mo adds 3 AI workflows. Turnkey Team Launch starts at $2.5k+; Managed Reliability starts at $800/mo+.
     </div>
   </div>
 

--- a/public/share.html
+++ b/public/share.html
@@ -4,17 +4,17 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Slack MCP Server</title>
-  <meta name="description" content="Session-based Slack MCP for Claude. Self-host locally or use the managed Cloud path with Gemini CLI support, pricing, deployment review, and hosted credentials.">
+  <meta name="description" content="Session-based Slack MCP for Claude. Self-host locally or use the managed Cloud path with Gemini CLI support, pricing, security/procurement review, deployment review, and hosted credentials.">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Slack MCP Server">
-  <meta property="og:description" content="Session-based Slack MCP for Claude. Self-host 16 tools for free or use Cloud for 15 managed tools, Gemini CLI support, deployment review, and support.">
+  <meta property="og:description" content="Session-based Slack MCP for Claude. Self-host 16 tools for free or use Cloud for 15 managed tools, Gemini CLI support, security/procurement review, deployment review, and support.">
   <meta property="og:url" content="https://jtalk22.github.io/slack-mcp-server/public/share.html">
   <meta property="og:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
   <meta property="og:image:width" content="1280">
   <meta property="og:image:height" content="640">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Slack MCP Server">
-  <meta name="twitter:description" content="Session-based Slack MCP for Claude. Self-host 16 tools for free or use Cloud for 15 managed tools, Gemini CLI support, deployment review, and support.">
+  <meta name="twitter:description" content="Session-based Slack MCP for Claude. Self-host 16 tools for free or use Cloud for 15 managed tools, Gemini CLI support, security/procurement review, deployment review, and support.">
   <meta name="twitter:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
   <link rel="icon" href="https://jtalk22.github.io/slack-mcp-server/docs/assets/icon-512.png" type="image/png">
   <style>
@@ -107,7 +107,7 @@
 <body>
   <main class="wrap">
     <h1>Slack MCP Server</h1>
-    <p class="sub">Give Claude full access to your Slack. Self-host 16 tools for free, or use Cloud for 15 managed tools, Gemini CLI support, hosted credentials, and rollout support.</p>
+    <p class="sub">Give Claude full access to your Slack. Self-host 16 tools for free, or use Cloud for 15 managed tools, Gemini CLI support, hosted credentials, rollout support, and buyer-facing security review.</p>
 
     <a class="preview" href="https://github.com/jtalk22/slack-mcp-server" rel="noopener">
       <img src="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png" alt="Slack MCP Server social preview card">
@@ -119,6 +119,7 @@
       <a href="https://github.com/jtalk22/slack-mcp-server/releases/latest" rel="noopener">Latest Release</a>
       <a href="https://mcp.revasserlabs.com/pricing" rel="noopener">Pricing</a>
       <a href="https://mcp.revasserlabs.com/docs" rel="noopener">Cloud Docs</a>
+      <a href="https://mcp.revasserlabs.com/security" rel="noopener">Security</a>
       <a href="https://mcp.revasserlabs.com/deployment" rel="noopener">Deployment Review</a>
       <a href="https://mcp.revasserlabs.com/support" rel="noopener">Cloud Support</a>
       <a href="https://mcp.revasserlabs.com/use-cases/support-triage" rel="noopener">Support Triage Use Case</a>
@@ -128,7 +129,7 @@
       <a href="https://mcp.revasserlabs.com" rel="noopener" style="background:rgba(240,194,70,0.18);border-color:rgba(240,194,70,0.45);color:#f0c246">Cloud</a>
     </div>
 
-    <p class="note"><strong>Verify in 30 seconds:</strong> <code>--version</code>, <code>--doctor</code>, <code>--status</code>. Self-host gives 16 tools and full operator control. Cloud starts at $19/mo for 15 managed tools, deployment review, and support. Team at $49/mo adds 3 AI workflows. Claude is the primary path; Gemini CLI is supported on the hosted endpoint.</p>
+    <p class="note"><strong>Verify in 30 seconds:</strong> <code>--version</code>, <code>--doctor</code>, <code>--status</code>. Self-host gives 16 tools and full operator control. Cloud starts at $19/mo for 15 managed tools, deployment review, security/procurement review, and support. Team at $49/mo adds 3 AI workflows. Claude is the primary path; Gemini CLI is supported on the hosted endpoint.</p>
   </main>
 </body>
 </html>

--- a/scripts/browser-smoke.js
+++ b/scripts/browser-smoke.js
@@ -219,7 +219,7 @@ async function runLocal() {
     await checkStaticPage(page, `${server.url}/public/share.html`, ".note", /Cloud starts at \$19\/mo/i, "share note");
     await checkStaticPage(page, `${server.url}/public/demo-video.html`, ".note", /Solo starts at \$19\/mo/i, "demo video note");
     await checkStaticPage(page, `${server.url}/public/demo.html`, ".cta-note", /Team at \$49\/mo adds 3 AI workflows/i, "demo note");
-    await checkStaticPage(page, `${server.url}/public/demo-claude.html`, ".note", /deployment review, and support/i, "demo claude note");
+    await checkStaticPage(page, `${server.url}/public/demo-claude.html`, ".note", /deployment review, security\/procurement review, and support/i, "demo claude note");
 
     if (errors.length > 0) {
       throw new Error(errors.join("\n"));

--- a/scripts/check-public-surface-integrity.js
+++ b/scripts/check-public-surface-integrity.js
@@ -155,10 +155,11 @@ function main() {
     readme.includes("Release health snapshot") &&
       readme.includes("Version parity report") &&
       readme.includes(PUBLIC_METADATA.cloudPricingUrl) &&
+      readme.includes(PUBLIC_METADATA.cloudSecurityUrl) &&
       readme.includes(PUBLIC_METADATA.cloudAccountUrl) &&
       readme.includes(PUBLIC_METADATA.cloudDeploymentUrl) &&
       readme.includes(PUBLIC_METADATA.cloudSupportUrl),
-    "README should link current release-health, version-parity, pricing, account, deployment, and support surfaces"
+    "README should link current release-health, version-parity, pricing, security, account, deployment, and support surfaces"
   );
 
   const marketingIndex = read("index.html");
@@ -180,10 +181,11 @@ function main() {
     "GitHub Pages cloud routing",
     marketingIndex.includes(PUBLIC_METADATA.cloudDocsUrl) &&
       marketingIndex.includes(PUBLIC_METADATA.cloudPricingUrl) &&
+      marketingIndex.includes(PUBLIC_METADATA.cloudSecurityUrl) &&
       marketingIndex.includes(PUBLIC_METADATA.cloudDeploymentUrl) &&
       marketingIndex.includes(PUBLIC_METADATA.cloudSupportUrl) &&
       marketingIndex.includes(`${PUBLIC_METADATA.canonicalSiteUrl}/privacy`),
-    "index.html should point Cloud routing at hosted pricing, docs, deployment, support, and privacy"
+    "index.html should point Cloud routing at hosted pricing, docs, security, deployment, support, and privacy"
   );
   check(
     results,
@@ -200,11 +202,12 @@ function main() {
     "Share surface cloud routing",
     sharePage.includes(PUBLIC_METADATA.cloudPricingUrl) &&
       sharePage.includes(PUBLIC_METADATA.cloudDocsUrl) &&
+      sharePage.includes(PUBLIC_METADATA.cloudSecurityUrl) &&
       sharePage.includes(PUBLIC_METADATA.cloudDeploymentUrl) &&
       sharePage.includes(PUBLIC_METADATA.cloudSupportUrl) &&
       !sharePage.includes("deployment-intake.md") &&
       !sharePage.includes("SUPPORT-BOUNDARIES.md"),
-    "share surface should send Cloud buyers to hosted pricing, docs, deployment review, and support"
+    "share surface should send Cloud buyers to hosted pricing, docs, security, deployment review, and support"
   );
   check(
     results,
@@ -219,10 +222,11 @@ function main() {
       results,
       `${demoPath} cloud routing`,
       demoPage.includes(PUBLIC_METADATA.cloudDocsUrl) &&
+        demoPage.includes(PUBLIC_METADATA.cloudSecurityUrl) &&
         demoPage.includes(PUBLIC_METADATA.cloudDeploymentUrl) &&
         demoPage.includes(PUBLIC_METADATA.cloudSupportUrl) &&
         !demoPage.includes("deployment-intake.md"),
-      `${demoPath} should keep Cloud routing on hosted docs, deployment review, and support`
+      `${demoPath} should keep Cloud routing on hosted docs, security, deployment review, and support`
     );
   }
 

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.jtalk22/slack-mcp-server",
   "title": "Slack MCP Server",
-  "description": "Claude-first Slack MCP for self-hosted local workflows or managed Cloud rollout, with Gemini CLI support and secure-default HTTP.",
+  "description": "Claude-first Slack MCP for self-hosted workflows or managed Cloud rollout, with Gemini CLI support, buyer-facing security review, and secure-default HTTP.",
   "websiteUrl": "https://mcp.revasserlabs.com",
   "icons": [
     {

--- a/templates/public-pages/demo-video.html.tpl
+++ b/templates/public-pages/demo-video.html.tpl
@@ -4,15 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Slack MCP Server — Video Demo</title>
-  <meta name="description" content="Give Claude your Slack. {{SELF_HOSTED_TOOL_COUNT}} self-hosted tools plus a managed Cloud path with Gemini CLI support, deployment review, and hosted credentials.">
+  <meta name="description" content="Give Claude your Slack. {{SELF_HOSTED_TOOL_COUNT}} self-hosted tools plus a managed Cloud path with Gemini CLI support, security/procurement review, deployment review, and hosted credentials.">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Slack MCP Server — Video Demo">
-  <meta property="og:description" content="Give Claude your Slack. {{SELF_HOSTED_TOOL_COUNT}} self-hosted tools plus a managed Cloud path with Gemini CLI support, deployment review, and hosted credentials.">
+  <meta property="og:description" content="Give Claude your Slack. {{SELF_HOSTED_TOOL_COUNT}} self-hosted tools plus a managed Cloud path with Gemini CLI support, security/procurement review, deployment review, and hosted credentials.">
   <meta property="og:url" content="{{GITHUB_PAGES_ROOT}}/public/demo-video.html">
   <meta property="og:image" content="{{SOCIAL_IMAGE_URL}}">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Slack MCP Server — Video Demo">
-  <meta name="twitter:description" content="Give Claude your Slack. {{SELF_HOSTED_TOOL_COUNT}} self-hosted tools plus a managed Cloud path with Gemini CLI support, deployment review, and hosted credentials.">
+  <meta name="twitter:description" content="Give Claude your Slack. {{SELF_HOSTED_TOOL_COUNT}} self-hosted tools plus a managed Cloud path with Gemini CLI support, security/procurement review, deployment review, and hosted credentials.">
   <meta name="twitter:image" content="{{SOCIAL_IMAGE_URL}}">
   <link rel="icon" href="{{ICON_URL}}" type="image/png">
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/templates/public-pages/index.html.tpl
+++ b/templates/public-pages/index.html.tpl
@@ -4,17 +4,17 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Slack MCP Server - Install in 30 Seconds</title>
-  <meta name="description" content="{{SELF_HOSTED_TOOL_COUNT}} self-hosted Slack MCP tools for Claude. Managed Cloud is Claude-first with Gemini CLI support, pricing, deployment review, and higher-touch rollout offers.">
+  <meta name="description" content="{{SELF_HOSTED_TOOL_COUNT}} self-hosted Slack MCP tools for Claude. Managed Cloud is Claude-first with Gemini CLI support, pricing, security/procurement review, deployment review, and higher-touch rollout offers.">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Slack MCP Server — Claude-first Slack MCP, self-hosted or managed">
-  <meta property="og:description" content="Give Claude your Slack. Self-host {{SELF_HOSTED_TOOL_COUNT}} tools for free, or use Cloud for {{CLOUD_MANAGED_TOOL_COUNT}} managed tools, Gemini CLI support, deployment review, and hosted credentials.">
+  <meta property="og:description" content="Give Claude your Slack. Self-host {{SELF_HOSTED_TOOL_COUNT}} tools for free, or use Cloud for {{CLOUD_MANAGED_TOOL_COUNT}} managed tools, Gemini CLI support, security/procurement review, deployment review, and hosted credentials.">
   <meta property="og:url" content="{{GITHUB_PAGES_ROOT}}/">
   <meta property="og:image" content="{{SOCIAL_IMAGE_URL}}">
   <meta property="og:image:width" content="1280">
   <meta property="og:image:height" content="640">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Slack MCP Server — Claude-first Slack MCP, self-hosted or managed">
-  <meta name="twitter:description" content="Give Claude your Slack. Self-host {{SELF_HOSTED_TOOL_COUNT}} tools for free, or use Cloud for {{CLOUD_MANAGED_TOOL_COUNT}} managed tools, Gemini CLI support, deployment review, and hosted credentials.">
+  <meta name="twitter:description" content="Give Claude your Slack. Self-host {{SELF_HOSTED_TOOL_COUNT}} tools for free, or use Cloud for {{CLOUD_MANAGED_TOOL_COUNT}} managed tools, Gemini CLI support, security/procurement review, deployment review, and hosted credentials.">
   <meta name="twitter:image" content="{{SOCIAL_IMAGE_URL}}">
   <link rel="icon" href="{{ICON_URL}}" type="image/png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -311,7 +311,7 @@
 npx -y @jtalk22/slack-mcp@latest --version
 npx -y @jtalk22/slack-mcp@latest --doctor
 npx -y @jtalk22/slack-mcp@latest --status</div>
-      <p class="verify" style="margin-top:12px">For rollout support, use deployment review. Solo starts at {{CLOUD_SOLO_PRICE}}, Team at {{CLOUD_TEAM_PRICE}}, Turnkey Team Launch at {{CLOUD_TURNKEY_LAUNCH_PRICE}}, and Managed Reliability at {{CLOUD_MANAGED_RELIABILITY_PRICE}}. Reproducible bugs and install blockers still go through standard issue triage.</p>
+      <p class="verify" style="margin-top:12px">For rollout support, use deployment review. For buyer-facing controls and procurement review, use the hosted security surface. Solo starts at {{CLOUD_SOLO_PRICE}}, Team at {{CLOUD_TEAM_PRICE}}, Turnkey Team Launch at {{CLOUD_TURNKEY_LAUNCH_PRICE}}, and Managed Reliability at {{CLOUD_MANAGED_RELIABILITY_PRICE}}. Reproducible bugs and install blockers still go through standard issue triage.</p>
     </section>
 
     <section class="stage" style="padding-top:0">

--- a/templates/public-pages/share.html.tpl
+++ b/templates/public-pages/share.html.tpl
@@ -4,17 +4,17 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Slack MCP Server</title>
-  <meta name="description" content="Session-based Slack MCP for Claude. Self-host locally or use the managed Cloud path with Gemini CLI support, pricing, deployment review, and hosted credentials.">
+  <meta name="description" content="Session-based Slack MCP for Claude. Self-host locally or use the managed Cloud path with Gemini CLI support, pricing, security/procurement review, deployment review, and hosted credentials.">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Slack MCP Server">
-  <meta property="og:description" content="Session-based Slack MCP for Claude. Self-host {{SELF_HOSTED_TOOL_COUNT}} tools for free or use Cloud for {{CLOUD_MANAGED_TOOL_COUNT}} managed tools, Gemini CLI support, deployment review, and support.">
+  <meta property="og:description" content="Session-based Slack MCP for Claude. Self-host {{SELF_HOSTED_TOOL_COUNT}} tools for free or use Cloud for {{CLOUD_MANAGED_TOOL_COUNT}} managed tools, Gemini CLI support, security/procurement review, deployment review, and support.">
   <meta property="og:url" content="{{GITHUB_PAGES_ROOT}}/public/share.html">
   <meta property="og:image" content="{{SOCIAL_IMAGE_URL}}">
   <meta property="og:image:width" content="1280">
   <meta property="og:image:height" content="640">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Slack MCP Server">
-  <meta name="twitter:description" content="Session-based Slack MCP for Claude. Self-host {{SELF_HOSTED_TOOL_COUNT}} tools for free or use Cloud for {{CLOUD_MANAGED_TOOL_COUNT}} managed tools, Gemini CLI support, deployment review, and support.">
+  <meta name="twitter:description" content="Session-based Slack MCP for Claude. Self-host {{SELF_HOSTED_TOOL_COUNT}} tools for free or use Cloud for {{CLOUD_MANAGED_TOOL_COUNT}} managed tools, Gemini CLI support, security/procurement review, deployment review, and support.">
   <meta name="twitter:image" content="{{SOCIAL_IMAGE_URL}}">
   <link rel="icon" href="{{ICON_URL}}" type="image/png">
   <style>
@@ -107,7 +107,7 @@
 <body>
   <main class="wrap">
     <h1>Slack MCP Server</h1>
-    <p class="sub">Give Claude full access to your Slack. Self-host {{SELF_HOSTED_TOOL_COUNT}} tools for free, or use Cloud for {{CLOUD_MANAGED_TOOL_COUNT}} managed tools, Gemini CLI support, hosted credentials, and rollout support.</p>
+    <p class="sub">Give Claude full access to your Slack. Self-host {{SELF_HOSTED_TOOL_COUNT}} tools for free, or use Cloud for {{CLOUD_MANAGED_TOOL_COUNT}} managed tools, Gemini CLI support, hosted credentials, rollout support, and buyer-facing security review.</p>
 
     <a class="preview" href="{{GITHUB_REPO_URL}}" rel="noopener">
       <img src="{{SOCIAL_IMAGE_URL}}" alt="Slack MCP Server social preview card">


### PR DESCRIPTION
## Summary

This PR aligns the public GitHub trust surface with the hosted hardening pass so GitHub Pages, README, release ops docs, and listing metadata all point at the same current hosted buyer-routing model.

- adds the hosted `/security` path to the public metadata layer, generated Pages surfaces, README, and commercial docs
- tightens the public Pages descriptions and generated links so search/share surfaces reflect security/procurement review as part of the Cloud path
- updates release and commercial runbook docs so hosted `/security` is treated as a first-class post-release trust surface
- aligns directory-facing descriptions in `server.json`, `glama.json`, and `package.json` with the current Cloud story
- extends the public integrity/browser checks so they fail if Cloud routing drops the new security surface

## Why this matters

The public repo is the proof and discovery layer for the product. If the hosted site gains new trust surfaces but the repo still routes buyers through older paths, GitHub becomes the lagging surface and weakens credibility. This PR keeps the public layer current and improves listing/search alignment without changing the published package version.

## Verification

- `node scripts/generate-public-pages.js`
- `node scripts/verify-generated-public-pages.js`
- `node scripts/check-public-surface-integrity.js`
- `node scripts/browser-smoke.js`
- `node scripts/release-preflight.js`
- `npm pack --dry-run`

## Follow-on after merge

- refresh public release-health and live smoke after hosted `0.7.1` is deployed
- if needed, republish MCP Registry metadata so the listing descriptions follow the updated source text
