### PR TITLE
polish: h264 video, play button poster, css fixes, schema.org

### DIFF
--- a/public/demo-claude.html
+++ b/public/demo-claude.html
@@ -107,6 +107,11 @@
 
       /* Shadows */
       --shadow-lg: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+
+      /* Z-index scale */
+      --z-caption: 50;
+      --z-dropdown: 100;
+      --z-modal: 200;
     }
 
     /* ═══════════════════════════════════════════════════════════════
@@ -650,7 +655,7 @@
     .tool-chevron {
       color: var(--text-muted);
       transition: transform 0.3s ease;
-      font-size: 10px;
+      font-size: 12px;
     }
 
     .tool-call.expanded .tool-chevron {
@@ -844,7 +849,7 @@
       visibility: hidden;
       transform: translateY(10px);
       transition: all 0.2s ease;
-      z-index: 100;
+      z-index: var(--z-dropdown);
     }
 
     .tools-button:hover .tools-dropdown,
@@ -938,7 +943,7 @@
       display: inline-block;
       padding: 2px 6px;
       font-family: var(--font-mono);
-      font-size: 10px;
+      font-size: 12px;
       background: rgba(255, 255, 255, 0.1);
       border: 1px solid rgba(255, 255, 255, 0.2);
       border-radius: 4px;
@@ -1140,11 +1145,12 @@
       align-items: center;
       justify-content: center;
       background: var(--window-bg);
-      z-index: 100;
+      z-index: var(--z-modal);
       opacity: 0;
       visibility: hidden;
       pointer-events: none;
       transition: opacity 0.5s ease, visibility 0s linear 0.5s;
+      will-change: opacity;
     }
 
     .title-card.visible {
@@ -1199,7 +1205,7 @@
       letter-spacing: 0.01em;
       opacity: 0;
       transition: opacity 0.3s ease;
-      z-index: 50;
+      z-index: var(--z-caption);
       pointer-events: none;
       max-width: calc(100% - 24px);
       white-space: nowrap;
@@ -1230,11 +1236,12 @@
       align-items: center;
       justify-content: center;
       background: var(--window-bg);
-      z-index: 100;
+      z-index: var(--z-modal);
       opacity: 0;
       visibility: hidden;
       pointer-events: none;
       transition: opacity 0.5s ease, visibility 0s linear 0.5s;
+      will-change: opacity;
     }
 
     .closing-card.visible {

--- a/public/demo-video.html
+++ b/public/demo-video.html
@@ -34,9 +34,14 @@
     "description": "Watch an AI handle 47 unread Slack messages without opening Slack. 16 tools, one command, no OAuth. Works with Claude, Cursor, Copilot, Gemini.",
     "thumbnailUrl": "https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png",
     "uploadDate": "2026-03-30",
-    "contentUrl": "https://jtalk22.github.io/slack-mcp-server/docs/videos/demo-claude.webm",
+    "contentUrl": "https://jtalk22.github.io/slack-mcp-server/docs/videos/demo-claude.mp4",
     "embedUrl": "https://jtalk22.github.io/slack-mcp-server/public/demo-video.html",
-    "duration": "PT3M",
+    "duration": "PT3M33S",
+    "author": {
+      "@type": "Person",
+      "name": "James Lambert",
+      "url": "https://github.com/jtalk22"
+    },
     "publisher": {
       "@type": "Organization",
       "name": "Revasser",
@@ -217,8 +222,8 @@
 
     <div class="video-wrapper">
       <video id="demo" poster="../docs/images/demo-poster.png" playsinline autoplay muted loop>
+        <source src="../docs/videos/demo-claude.mp4" type="video/mp4">
         <source src="../docs/videos/demo-claude.webm" type="video/webm">
-        <source src="https://jtalk22.github.io/slack-mcp-server/docs/videos/demo-claude.webm" type="video/webm">
         Your browser does not support the video tag.
       </video>
     </div>

--- a/scripts/capture-screenshots.js
+++ b/scripts/capture-screenshots.js
@@ -7,6 +7,7 @@
 import { chromium } from 'playwright';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { readFileSync } from 'fs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -108,6 +109,27 @@ async function captureScreenshots() {
       clip: { x: 0, y: 0, width: 1280, height: 800 }
     });
     await context.close();
+  }
+
+  // Composite a play-button overlay onto the poster so README viewers
+  // know it's a clickable video link, not just a static screenshot.
+  {
+    const posterPath = join(imagesDir, 'demo-poster.png');
+    const posterB64 = readFileSync(posterPath).toString('base64');
+    const overlayHTML = `
+      <html><body style="margin:0;padding:0;width:1280px;height:800px;position:relative">
+        <img src="data:image/png;base64,${posterB64}" style="width:1280px;height:800px;display:block">
+        <div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center">
+          <div style="width:88px;height:88px;background:rgba(218,119,86,0.82);border-radius:50%;display:flex;align-items:center;justify-content:center;box-shadow:0 4px 24px rgba(0,0,0,0.5)">
+            <div style="width:0;height:0;border-style:solid;border-width:18px 0 18px 30px;border-color:transparent transparent transparent #fff;margin-left:4px"></div>
+          </div>
+        </div>
+      </body></html>`;
+    const ctx2 = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+    const pg2 = await ctx2.newPage();
+    await pg2.setContent(overlayHTML, { waitUntil: 'load' });
+    await pg2.screenshot({ path: posterPath, clip: { x: 0, y: 0, width: 1280, height: 800 } });
+    await ctx2.close();
   }
 
   // Mobile captures for web, demo, and claude demo pages

--- a/scripts/record-demo.js
+++ b/scripts/record-demo.js
@@ -10,7 +10,8 @@
 import { chromium } from 'playwright';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
-import { mkdirSync, existsSync, copyFileSync } from 'fs';
+import { mkdirSync, existsSync, copyFileSync, statSync } from 'fs';
+import { spawnSync } from 'child_process';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -150,21 +151,41 @@ async function recordDemo() {
   const videoPath = await video.path();
   copyFileSync(videoPath, canonicalOutput);
 
+  // ── Encode H.264 MP4 from WebM ──────────────────────────────
+  // Playwright records VP8 WebM (~9MB). Re-encode to H.264 MP4
+  // for universal browser support and ~85% smaller file size.
+  const mp4Output = canonicalOutput.replace(/\.webm$/, '.mp4');
+  const ffprobe = spawnSync('ffmpeg', ['-version'], { stdio: 'ignore' });
+  if (ffprobe.status === 0) {
+    console.log('🎞️  Encoding H.264 MP4...');
+    const enc = spawnSync('ffmpeg', [
+      '-y', '-i', canonicalOutput,
+      '-c:v', 'libx264', '-preset', 'slow', '-crf', '18',
+      '-pix_fmt', 'yuv420p', '-movflags', '+faststart',
+      mp4Output,
+    ], { stdio: 'inherit' });
+    if (enc.status === 0) {
+      const webmSize = (statSync(canonicalOutput).size / 1048576).toFixed(1);
+      const mp4Size = (statSync(mp4Output).size / 1048576).toFixed(1);
+      console.log(`   WebM: ${webmSize} MB → MP4: ${mp4Size} MB`);
+    } else {
+      console.warn('   ⚠️  H.264 encode failed — WebM still available');
+    }
+  } else {
+    console.log('ℹ️  FFmpeg not found — skipping H.264 encode (WebM only)');
+  }
+
   console.log();
   console.log('╔════════════════════════════════════════════════════════════╗');
   console.log('║  ✅ Recording Complete                                     ║');
   console.log('╚════════════════════════════════════════════════════════════╝');
   console.log();
   console.log(`📹 Video: ${canonicalOutput}`);
+  if (existsSync(mp4Output)) console.log(`📹 MP4:   ${mp4Output}`);
   if (archiveOutput) {
     copyFileSync(videoPath, timestampedOutput);
     console.log(`🗂️  Archive: ${timestampedOutput}`);
   }
-  console.log();
-  console.log('Next steps:');
-  console.log('  1. Review in a media player');
-  console.log('  2. Optional GIF:');
-  console.log(`     ffmpeg -y -i "${canonicalOutput}" -vf "fps=12,scale=800:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse" docs/images/demo-claude.gif`);
 }
 
 recordDemo().catch(err => {

--- a/templates/public-pages/demo-claude.html.tpl
+++ b/templates/public-pages/demo-claude.html.tpl
@@ -107,6 +107,11 @@
 
       /* Shadows */
       --shadow-lg: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+
+      /* Z-index scale */
+      --z-caption: 50;
+      --z-dropdown: 100;
+      --z-modal: 200;
     }
 
     /* ═══════════════════════════════════════════════════════════════
@@ -650,7 +655,7 @@
     .tool-chevron {
       color: var(--text-muted);
       transition: transform 0.3s ease;
-      font-size: 10px;
+      font-size: 12px;
     }
 
     .tool-call.expanded .tool-chevron {
@@ -844,7 +849,7 @@
       visibility: hidden;
       transform: translateY(10px);
       transition: all 0.2s ease;
-      z-index: 100;
+      z-index: var(--z-dropdown);
     }
 
     .tools-button:hover .tools-dropdown,
@@ -938,7 +943,7 @@
       display: inline-block;
       padding: 2px 6px;
       font-family: var(--font-mono);
-      font-size: 10px;
+      font-size: 12px;
       background: rgba(255, 255, 255, 0.1);
       border: 1px solid rgba(255, 255, 255, 0.2);
       border-radius: 4px;
@@ -1140,11 +1145,12 @@
       align-items: center;
       justify-content: center;
       background: var(--window-bg);
-      z-index: 100;
+      z-index: var(--z-modal);
       opacity: 0;
       visibility: hidden;
       pointer-events: none;
       transition: opacity 0.5s ease, visibility 0s linear 0.5s;
+      will-change: opacity;
     }
 
     .title-card.visible {
@@ -1199,7 +1205,7 @@
       letter-spacing: 0.01em;
       opacity: 0;
       transition: opacity 0.3s ease;
-      z-index: 50;
+      z-index: var(--z-caption);
       pointer-events: none;
       max-width: calc(100% - 24px);
       white-space: nowrap;
@@ -1230,11 +1236,12 @@
       align-items: center;
       justify-content: center;
       background: var(--window-bg);
-      z-index: 100;
+      z-index: var(--z-modal);
       opacity: 0;
       visibility: hidden;
       pointer-events: none;
       transition: opacity 0.5s ease, visibility 0s linear 0.5s;
+      will-change: opacity;
     }
 
     .closing-card.visible {

--- a/templates/public-pages/demo-video.html.tpl
+++ b/templates/public-pages/demo-video.html.tpl
@@ -34,9 +34,14 @@
     "description": "Watch an AI handle 47 unread Slack messages without opening Slack. 16 tools, one command, no OAuth. Works with Claude, Cursor, Copilot, Gemini.",
     "thumbnailUrl": "{{SOCIAL_IMAGE_URL}}",
     "uploadDate": "2026-03-30",
-    "contentUrl": "{{GITHUB_PAGES_ROOT}}/docs/videos/demo-claude.webm",
+    "contentUrl": "{{GITHUB_PAGES_ROOT}}/docs/videos/demo-claude.mp4",
     "embedUrl": "{{GITHUB_PAGES_ROOT}}/public/demo-video.html",
-    "duration": "PT3M",
+    "duration": "PT3M33S",
+    "author": {
+      "@type": "Person",
+      "name": "James Lambert",
+      "url": "https://github.com/jtalk22"
+    },
     "publisher": {
       "@type": "Organization",
       "name": "Revasser",
@@ -215,8 +220,8 @@
 
     <div class="video-wrapper">
       <video id="demo" poster="../docs/images/demo-poster.png" playsinline autoplay muted loop>
+        <source src="../docs/videos/demo-claude.mp4" type="video/mp4">
         <source src="../docs/videos/demo-claude.webm" type="video/webm">
-        <source src="https://jtalk22.github.io/slack-mcp-server/docs/videos/demo-claude.webm" type="video/webm">
         Your browser does not support the video tag.
       </video>
     </div>


### PR DESCRIPTION
## Summary\n\n- **H.264 MP4 post-processing**: record-demo.js now auto-encodes VP8 WebM to H.264 MP4 via FFmpeg after recording (~85% size reduction, universal browser support). demo-video.html serves MP4 first with WebM fallback.\n- **Play button overlay**: Poster image now has a centered semi-transparent play button so README viewers know it links to a video.\n- **CSS polish**: Minimum font size raised from 10px to 12px (WCAG), z-index uses CSS variables, will-change hints on animated cards.\n- **Schema.org fixes**: Added author field, updated contentUrl to MP4, corrected duration to PT3M33S.\n\n## After merge — run on Mac\n\n```bash\nnpm run build:public-pages\nnpm run record-demo      # records WebM + auto-encodes MP4\nnpm run screenshot       # poster with play button overlay\nnpm run build:social-preview\nnpm run build:demo-mobile\n```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MP4 format support for demo video playback
  * Added play button overlay to demo poster

* **Improvements**
  * Increased font sizes for keyboard shortcuts and UI indicators for better readability
  * Updated demo metadata with author attribution and corrected duration
  * Optimized rendering performance for modal animations
  * Reorganized visual layering system for consistent stacking order

<!-- end of auto-generated comment: release notes by coderabbit.ai -->