### PR TITLE
feat: bookmarklet extractor, multi-client configs, hq video pipeline, play button fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,65 @@ This server uses your browser's session tokens instead. If you can see it in Sla
 | Admin approval | Yes | **No** |
 | Works with Claude Code | No (DCR incompatible) | **Yes** |
 | Works with Copilot | No | **Yes** |
+| Works with Cursor | No | **Yes** |
+| Works with Gemini CLI | No | **Yes** |
+| Works with Windsurf | No | **Yes** |
 | Setup time | ~30 min | **~2 min** |
 | Tools | Limited | **16** |
+
+## Quick Start per Client
+
+<details>
+<summary><strong>Claude Desktop / Claude Code</strong></summary>
+
+Add to `~/.claude.json` or Claude Desktop settings:
+```json
+{
+  "mcpServers": {
+    "slack": { "command": "npx", "args": ["-y", "@jtalk22/slack-mcp"] }
+  }
+}
+```
+</details>
+
+<details>
+<summary><strong>Cursor</strong></summary>
+
+Add to `.cursor/mcp.json`:
+```json
+{
+  "mcpServers": {
+    "slack": { "command": "npx", "args": ["-y", "@jtalk22/slack-mcp"] }
+  }
+}
+```
+</details>
+
+<details>
+<summary><strong>Windsurf</strong></summary>
+
+Add to `~/.codeium/windsurf/mcp_config.json`:
+```json
+{
+  "mcpServers": {
+    "slack": { "command": "npx", "args": ["-y", "@jtalk22/slack-mcp"] }
+  }
+}
+```
+</details>
+
+<details>
+<summary><strong>Gemini CLI</strong></summary>
+
+Add to `~/.gemini/settings.json`:
+```json
+{
+  "mcpServers": {
+    "slack": { "command": "npx", "args": ["-y", "@jtalk22/slack-mcp"] }
+  }
+}
+```
+</details>
 
 ## Tools
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "build:demo-mobile:gif": "node scripts/build-mobile-demo.js --gif",
     "record-demo": "node scripts/record-demo.js",
     "social-preview:update": "node scripts/update-github-social-preview.js --headed",
+    "bookmarklet": "node scripts/generate-bookmarklet.js",
     "cf:browser": "node scripts/cloudflare-browser-tool.js",
     "verify:attribution-guardrail": "node scripts/verify-attribution-guardrail.js",
     "verify:public-pages": "node scripts/verify-generated-public-pages.js",

--- a/public/demo-video.html
+++ b/public/demo-video.html
@@ -240,7 +240,7 @@
 
   <script>
     const video = document.getElementById('demo');
-    const HIGHLIGHT_START_SECONDS = 6;
+    const HIGHLIGHT_START_SECONDS = 2;
 
     function playFromHighlight() {
       if (video.duration && video.duration > HIGHLIGHT_START_SECONDS + 1) {

--- a/scripts/capture-screenshots.js
+++ b/scripts/capture-screenshots.js
@@ -119,9 +119,9 @@ async function captureScreenshots() {
     const overlayHTML = `
       <html><body style="margin:0;padding:0;width:1280px;height:800px;position:relative">
         <img src="data:image/png;base64,${posterB64}" style="width:1280px;height:800px;display:block">
-        <div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center">
-          <div style="width:88px;height:88px;background:rgba(218,119,86,0.82);border-radius:50%;display:flex;align-items:center;justify-content:center;box-shadow:0 4px 24px rgba(0,0,0,0.5)">
-            <div style="width:0;height:0;border-style:solid;border-width:18px 0 18px 30px;border-color:transparent transparent transparent #fff;margin-left:4px"></div>
+        <div style="position:absolute;bottom:28px;left:28px">
+          <div style="width:48px;height:48px;background:rgba(218,119,86,0.55);border-radius:50%;display:flex;align-items:center;justify-content:center;box-shadow:0 2px 10px rgba(0,0,0,0.3)">
+            <div style="width:0;height:0;border-style:solid;border-width:10px 0 10px 16px;border-color:transparent transparent transparent rgba(255,255,255,0.9);margin-left:2px"></div>
           </div>
         </div>
       </body></html>`;

--- a/scripts/generate-bookmarklet.js
+++ b/scripts/generate-bookmarklet.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/**
+ * Generates a bookmarklet for one-click Slack token extraction.
+ *
+ * Usage: node scripts/generate-bookmarklet.js
+ * Output: Prints the bookmarklet URL to stdout.
+ *
+ * How it works:
+ *   1. User drags the bookmarklet to their Chrome toolbar
+ *   2. Navigates to app.slack.com (must be logged in)
+ *   3. Clicks the bookmarklet
+ *   4. Token + cookie are copied to clipboard as JSON
+ *   5. User pastes into `npx -y @jtalk22/slack-mcp --setup`
+ */
+
+const js = `
+(function(){
+  try {
+    var c = document.cookie.split('; ').find(function(x){return x.startsWith('d=')});
+    if (!c) throw new Error('No session cookie found. Are you on app.slack.com?');
+    var cookie = c.split('=').slice(1).join('=');
+    var token = null;
+    try {
+      var cfg = JSON.parse(localStorage.localConfig_v2 || '{}');
+      var tid = Object.keys(cfg.teams || {})[0];
+      if (tid) token = cfg.teams[tid].token;
+    } catch(e){}
+    if (!token) {
+      try { token = window.boot_data && window.boot_data.api_token; } catch(e){}
+    }
+    if (!token) throw new Error('Token not found in localStorage. Try refreshing Slack first.');
+    var payload = JSON.stringify({token: token, cookie: cookie});
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(payload).then(function(){
+        alert('Tokens copied to clipboard.\\n\\nPaste into: npx -y @jtalk22/slack-mcp --setup');
+      });
+    } else {
+      window.prompt('Copy this (Cmd+A, Cmd+C):', payload);
+    }
+  } catch(e) {
+    alert('Token extraction failed: ' + e.message);
+  }
+})();
+`.replace(/\n/g, '').replace(/  +/g, ' ').trim();
+
+const bookmarklet = `javascript:${encodeURIComponent(js)}`;
+
+console.log('Slack MCP Token Bookmarklet');
+console.log('==========================');
+console.log();
+console.log('Drag this URL to your Chrome bookmarks bar:');
+console.log();
+console.log(bookmarklet);
+console.log();
+console.log('Then:');
+console.log('  1. Go to app.slack.com (must be logged in)');
+console.log('  2. Click the bookmarklet');
+console.log('  3. Tokens are copied to clipboard');
+console.log('  4. Run: npx -y @jtalk22/slack-mcp --setup');
+console.log('  5. Paste when prompted');

--- a/scripts/record-demo.js
+++ b/scripts/record-demo.js
@@ -10,7 +10,7 @@
 import { chromium } from 'playwright';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
-import { mkdirSync, existsSync, copyFileSync, statSync } from 'fs';
+import { mkdirSync, existsSync, copyFileSync, statSync, readdirSync, unlinkSync, rmSync } from 'fs';
 import { spawnSync } from 'child_process';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -23,8 +23,10 @@ const argValue = (flag) => {
   return idx >= 0 && idx + 1 < argv.length ? argv[idx + 1] : null;
 };
 
+const pngSequenceMode = hasArg('--png-sequence');
+
 const CONFIG = {
-  viewport: { width: 1280, height: 800 },
+  viewport: pngSequenceMode ? { width: 2560, height: 1600 } : { width: 1280, height: 800 },
   speed: '0.5',
   maxDemoTimeout: 600000, // 10 min safety net
 };
@@ -46,13 +48,20 @@ async function recordDemo() {
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
   const timestampedOutput = join(videosDir, `demo-claude-${timestamp}.webm`);
 
+  const framesDir = join(videosDir, 'frames');
+  if (pngSequenceMode) {
+    mkdirSync(framesDir, { recursive: true });
+    console.log(`📸 PNG sequence mode: ${CONFIG.viewport.width}x${CONFIG.viewport.height} (2x Retina)`);
+  }
+
   console.log('🚀 Launching browser...');
   const browser = await chromium.launch({ headless: true });
-  const context = await browser.newContext({
+  const contextOpts = {
     viewport: CONFIG.viewport,
-    recordVideo: { dir: videosDir, size: CONFIG.viewport },
     colorScheme: 'dark',
-  });
+    ...(pngSequenceMode ? { deviceScaleFactor: 2 } : { recordVideo: { dir: videosDir, size: CONFIG.viewport } }),
+  };
+  const context = await browser.newContext(contextOpts);
   const page = await context.newPage();
 
   // ── Load page ────────────────────────────────────────────────
@@ -104,6 +113,20 @@ async function recordDemo() {
   console.log('▶️  Scenarios running...');
   console.log();
 
+  // PNG frame capture loop (--png-sequence mode only)
+  let frameCount = 0;
+  let frameCapture = null;
+  if (pngSequenceMode) {
+    const captureFrame = async () => {
+      try {
+        const framePath = join(framesDir, `frame-${String(frameCount).padStart(5, '0')}.png`);
+        await page.screenshot({ path: framePath, type: 'png' });
+        frameCount++;
+      } catch (_) { /* page closing */ }
+    };
+    frameCapture = setInterval(captureFrame, 33); // ~30fps
+  }
+
   // Poll scenario progress for console output
   const scenarios = ['triage', 'search', 'thread', 'respond', 'people', 'react', 'export'];
   let lastScenario = null;
@@ -128,8 +151,10 @@ async function recordDemo() {
     { timeout: CONFIG.maxDemoTimeout },
   );
   clearInterval(poller);
+  if (frameCapture) clearInterval(frameCapture);
   console.log();
   console.log('🎬 Closing card visible.');
+  if (pngSequenceMode) console.log(`   Captured ${frameCount} frames`);
 
   // Wait for closing card to fade out
   await page.waitForFunction(
@@ -143,13 +168,42 @@ async function recordDemo() {
   await page.waitForTimeout(600);
 
   // ── Save video ──────────────────────────────────────────────
-  console.log('💾 Saving video...');
-  const video = await page.video();
-  await context.close();
-  await browser.close();
+  if (pngSequenceMode) {
+    console.log('💾 Stitching PNG frames with FFmpeg...');
+    await context.close();
+    await browser.close();
 
-  const videoPath = await video.path();
-  copyFileSync(videoPath, canonicalOutput);
+    const hqOutput = canonicalOutput.replace(/\.webm$/, '-hq.mp4');
+    const enc = spawnSync('ffmpeg', [
+      '-y', '-framerate', '30',
+      '-i', join(framesDir, 'frame-%05d.png'),
+      '-vf', 'scale=1280:800:flags=lanczos',
+      '-c:v', 'libx264', '-preset', 'slow', '-crf', '18',
+      '-pix_fmt', 'yuv420p', '-movflags', '+faststart',
+      hqOutput,
+    ], { stdio: 'inherit' });
+
+    if (enc.status === 0) {
+      const hqSize = (statSync(hqOutput).size / 1048576).toFixed(1);
+      console.log(`   HQ MP4: ${hqSize} MB (${frameCount} frames @ 30fps)`);
+      // Also copy as the standard MP4
+      copyFileSync(hqOutput, canonicalOutput.replace(/\.webm$/, '.mp4'));
+    } else {
+      console.warn('   ⚠️  FFmpeg stitch failed');
+    }
+
+    // Clean up frames
+    console.log('🧹 Cleaning up frames...');
+    rmSync(framesDir, { recursive: true, force: true });
+  } else {
+    console.log('💾 Saving video...');
+    const video = await page.video();
+    await context.close();
+    await browser.close();
+
+    const videoPath = await video.path();
+    copyFileSync(videoPath, canonicalOutput);
+  }
 
   // ── Encode H.264 MP4 from WebM ──────────────────────────────
   // Playwright records VP8 WebM (~9MB). Re-encode to H.264 MP4

--- a/templates/public-pages/demo-video.html.tpl
+++ b/templates/public-pages/demo-video.html.tpl
@@ -238,7 +238,7 @@
 
   <script>
     const video = document.getElementById('demo');
-    const HIGHLIGHT_START_SECONDS = 6;
+    const HIGHLIGHT_START_SECONDS = 2;
 
     function playFromHighlight() {
       if (video.duration && video.duration > HIGHLIGHT_START_SECONDS + 1) {


### PR DESCRIPTION
## Features\n\n- **Bookmarklet token extractor** (`npm run bookmarklet`): One-click Slack token extraction. Drag to toolbar, click on app.slack.com, tokens copied to clipboard. No more F12 → Console → copy 55-char command.\n- **Multi-client install configs**: README now has collapsible config snippets for Claude, Cursor, Windsurf, Gemini CLI. Copy-paste ready.\n- **HQ video pipeline** (`npm run record-demo -- --png-sequence`): Captures 2x DPI PNG frames at 30fps, stitches with FFmpeg H.264 CRF 18. Broadcast quality on M4 Max.\n- **Play button fix**: Moved to bottom-left, 48px, semi-transparent. No longer blocks title card text.\n- **Video start fix**: Demo video page starts at 2s instead of 6s — skips the fullscreen transition wobble.\n- **Comparison table expanded**: Added Cursor, Gemini CLI, Windsurf rows.