### PR TITLE
fix: accept polished cloud fallback label

### DIFF
--- a/scripts/browser-smoke.js
+++ b/scripts/browser-smoke.js
@@ -183,7 +183,7 @@ async function checkRoot(page, url, { allowHostedStatusFallback = false } = {}) 
     return { cloudState: "ok" };
   }
 
-  if (allowHostedStatusFallback && /^Open \/status$/i.test(snapshot.cloud)) {
+  if (allowHostedStatusFallback && /^(Open \/status|Status available)$/i.test(snapshot.cloud)) {
     assertText(snapshot.cloudNote, /raw status JSON/i, "#cloudHealthNote");
     assertText(snapshot.cloudNote, /Cross-origin status lookup unavailable/i, "#cloudHealthNote");
     return { cloudState: "fallback" };


### PR DESCRIPTION
## Summary
- keep the public live browser smoke aligned with the polished GitHub Pages fallback label
- accept `Status available` as the documented hosted-status fallback alongside the older label

## Verification
- node scripts/browser-smoke.js
- node scripts/browser-smoke.js --mode live --base-url https://jtalk22.github.io/slack-mcp-server --retries 4 --retry-delay-ms 3000