### PR TITLE
chore: refresh registry parity metadata

### DIFF
--- a/docs/COMMERCIAL-SURFACE.md
+++ b/docs/COMMERCIAL-SURFACE.md
@@ -90,6 +90,6 @@ flowchart TD
 - Add more named workflow proof to the public Pages surface.
 - Keep public buyer-trust links routed to hosted `/security`, `/deployment`, and `/support`.
 - Pull hosted funnel summary into release-health whenever admin auth is available.
-- Ship `3.2.5` specifically to close MCP Registry description drift and refresh downstream crawlers.
+- Keep `3.2.5` as the metadata baseline that closed MCP Registry description drift, then monitor secondary crawlers for lag.
 - Keep README and Pages focused on trust, not feature bloat.
 - Continue reducing GitHub-side noise so public history looks operator-led.

--- a/docs/DISTRIBUTION-LEDGER.md
+++ b/docs/DISTRIBUTION-LEDGER.md
@@ -1,6 +1,6 @@
 # Distribution Ledger
 
-Checked: March 11, 2026
+Checked: March 12, 2026
 
 This ledger tracks the current public discovery surfaces for Slack MCP and the next corrective action for each one.
 
@@ -9,17 +9,17 @@ This ledger tracks the current public discovery surfaces for Slack MCP and the n
 - Public package and self-host docs: this repo
 - Canonical homepage: `https://mcp.revasserlabs.com`
 - Canonical package metadata: `package.json`, `server.json`, `glama.json`
-- Next metadata-bearing public release: `3.2.5`
+- Next metadata-bearing public release: `3.2.6+` if metadata drifts again or a listing-facing fix requires republish
 
 ## Current External Surface
 
 | Surface | Current state | Evidence (March 11, 2026) | Owner | Next action |
 |---|---|---|---|---|
-| MCP Registry | Version and homepage aligned; description still stale | Registry API returns `3.2.4`, `websiteUrl=https://mcp.revasserlabs.com`, description still says `Session-based Slack MCP for Claude and MCP clients: local-first workflows, secure-default HTTP.` | Revasser / jtalk22 | Publish `3.2.5` so the new canonical description can propagate |
-| Glama | Metadata prepared locally; public correction still pending | `glama.json` is updated for `3.2.5`; public ticket already opened; stable public listing not yet confirmed in search | Revasser / jtalk22 | Re-check after `3.2.5` publish and after the Glama correction closes |
-| mcp.so | Listing reachable, but copy is stale and self-host-only | Browser fetch returns title `Slack Mcp Server MCP Server` and meta description focused on browser token auth and Claude-only setup | Third-party index | Monitor next crawl after `3.2.5`; request correction if description remains stale |
-| PulseMCP | Indexed listing appears stale or removed | Direct request to `https://www.pulsemcp.com/servers/jtalk22-slack-mcp-server` returns `404` | Third-party index | Treat as stale index drift; re-check after `3.2.5` and remove from active acquisition assumptions until it resolves |
-| Smithery | Endpoint/listing surface exists but is not easy to validate from unattended scripts | Public CLI check currently hits rate-limit/challenge behavior; version parity script still treats endpoint reachability as manual | Third-party index | Do manual browser verification after `3.2.5`; keep as secondary monitoring surface, not a primary acquisition bet |
+| MCP Registry | Fully aligned on version, homepage, and canonical short description | Registry API returns `3.2.5`, `websiteUrl=https://mcp.revasserlabs.com`, description `Slack MCP for self-host or managed Cloud, with Gemini CLI and secure-default HTTP.` | Revasser / jtalk22 | No immediate action; keep parity checks in release cadence |
+| Glama | Local metadata is current; public correction still pending external follow-through | `glama.json` is updated for `3.2.5`; correction ticket is already open; stable public listing still not confirmed from search | Revasser / jtalk22 | Re-check after the Glama correction closes and record the resulting public state |
+| mcp.so | Listing reachable, but copy is still stale and Claude/browser-token-heavy | Browser fetch returns title `Slack Mcp Server MCP Server` and meta description focused on browser token auth and Claude-only setup | Third-party index | Monitor the next crawl and request correction if the stale description persists |
+| PulseMCP | Indexed listing appears stale or removed | Direct request to `https://www.pulsemcp.com/servers/jtalk22-slack-mcp-server` still returns `404` | Third-party index | Treat as stale index drift; remove from active acquisition assumptions until it resolves |
+| Smithery | Endpoint/listing surface exists but is still awkward to validate from unattended scripts | Public CLI/browser checks still hit rate-limit or challenge behavior; parity script treats endpoint reachability as manual | Third-party index | Keep as secondary monitoring surface and do periodic manual verification |
 
 ## Release Discipline
 
@@ -33,6 +33,6 @@ For any metadata-bearing release:
 
 ## Current Risk Read
 
-- The biggest live mismatch is descriptive, not structural: MCP Registry is pointing at the correct homepage but still carrying older description text until `3.2.5` ships.
-- Secondary directories are less reliable than GitHub, npm, the hosted site, and MCP Registry.
-- Treat Google, GitHub, and MCP Registry as the primary acquisition stack; treat the rest as parity surfaces that still need periodic hygiene.
+- MCP Registry is now aligned; the remaining discovery drift is mostly in secondary directories.
+- Secondary directories are still less reliable than GitHub, npm, the hosted site, and MCP Registry.
+- Treat Google, GitHub, the hosted site, and MCP Registry as the primary acquisition stack; treat the rest as parity surfaces that still need periodic hygiene.

--- a/docs/release-health/2026-03-11.md
+++ b/docs/release-health/2026-03-11.md
@@ -1,6 +1,6 @@
 # Release Health Snapshot
 
-- Generated: 2026-03-12T00:09:37.669Z
+- Generated: 2026-03-12T00:32:45.999Z
 - Repo: `jtalk22/slack-mcp-server`
 - Package: `@jtalk22/slack-mcp`
 
@@ -8,7 +8,7 @@
 
 - npm downloads (last week): 195
 - npm downloads (last month): 1611
-- npm latest version: 3.2.4
+- npm latest version: 3.2.5
 
 ## GitHub Reach
 

--- a/docs/release-health/latest.md
+++ b/docs/release-health/latest.md
@@ -1,6 +1,6 @@
 # Release Health Snapshot
 
-- Generated: 2026-03-12T00:09:37.669Z
+- Generated: 2026-03-12T00:32:45.999Z
 - Repo: `jtalk22/slack-mcp-server`
 - Package: `@jtalk22/slack-mcp`
 
@@ -8,7 +8,7 @@
 
 - npm downloads (last week): 195
 - npm downloads (last month): 1611
-- npm latest version: 3.2.4
+- npm latest version: 3.2.5
 
 ## GitHub Reach
 

--- a/docs/release-health/version-parity.md
+++ b/docs/release-health/version-parity.md
@@ -1,6 +1,6 @@
 # Version Parity Report
 
-- Generated: 2026-03-12T00:09:38.739Z
+- Generated: 2026-03-12T00:32:42.881Z
 - Local target version: 3.2.5
 
 ## Surface Matrix
@@ -10,19 +10,19 @@
 | package.json | 3.2.5 | ok |  |
 | server.json (root) | 3.2.5 | ok |  |
 | server.json (package entry) | 3.2.5 | ok |  |
-| npm dist-tag latest | 3.2.4 | mismatch |  |
-| MCP Registry latest | 3.2.4 | mismatch |  |
+| npm dist-tag latest | 3.2.5 | ok |  |
+| MCP Registry latest | 3.2.5 | ok |  |
 | MCP Registry websiteUrl | https://mcp.revasserlabs.com | ok | expected: https://mcp.revasserlabs.com |
-| MCP Registry description | Session-based Slack MCP for Claude and MCP clients: local-first workflows, secure-default HTTP. | mismatch | expected_prefix: Claude-first Slack MCP for self-host or managed Cloud, with Gemini CLI, deployment review, and secure-default HTTP. |
+| MCP Registry description | Slack MCP for self-host or managed Cloud, with Gemini CLI and secure-default HTTP. | ok | expected_prefix: Slack MCP for self-host or managed Cloud, with Gemini CLI and secure-default HTTP. |
 | Smithery endpoint | n/a | reachable | status: 401; version check is manual. |
 
 ## Interpretation
 
 - Local metadata parity: pass.
-- External parity mismatch: npm latest, MCP registry latest, MCP registry description prefix.
+- External parity: pass.
 
 ## Actionable Drift Notes
 
 - MCP registry `websiteUrl` matches local metadata.
-- MCP registry description drift detected. Align registry listing description with local `server.json` wording.
-- Propagation mode enabled: external mismatch accepted temporarily.
+- MCP registry description prefix matches local metadata.
+- Propagation mode: not needed (external parity is already aligned).

--- a/glama.json
+++ b/glama.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "name": "slack-mcp-server",
-  "description": "Claude-first Slack MCP for self-host or managed Cloud, with Gemini CLI, deployment review, and secure-default HTTP.",
+  "description": "Slack MCP for self-host or managed Cloud, with Gemini CLI and secure-default HTTP.",
   "repository": "https://github.com/jtalk22/slack-mcp-server",
   "homepage": "https://mcp.revasserlabs.com",
   "version": "3.2.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@jtalk22/slack-mcp",
   "mcpName": "io.github.jtalk22/slack-mcp-server",
   "version": "3.2.5",
-  "description": "Claude-first Slack MCP for self-host or managed Cloud, with Gemini CLI, deployment review, and secure-default HTTP.",
+  "description": "Slack MCP for self-host or managed Cloud, with Gemini CLI and secure-default HTTP.",
   "type": "module",
   "main": "src/server.js",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.jtalk22/slack-mcp-server",
   "title": "Slack MCP Server",
-  "description": "Claude-first Slack MCP for self-host or managed Cloud, with Gemini CLI, deployment review, and secure-default HTTP.",
+  "description": "Slack MCP for self-host or managed Cloud, with Gemini CLI and secure-default HTTP.",
   "websiteUrl": "https://mcp.revasserlabs.com",
   "icons": [
     {


### PR DESCRIPTION
## Summary
- shorten the directory-facing metadata description to the MCP Registry validator limit
- refresh public parity and release-health docs against the live 3.2.5 state
- update the distribution ledger to reflect that MCP Registry is now aligned and secondary directories are the remaining drift surface

## Verification
- node scripts/check-public-surface-integrity.js
- node scripts/check-version-parity.js --public
- node scripts/check-version-parity.js
- node scripts/collect-release-health.js --public
- bash scripts/publish-mcp-registry.sh server.json