### PR TITLE
chore(ci): add safe Dependabot posture

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "06:30"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 2
+    rebase-strategy: "disabled"
+    labels: ["dependencies", "slack-mcp-server"]
+    groups:
+      npm-all:
+        patterns: ["*"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "06:45"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 1
+    rebase-strategy: "disabled"
+    labels: ["dependencies", "ci"]
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/ai-review-noise-guard.yml
+++ b/.github/workflows/ai-review-noise-guard.yml
@@ -1,96 +1,24 @@
-name: AI Review Noise Guard
+name: AI Review Noise Guard (parked)
 
 on:
-  issue_comment:
-    types: [created]
-  pull_request_review:
-    types: [submitted]
-  pull_request_review_comment:
-    types: [created]
+  workflow_dispatch:
 
 permissions:
   issues: write
   pull-requests: write
 
 jobs:
-  minimize-unsolicited-ai-review:
-    if: >
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request) ||
-      github.event_name == 'pull_request_review' ||
-      github.event_name == 'pull_request_review_comment'
+  parked:
     runs-on: ubuntu-latest
     steps:
-      - name: Minimize unsolicited AI review artifacts
-        env:
-          GH_TOKEN: ${{ github.token }}
-          OPT_IN_LABEL: manual-ai-review
+      - name: Explain parked status
         run: |
-          python3 - <<'PY'
-          import json
-          import os
-          import subprocess
-          import sys
+          cat <<'MSG'
+          This workflow is parked during GitHub sprawl recovery.
 
-          BOT_AUTHORS = {
-              "gemini-code-assist",
-              "coderabbitai",
-              "chatgpt-codex-connector",
-          }
+          Why:
+          - It manages AI review artifact noise rather than core OSS product health.
+          - It can be restored later if manual-ai-review becomes a real maintainer burden.
 
-          with open(os.environ["GITHUB_EVENT_PATH"], "r", encoding="utf-8") as handle:
-              event = json.load(handle)
-
-          event_name = os.environ["GITHUB_EVENT_NAME"]
-          repository = os.environ["GITHUB_REPOSITORY"]
-          opt_in_label = os.environ["OPT_IN_LABEL"]
-
-          if event_name == "issue_comment":
-              if not event.get("issue", {}).get("pull_request"):
-                  print("Issue comment is not on a pull request.")
-                  sys.exit(0)
-              subject = event["comment"]
-              pr_number = event["issue"]["number"]
-          elif event_name == "pull_request_review":
-              subject = event["review"]
-              pr_number = event["pull_request"]["number"]
-          elif event_name == "pull_request_review_comment":
-              subject = event["comment"]
-              pr_number = event["pull_request"]["number"]
-          else:
-              print(f"Unsupported event: {event_name}")
-              sys.exit(0)
-
-          author = subject["user"]["login"]
-          normalized_author = author[:-5] if author.endswith("[bot]") else author
-          node_id = subject.get("node_id")
-
-          if normalized_author not in BOT_AUTHORS:
-              print(f"Author {author} is not managed by this guard.")
-              sys.exit(0)
-
-          if not node_id:
-              print("Event payload did not include a node_id.")
-              sys.exit(1)
-
-          labels_raw = subprocess.check_output(
-              ["gh", "api", f"repos/{repository}/issues/{pr_number}/labels"],
-              text=True,
-          )
-          labels = {label["name"] for label in json.loads(labels_raw)}
-
-          if opt_in_label in labels:
-              print(f"Label {opt_in_label} present; leaving AI review artifact visible.")
-              sys.exit(0)
-
-          mutation = (
-              "mutation($id:ID!) { "
-              "minimizeComment(input:{subjectId:$id,classifier:OUTDATED}) { "
-              "minimizedComment { isMinimized minimizedReason } "
-              "} }"
-          )
-
-          subprocess.check_call(
-              ["gh", "api", "graphql", "-f", f"query={mutation}", "-f", f"id={node_id}"]
-          )
-          print(f"Minimized unsolicited AI review artifact from {author} on PR #{pr_number}.")
-          PY
+          Restore the event-driven triggers from git history if you need this guard again.
+          MSG

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,61 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-Merge Safe Updates
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7  # pin:v2.4.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge patch updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: |
+          gh pr review --approve "$PR_URL" --body "Auto-approved: patch dependency update" || echo "::notice::Approval skipped"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Auto-merge GitHub Actions updates
+        if: steps.metadata.outputs.package-ecosystem == 'github-actions'
+        run: |
+          gh pr review --approve "$PR_URL" --body "Auto-approved: GitHub Actions update" || echo "::notice::Approval skipped"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Auto-merge minor development updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
+          steps.metadata.outputs.dependency-type == 'direct:development'
+        run: |
+          gh pr review --approve "$PR_URL" --body "Auto-approved: minor development dependency update" || echo "::notice::Approval skipped"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Summary
+        run: |
+          echo "## Dependabot Auto-Merge" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Package | ${{ steps.metadata.outputs.dependency-names }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Update type | ${{ steps.metadata.outputs.update-type }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Ecosystem | ${{ steps.metadata.outputs.package-ecosystem }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Dependency type | ${{ steps.metadata.outputs.dependency-type }} |" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Why
The public Slack repo is canonical OSS/proof, so it should keep strong CI, release-health, attribution, and distribution trust signals — but it should not require manual babysitting for every safe patch or GitHub Actions update. This PR adds the same low-ceremony, per-repo Dependabot posture now used on the private canonical repos.

## What changed
- added .github/dependabot.yml for weekly npm + GitHub Actions updates
- added .github/workflows/dependabot-auto-merge.yml
- kept auto-merge limited to:
  - semver patch updates
  - GitHub Actions updates
  - semver minor direct development dependency updates
- parked AI Review Noise Guard behind manual dispatch only so public repo noise stays tied to OSS health, not bot-artifact minimization theatre

## Live repo setting already aligned
- allow_auto_merge = true
- delete_branch_on_merge = true
- existing main protection remains intact: test (20.x), test (22.x), lint, attribution

## Validation
- YAML parse: .github/dependabot.yml
- YAML parse: .github/workflows/dependabot-auto-merge.yml
- YAML parse: .github/workflows/ai-review-noise-guard.yml
- git diff --check

## Next
- keep public proof surfaces sharp: README, demos, install proof, release health, attribution, registry metadata
- use hosted for commercial depth; do not pull private runtime concerns back into the OSS repo