### PR TITLE
chore: tighten server proof and dependabot hygiene

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,31 @@ updates:
       npm-all:
         patterns: ["*"]
 
+  - package-ecosystem: "npm"
+    directory: "/workers/browser-ops"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "06:35"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 1
+    rebase-strategy: "disabled"
+    labels: ["dependencies", "browser-ops"]
+    groups:
+      browser-ops:
+        patterns: ["*"]
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "06:40"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 1
+    rebase-strategy: "disabled"
+    labels: ["dependencies", "docker"]
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/docs/LAUNCH-OPS.md
+++ b/docs/LAUNCH-OPS.md
@@ -94,6 +94,8 @@ node scripts/browser-smoke.js --mode live --base-url https://jtalk22.github.io/s
 - GitHub Pages live browser smoke workflow passes against `https://jtalk22.github.io/slack-mcp-server/`.
 - Hosted deployment review routing is visible on the current repo trust surfaces.
 
+Use [`docs/release-health/launch-log-template.md`](release-health/launch-log-template.md) to record each public distribution action and observed outcome while the release fanout is in flight.
+
 ## Monitoring Cadence
 
 - First 4 hours: every 30 minutes

--- a/docs/release-health/launch-log-template.md
+++ b/docs/release-health/launch-log-template.md
@@ -1,0 +1,21 @@
+# Launch Log Template
+
+Use this template to record public distribution actions and outcomes.
+
+## Entry Format
+
+| UTC Timestamp | Channel | Action | URL | Outcome | Notes |
+|---|---|---|---|---|---|
+| 2026-02-26T00:00:00Z | GitHub | Published release | <url> | success/pending/fail | <note> |
+
+## Recommended Channels
+
+- GitHub release
+- npm publish
+- MCP registry update
+- Smithery update
+- awesome-mcp-servers PR
+- Glama listing update
+- HN post/comment
+- X thread
+- Reddit post


### PR DESCRIPTION
Why
The public Slack canon still had two low-risk holes: no reusable launch-log template in the active release-health docs, and Dependabot was not watching the browser-ops worker or Docker image.

What changed
- add `docs/release-health/launch-log-template.md` from the remaining dev public-proof delta
- reference the template from `docs/LAUNCH-OPS.md`
- expand `.github/dependabot.yml` to cover `/workers/browser-ops` and the root `Dockerfile`

Validation
- YAML parse of `.github/dependabot.yml`
- `git diff --check`

Outcome
The public repo keeps the one missing reusable proof artifact and stops carrying obvious Dependabot blind spots.