### PR TITLE
[codex] refresh parity and listing metadata

### DIFF
--- a/docs/release-health/2026-03-11.md
+++ b/docs/release-health/2026-03-11.md
@@ -1,6 +1,6 @@
 # Release Health Snapshot
 
-- Generated: 2026-03-11T16:07:16.139Z
+- Generated: 2026-03-11T17:03:19.402Z
 - Repo: `jtalk22/slack-mcp-server`
 - Package: `@jtalk22/slack-mcp`
 

--- a/docs/release-health/latest.md
+++ b/docs/release-health/latest.md
@@ -1,6 +1,6 @@
 # Release Health Snapshot
 
-- Generated: 2026-03-11T16:07:16.139Z
+- Generated: 2026-03-11T17:03:19.402Z
 - Repo: `jtalk22/slack-mcp-server`
 - Package: `@jtalk22/slack-mcp`
 

--- a/docs/release-health/version-parity.md
+++ b/docs/release-health/version-parity.md
@@ -1,6 +1,6 @@
 # Version Parity Report
 
-- Generated: 2026-03-11T04:35:03.849Z
+- Generated: 2026-03-11T17:03:58.472Z
 - Local target version: 3.2.4
 
 ## Surface Matrix
@@ -13,16 +13,16 @@
 | npm dist-tag latest | 3.2.4 | ok |  |
 | MCP Registry latest | 3.2.4 | ok |  |
 | MCP Registry websiteUrl | https://mcp.revasserlabs.com | ok | expected: https://mcp.revasserlabs.com |
-| MCP Registry description | Session-based Slack MCP for Claude and MCP clients: local-first workflows, secure-default HTTP. | ok | expected_prefix: Session-based Slack MCP for Claude and MCP clients: local-first workflows, secure-default HTTP. |
+| MCP Registry description | Session-based Slack MCP for Claude and MCP clients: local-first workflows, secure-default HTTP. | mismatch | expected_prefix: Claude-first Slack MCP for self-host or managed Cloud, with Gemini CLI and secure-default HTTP. |
 | Smithery endpoint | n/a | reachable | status: 401; version check is manual. |
 
 ## Interpretation
 
 - Local metadata parity: pass.
-- External parity: pass.
+- External parity mismatch: MCP registry description prefix.
 
 ## Actionable Drift Notes
 
 - MCP registry `websiteUrl` matches local metadata.
-- MCP registry description prefix matches local metadata.
-- Propagation mode: not needed (external parity is already aligned).
+- MCP registry description drift detected. Registry metadata for the same version cannot be republished; carry the new description on the next publishable version.
+- Propagation mode enabled: external mismatch accepted temporarily.

--- a/glama.json
+++ b/glama.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "name": "slack-mcp-server",
-  "description": "Session-based Slack MCP for Claude and MCP clients. 16 local-first tools for channels, search, replies, reactions, unreads, and user search. Managed Cloud option with security/procurement review lives at mcp.revasserlabs.com.",
+  "description": "Session-based Slack MCP for Claude and MCP clients. 16 local-first tools. Managed Cloud lives at mcp.revasserlabs.com.",
   "repository": "https://github.com/jtalk22/slack-mcp-server",
   "homepage": "https://mcp.revasserlabs.com",
   "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@jtalk22/slack-mcp",
   "mcpName": "io.github.jtalk22/slack-mcp-server",
   "version": "3.2.4",
-  "description": "Claude-first Slack MCP for self-hosted workflows or managed Cloud rollout, with Gemini CLI support, buyer-facing security review, and secure-default HTTP.",
+  "description": "Claude-first Slack MCP for self-host or managed Cloud, with Gemini CLI and secure-default HTTP.",
   "type": "module",
   "main": "src/server.js",
   "bin": {

--- a/scripts/check-version-parity.js
+++ b/scripts/check-version-parity.js
@@ -109,6 +109,8 @@ async function main() {
     "MCP registry websiteUrl",
     "MCP registry description prefix",
   ]);
+  const registryDescriptionDrift =
+    !(typeof mcpRegistryDescription === "string" && mcpRegistryDescription.startsWith(expectedDescriptionPrefix));
   const externalMismatches = parityChecks
     .filter((check) => !check.ok && externalMismatchNames.has(check.name));
   const hardFailures = parityChecks
@@ -191,7 +193,9 @@ async function main() {
       : "- MCP registry `websiteUrl` drift detected. Re-publish metadata-bearing release info with `bash scripts/publish-mcp-registry.sh` after `mcp-publisher login`.",
     typeof mcpRegistryDescription === "string" && mcpRegistryDescription.startsWith(expectedDescriptionPrefix)
       ? "- MCP registry description prefix matches local metadata."
-      : "- MCP registry description drift detected. Align registry listing description with local `server.json` wording.",
+      : (mcpRegistryVersion === localVersion && registryDescriptionDrift
+          ? "- MCP registry description drift detected. Registry metadata for the same version cannot be republished; carry the new description on the next publishable version."
+          : "- MCP registry description drift detected. Align registry listing description with local `server.json` wording."),
     externalMismatches.length === 0
       ? "- Propagation mode: not needed (external parity is already aligned)."
       : (allowPropagation

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.jtalk22/slack-mcp-server",
   "title": "Slack MCP Server",
-  "description": "Claude-first Slack MCP for self-hosted workflows or managed Cloud rollout, with Gemini CLI support, buyer-facing security review, and secure-default HTTP.",
+  "description": "Claude-first Slack MCP for self-host or managed Cloud, with Gemini CLI and secure-default HTTP.",
   "websiteUrl": "https://mcp.revasserlabs.com",
   "icons": [
     {


### PR DESCRIPTION
## Summary

This PR is a post-deploy follow-up that refreshes the public parity artifacts and tightens directory-facing metadata after the hosted `0.7.1` deploy.

- shortens `server.json` and package metadata descriptions to a MCP Registry-valid length
- refreshes the public release-health and version-parity reports against the current live state
- updates the parity script note so it accurately explains the remaining registry description drift: the registry rejects metadata-only republish for the same published version

## Why this matters

After the hosted hardening pass went live, the public reports needed one more refresh. I also validated the MCP Registry publish path and confirmed that the remaining description drift is not a repo-state bug or auth problem; it is a duplicate-version publish constraint. This PR makes the public docs say that explicitly instead of implying the repo simply forgot to publish.

## Verification

- `bash scripts/publish-mcp-registry.sh server.json --validate-only`
- `mcp-publisher login github -token "$(gh auth token)"`
- attempted registry publish and confirmed duplicate-version rejection for metadata-only update
- `node scripts/check-version-parity.js --public --allow-propagation`
- `node scripts/collect-release-health.js --public`
- `node scripts/check-public-surface-integrity.js`
- `npm pack --dry-run`
