### PR TITLE
docs: refresh release health for hosted 0.8.5

### DIFF
--- a/docs/release-health/2026-03-12.md
+++ b/docs/release-health/2026-03-12.md
@@ -1,6 +1,6 @@
 # Release Health Snapshot
 
-- Generated: 2026-03-12T06:09:10.711Z
+- Generated: 2026-03-12T06:25:40.569Z
 - Repo: `jtalk22/slack-mcp-server`
 - Package: `@jtalk22/slack-mcp`
 

--- a/docs/release-health/latest.md
+++ b/docs/release-health/latest.md
@@ -1,6 +1,6 @@
 # Release Health Snapshot
 
-- Generated: 2026-03-12T06:09:10.711Z
+- Generated: 2026-03-12T06:25:40.569Z
 - Repo: `jtalk22/slack-mcp-server`
 - Package: `@jtalk22/slack-mcp`
 


### PR DESCRIPTION
## Summary
- refresh public release-health snapshots after the hosted 0.8.5 deploy
- keep the repo's current-state docs aligned with the live hosted surface

## Verification
- node scripts/collect-release-health.js --public
- node scripts/check-version-parity.js