### PR TITLE
ux: one-liner token extractor in setup wizard, sequential png capture

### DIFF
--- a/scripts/generate-bookmarklet.js
+++ b/scripts/generate-bookmarklet.js
@@ -1,60 +1,30 @@
 #!/usr/bin/env node
 /**
- * Generates a bookmarklet for one-click Slack token extraction.
+ * Prints a Chrome DevTools Console one-liner that extracts
+ * Slack session tokens and copies them to clipboard as JSON.
  *
- * Usage: node scripts/generate-bookmarklet.js
- * Output: Prints the bookmarklet URL to stdout.
+ * Usage: npm run bookmarklet
  *
- * How it works:
- *   1. User drags the bookmarklet to their Chrome toolbar
- *   2. Navigates to app.slack.com (must be logged in)
- *   3. Clicks the bookmarklet
- *   4. Token + cookie are copied to clipboard as JSON
- *   5. User pastes into `npx -y @jtalk22/slack-mcp --setup`
+ * The output is designed to be pasted into the Chrome Console
+ * while on app.slack.com, then the result pasted into --setup.
  */
 
-const js = `
-(function(){
-  try {
-    var c = document.cookie.split('; ').find(function(x){return x.startsWith('d=')});
-    if (!c) throw new Error('No session cookie found. Are you on app.slack.com?');
-    var cookie = c.split('=').slice(1).join('=');
-    var token = null;
-    try {
-      var cfg = JSON.parse(localStorage.localConfig_v2 || '{}');
-      var tid = Object.keys(cfg.teams || {})[0];
-      if (tid) token = cfg.teams[tid].token;
-    } catch(e){}
-    if (!token) {
-      try { token = window.boot_data && window.boot_data.api_token; } catch(e){}
-    }
-    if (!token) throw new Error('Token not found in localStorage. Try refreshing Slack first.');
-    var payload = JSON.stringify({token: token, cookie: cookie});
-    if (navigator.clipboard && navigator.clipboard.writeText) {
-      navigator.clipboard.writeText(payload).then(function(){
-        alert('Tokens copied to clipboard.\\n\\nPaste into: npx -y @jtalk22/slack-mcp --setup');
-      });
-    } else {
-      window.prompt('Copy this (Cmd+A, Cmd+C):', payload);
-    }
-  } catch(e) {
-    alert('Token extraction failed: ' + e.message);
-  }
-})();
-`.replace(/\n/g, '').replace(/  +/g, ' ').trim();
+const oneLiner = `copy(JSON.stringify({token:JSON.parse(localStorage.localConfig_v2).teams[Object.keys(JSON.parse(localStorage.localConfig_v2).teams)[0]].token,cookie:document.cookie.split('; ').find(c=>c.startsWith('d=')).slice(2)}))`;
 
-const bookmarklet = `javascript:${encodeURIComponent(js)}`;
+const isMac = process.platform === 'darwin';
+const hotkey = isMac ? 'Cmd+Option+J' : 'Ctrl+Shift+J';
 
-console.log('Slack MCP Token Bookmarklet');
-console.log('==========================');
 console.log();
-console.log('Drag this URL to your Chrome bookmarks bar:');
+console.log('Slack MCP — Token Extractor');
+console.log('===========================');
 console.log();
-console.log(bookmarklet);
+console.log(`1. Open Chrome → app.slack.com (must be logged in)`);
+console.log(`2. Press ${hotkey} to open the Console`);
+console.log(`3. Paste this and press Enter:`);
 console.log();
-console.log('Then:');
-console.log('  1. Go to app.slack.com (must be logged in)');
-console.log('  2. Click the bookmarklet');
-console.log('  3. Tokens are copied to clipboard');
-console.log('  4. Run: npx -y @jtalk22/slack-mcp --setup');
-console.log('  5. Paste when prompted');
+console.log(`   ${oneLiner}`);
+console.log();
+console.log(`4. Your tokens are now on the clipboard`);
+console.log(`5. Run: npx -y @jtalk22/slack-mcp --setup`);
+console.log(`6. Paste when prompted`);
+console.log();

--- a/scripts/record-demo.js
+++ b/scripts/record-demo.js
@@ -114,17 +114,22 @@ async function recordDemo() {
   console.log();
 
   // PNG frame capture loop (--png-sequence mode only)
+  // Sequential: await each screenshot before starting the next.
+  // setInterval doesn't work — screenshots take ~100-200ms at 2x DPI,
+  // so 33ms intervals cause overlapping captures that pile up.
   let frameCount = 0;
-  let frameCapture = null;
+  let captureRunning = false;
   if (pngSequenceMode) {
-    const captureFrame = async () => {
-      try {
-        const framePath = join(framesDir, `frame-${String(frameCount).padStart(5, '0')}.png`);
-        await page.screenshot({ path: framePath, type: 'png' });
-        frameCount++;
-      } catch (_) { /* page closing */ }
-    };
-    frameCapture = setInterval(captureFrame, 33); // ~30fps
+    captureRunning = true;
+    (async () => {
+      while (captureRunning) {
+        try {
+          const framePath = join(framesDir, `frame-${String(frameCount).padStart(5, '0')}.png`);
+          await page.screenshot({ path: framePath, type: 'png' });
+          frameCount++;
+        } catch (_) { break; } // page closing
+      }
+    })(); // fire-and-forget — runs concurrently with DOM watchers below
   }
 
   // Poll scenario progress for console output
@@ -151,7 +156,7 @@ async function recordDemo() {
     { timeout: CONFIG.maxDemoTimeout },
   );
   clearInterval(poller);
-  if (frameCapture) clearInterval(frameCapture);
+  captureRunning = false; // signal PNG capture loop to stop
   console.log();
   console.log('🎬 Closing card visible.');
   if (pngSequenceMode) console.log(`   Captured ${frameCount} frames`);

--- a/scripts/setup-wizard.js
+++ b/scripts/setup-wizard.js
@@ -131,10 +131,18 @@ async function runMacOSSetup(rl) {
     }
     print();
     if (extractionError?.code === "apple_events_javascript_disabled") {
-      print("Fix and retry:");
-      print("  1. In Chrome menu: View > Developer > Allow JavaScript from Apple Events");
-      print("  2. Keep Slack open in a Chrome tab (app.slack.com)");
-      print("  3. Re-run: npx -y @jtalk22/slack-mcp --setup");
+      print();
+      printBox([
+        "Chrome needs one setting enabled (one-time only):",
+        "",
+        "1. Open Chrome",
+        "2. Menu bar: View → Developer → Allow JavaScript",
+        "   from Apple Events  ✓",
+        "3. Run this command again",
+      ], 55);
+      print();
+      print("Once enabled, --setup extracts tokens automatically.");
+      print("No DevTools, no copy-paste, just one command.");
     } else {
       print("Make sure:");
       print("  1. Chrome is running");
@@ -184,38 +192,55 @@ async function runManualSetup(rl) {
     info(`Detected platform: ${platform()}`);
     warn("Auto-extraction not available on this platform.");
   }
+
+  const consoleHotkey = IS_MACOS ? "Cmd+Option+J" : "Ctrl+Shift+J";
+  const oneLiner = `copy(JSON.stringify({token:JSON.parse(localStorage.localConfig_v2).teams[Object.keys(JSON.parse(localStorage.localConfig_v2).teams)[0]].token,cookie:document.cookie.split('; ').find(c=>c.startsWith('d=')).slice(2)}))`;
+
   print();
-  print("Follow these steps to extract tokens from Chrome:");
+  print(`${colors.bold}Quick extract (recommended):${colors.reset}`);
   print();
-  print(`${colors.bold}Step 1:${colors.reset} Open Chrome and navigate to your Slack workspace`);
-  print("         https://app.slack.com");
+  print(`  1. Open Chrome → ${colors.cyan}app.slack.com${colors.reset} (must be logged in)`);
+  print(`  2. Press ${colors.cyan}${consoleHotkey}${colors.reset} to open the Console`);
+  print(`  3. Paste this one-liner and press Enter:`);
   print();
-  print(`${colors.bold}Step 2:${colors.reset} Press F12 to open DevTools`);
+  printBox([oneLiner], oneLiner.length + 4);
   print();
-  print(`${colors.bold}Step 3:${colors.reset} Go to the ${colors.cyan}Console${colors.reset} tab and paste this:`);
+  print(`  4. Your tokens are now on the clipboard. Paste below.`);
   print();
-  printBox([
-    "JSON.parse(localStorage.localConfig_v2).teams[",
-    "  Object.keys(JSON.parse(localStorage.localConfig_v2)",
-    "  .teams)[0]].token",
-  ], 55);
-  print();
-  print(`         Copy the token (starts with ${colors.cyan}xoxc-${colors.reset})`);
+  print(`${colors.dim}(Or paste a raw xoxc- token for manual two-step entry)${colors.reset}`);
   print();
 
-  const token = await question(rl, `${colors.bold}Paste your token:${colors.reset} `);
+  const input = await question(rl, `${colors.bold}Paste tokens:${colors.reset} `);
+  const trimmed = input.trim();
 
-  if (!token.startsWith('xoxc-')) {
-    error("Invalid token. Token should start with 'xoxc-'");
-    return false;
+  let token, cookie;
+
+  // Try JSON parse first (one-liner output: {"token":"xoxc-...","cookie":"xoxd-..."})
+  if (trimmed.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (parsed.token && parsed.cookie) {
+        token = parsed.token;
+        cookie = parsed.cookie;
+      }
+    } catch (_) {
+      // Not valid JSON — fall through to manual
+    }
   }
 
-  print();
-  print(`${colors.bold}Step 4:${colors.reset} Go to ${colors.cyan}Application${colors.reset} tab → ${colors.cyan}Cookies${colors.reset} → slack.com`);
-  print(`         Find the '${colors.cyan}d${colors.reset}' cookie and copy its value`);
-  print();
-
-  const cookie = await question(rl, `${colors.bold}Paste your cookie:${colors.reset} `);
+  // If JSON didn't work, treat as raw token
+  if (!token) {
+    token = trimmed;
+    if (!token.startsWith('xoxc-')) {
+      error("Invalid input. Expected JSON from the one-liner or a token starting with 'xoxc-'");
+      return false;
+    }
+    print();
+    print(`Now paste the cookie. In Chrome: ${colors.cyan}Application${colors.reset} tab → ${colors.cyan}Cookies${colors.reset} → find '${colors.cyan}d${colors.reset}'`);
+    print();
+    const cookieInput = await question(rl, `${colors.bold}Paste cookie (xoxd-...):${colors.reset} `);
+    cookie = cookieInput.trim();
+  }
 
   if (!cookie.startsWith('xoxd-')) {
     error("Invalid cookie. Cookie should start with 'xoxd-'");


### PR DESCRIPTION
## Setup UX overhaul\n\n**The setup wizard now has a 3-step flow instead of 6:**\n\n1. Open Chrome Console on app.slack.com (Cmd+Option+J on Mac)\n2. Paste one-liner → tokens copied to clipboard\n3. Paste into the wizard → validated and saved\n\n### Changes\n\n- **Setup wizard** (`scripts/setup-wizard.js`): Shows a Console one-liner that extracts token + cookie in a single `copy()` call. Accepts JSON paste (`{"token":"xoxc-...","cookie":"xoxd-..."}`) as a single input. Falls back to two-step manual if paste isn't JSON. Better Apple Events error message with clear visual box.\n- **PNG-sequence fix** (`scripts/record-demo.js`): Replaced `setInterval(33ms)` with sequential `await` loop. The old approach captured only 180 overlapping frames; now it awaits each screenshot before starting the next.\n- **Bookmarklet script** (`scripts/generate-bookmarklet.js`): Now prints a readable Console one-liner with platform-specific hotkey instead of a URL-encoded blob.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform-specific console hotkey guidance for faster token extraction.
  * Introduced "Quick extract" method using a one-liner for streamlined setup.
  * Enhanced token input handling to accept both JSON and raw token formats.

* **Chores**
  * Improved setup wizard instructions and messaging for better user experience.
  * Refined demo recording frame capture mechanism for stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->