### PR TITLE
docs(v4.2.0): publish prep — RELEASE-NOTES-v4.2.0.md + morning-DM Q2 2026 caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Six prebuilt templates ship with the package:
 npx -y @jtalk22/slack-mcp --apply-template oncall-handoff --channels C012345,C067890
 ```
 
-Available templates: `oncall-handoff`, `support-triage`, `exec-monday`, `sprint-tracker`, `customer-feedback`, `incident-room`. The structural primitives (`slack_workflow_save`, `slack_workflows`) are free forever in OSS; the hosted brain is `$0` to start (no card) and `$9/mo` Pro for unlimited + the scheduled morning catch-up DM at 8am workspace time.
+Available templates: `oncall-handoff`, `support-triage`, `exec-monday`, `sprint-tracker`, `customer-feedback`, `incident-room`. The structural primitives (`slack_workflow_save`, `slack_workflows`) are free forever in OSS; the hosted brain is `$0` to start (no card) and `$9/mo` Pro for unlimited AI tools (scheduled morning catch-up DM rolling out Q2 2026).
 
 ## Quick Start per Client
 
@@ -263,7 +263,7 @@ Hosted tiers at [mcp.revasserlabs.com](https://mcp.revasserlabs.com):
 |------|-------|-------------|
 | Self-host | Free (MIT) | Local stdio, all 21 tools (16 read/write Slack + 2 workflow profile primitives + 3 discoverable upgrade stubs to hosted brain) |
 | Hosted Free | $0 (no card) | Email signup, 1 workspace, 10 smart_search/mo + 3 catch_me_up/mo + 5 triage/day. All 5 workflow profile types. 7-day index retention. |
-| Pro | $9/mo | Unlimited AI tools, **scheduled morning catch-up DM (8am workspace tz)**, permanent OAuth, 90-day Vectorize, 2 workspaces |
+| Pro | $9/mo | Unlimited AI tools, **scheduled morning catch-up DM** *(rolling out Q2 2026, 8am workspace tz)*, permanent OAuth, 90-day Vectorize, 2 workspaces |
 | Team | $49/mo flat | Pro + shared workflow profiles + audit log + 24h support + scheduled catch-up to channel + 5 workspaces |
 | Ops | from $199/mo (custom) | SLA, custom retention, SOC2 evidence path, multi-tenant isolation, 10+ workspaces, dedicated workflow tuning |
 
@@ -371,4 +371,4 @@ Not affiliated with Slack Technologies, Inc. Uses browser session credentials â€
 
 ---
 
-Hosted version live at [mcp.revasserlabs.com](https://mcp.revasserlabs.com): Free tier (no card), $9/mo Pro, $49/mo Team flat, Ops from $199/mo. Hosted owns the AI brain (smart_search, catch_me_up, triage), the scheduled morning catch-up DM at 8am workspace time, permanent OAuth (no 2-week token rotation), 90-day Vectorize retention, and shared workflow profiles. The OSS package owns local stdio + all 16 read/write Slack tools + workflow profile primitives (slack_workflow_save, slack_workflows). The 3 paid stubs (slack_smart_search, slack_catch_me_up, slack_triage) appear in OSS as discoverable upgrade prompts.
+Hosted version live at [mcp.revasserlabs.com](https://mcp.revasserlabs.com): Free tier (no card), $9/mo Pro, $49/mo Team flat, Ops from $199/mo. Hosted owns the AI brain (smart_search, catch_me_up, triage), the scheduled morning catch-up DM at 8am workspace time *(rolling out Q2 2026)*, permanent OAuth (no 2-week token rotation), 90-day Vectorize retention, and shared workflow profiles. The OSS package owns local stdio + all 16 read/write Slack tools + workflow profile primitives (slack_workflow_save, slack_workflows). The 3 paid stubs (slack_smart_search, slack_catch_me_up, slack_triage) appear in OSS as discoverable upgrade prompts.

--- a/docs/RELEASE-NOTES-v4.2.0.md
+++ b/docs/RELEASE-NOTES-v4.2.0.md
@@ -1,0 +1,138 @@
+# Release Notes — v4.2.0
+
+**Workflow primitives + paid stubs + 6 templates. Structured JSON, not message dumps.**
+
+---
+
+## The axiom
+
+A Slack catch-up that returns a wall of recent messages is a transcript, not an answer. Operators don't ask "what was said in #incident-room?" — they ask "what is open, who owns it, what's the next action?" Two different shapes. The first is what the MCP returned for a year. The second is what every actual workflow needs.
+
+The bug class: tools that hand back narrative when the workflow needs structure. A support inbox catch-up should return `{open_threads, ack_lag, owner_gaps, escalations, next_actions}` — not paragraphs that the operator then has to re-parse into the same shape. The workflow_kind taxonomy makes the structure explicit, so the AI returns it instead of the operator extracting it.
+
+v4.2.0 is the structural fix. v4.2 reorchestrates the hosted tier model around it. v4.3 (Q2 2026) adds the scheduled morning catch-up DM that turns this into a daily habit.
+
+---
+
+## What's new — v4.2.0
+
+Three structural shifts. The OSS package gets new primitives that work standalone and gracefully degrade into discoverable upgrade stubs when the AI brain isn't reachable.
+
+### 1. Workflow profile primitives (free in OSS)
+
+Two new tools ship in the OSS package:
+
+- `slack_workflow_save` — define a named profile bound to a `workflow_kind` (`support_inbox`, `incident_room`, `exec_brief`, `product_launch_watch`, or `custom`), a list of channels, optional priority people, retention mode, and summary cadence. Stored at `~/.slack-mcp-workflows.json`. Local. Yours.
+- `slack_workflows` — list saved profiles.
+
+Profiles are the routing surface. Once a profile is saved, paid tools (`slack_catch_me_up`, `slack_smart_search`, `slack_triage`) target it by name and return JSON shaped to the `workflow_kind`. The shape contract is part of the tool description, so MCP clients can present structured output directly.
+
+### 2. Six packaged templates
+
+Apply with one command at install time:
+
+```
+npx -y @jtalk22/slack-mcp --apply-template <template-name> --channels C012,C067
+```
+
+| Template | workflow_kind | Use case |
+|---|---|---|
+| `oncall-handoff` | `incident_room` | Engineering handoffs, on-call queue, postmortems |
+| `support-triage` | `support_inbox` | CX/support backlog, ack lag, owner gaps |
+| `exec-monday` | `exec_brief` | Weekly exec brief, decisions, risks, asks |
+| `sprint-tracker` | `product_launch_watch` | Launch readiness, blockers, metrics |
+| `customer-feedback` | `custom` | Voice-of-customer rollups |
+| `incident-room` | `incident_room` | Live incidents, timeline, owner gaps |
+
+Templates set sensible defaults. Channels are bound at apply time. Profile name can be overridden via `--profile-name`.
+
+### 3. Three discoverable upgrade stubs
+
+The AI brain (`slack_smart_search`, `slack_catch_me_up`, `slack_triage`) is hosted-only — semantic search over a Vectorize index, structured catch-up output, multi-channel triage scoring. In OSS, these tools surface as discoverable stubs that return a structured `tool_requires_hosted` payload with the signup URL, free quota details, and Pro value prop. No silent failure. The MCP client sees the stub, knows the upgrade path, and the operator can route to `mcp.revasserlabs.com` to enable the full surface.
+
+This is the right shape for OSS↔hosted boundaries: the OSS package is honest about what it can and can't do; the upgrade is one click away; the hosted tier delivers what self-host structurally cannot.
+
+### Total tool surface
+
+**21 tools.** 16 read/write Slack tools (the existing surface from v4.1.x) + 2 workflow profile primitives (new, free) + 3 discoverable upgrade stubs (new, free OSS, paid hosted).
+
+---
+
+## v4.2 hosted tier reorchestration
+
+This release ships alongside the v5 hosted pricing model that went live on `mcp.revasserlabs.com` this week.
+
+| Tier | Price | What it covers |
+|---|---|---|
+| Self-host (OSS) | Free (MIT) | Local stdio, all 21 tools (16 read/write + 2 primitives + 3 discoverable stubs) |
+| Hosted Free | $0 (no card) | Email signup, 1 workspace, 10 smart_search/mo + 3 catch_me_up/mo + 5 triage/day. All 5 workflow profile types. 7-day index retention. |
+| Hosted Pro | $9/mo | Unlimited AI tools, permanent OAuth (no 2-week token rotation), 90-day Vectorize retention, 2 workspaces. Scheduled morning catch-up DM at 8am workspace tz **rolling out Q2 2026**. |
+| Hosted Team | $49/mo flat | Pro + shared workflow profiles + audit log + 24h support + scheduled catch-up to channel + 5 workspaces |
+| Ops engagement | from $199/mo (custom) | SLA, custom retention, SOC2 evidence path, multi-tenant isolation, 10+ workspaces, dedicated workflow tuning |
+
+**Rolling out Q2 2026 — explicit caveat:** the scheduled morning catch-up DM at 8am workspace time is named in the Pro tier description because it is the daily-habit lever the architecture is designed around. The Cloudflare Cron handler that posts the structured brief to your Slack DM ships in **v4.3.0 (Q2 2026)**. Until then, Pro at $9/mo unlocks unlimited AI tools (the differentiator from Free); the morning DM is forward-looking. Free $0 is fully functional today. Pro is a real upgrade today (unlimited credits, permanent OAuth, 90-day retention, 2 workspaces). The morning DM joins in v4.3.0.
+
+We chose to ship v4.2.0 today rather than wait for the morning DM build because the workflow primitives are the structural foundation everything else depends on. Operators using Free or Pro today get real value; the morning DM lands when it lands.
+
+---
+
+## Honest tradeoff
+
+**What self-host (free) owns:** Workflow profile primitives (`slack_workflow_save`, `slack_workflows`), 6 packaged templates, all 16 read/write Slack tools, LevelDB token extraction, multi-profile Chrome enumeration, zombie-free process lifecycle, structured error codes, auto-heal telemetry. MIT licensed. The 3 discoverable upgrade stubs ship in OSS as honest signposts to the hosted brain.
+
+**What hosted owns that self-host structurally cannot:**
+
+- The AI brain (`slack_smart_search`, `slack_catch_me_up`, `slack_triage`) — Vectorize semantic search, structured workflow_kind output, multi-channel triage scoring. Stateful. Hosted-only.
+- Managed MCP endpoint on the public internet — required for Claude.ai web users.
+- OAuth 2.1 bridge into the Anthropic MCP Directory.
+- Encrypted credential storage (AES-256-GCM in Cloudflare D1) — credentials never touch your filesystem.
+- Permanent OAuth (no 2-week token rotation).
+- Stripe subscription billing + SLA guarantees on Team and Ops tiers.
+- Structural absence of the zombie-process class.
+
+**What's coming in v4.3.0 (Q2 2026):**
+
+- Scheduled morning catch-up DM at 8am workspace time (Pro+).
+- Scheduled catch-up to a team Slack channel (Team).
+- Cron handler in `slack-mcp-hosted` that reads active Pro/Team tenants from D1, runs structured catch-ups against each tenant's primary workflow profile, posts the brief via `chat.postMessage`, and records the run in `scheduled_catchup_runs`.
+
+---
+
+## Install
+
+```bash
+npx -y @jtalk22/slack-mcp
+```
+
+### Apply a template at install time
+
+```bash
+npx -y @jtalk22/slack-mcp --apply-template support-triage --channels C012345,C067890
+```
+
+### Claude Code
+
+```json
+{
+  "mcpServers": {
+    "slack": {
+      "command": "npx",
+      "args": ["-y", "@jtalk22/slack-mcp"]
+    }
+  }
+}
+```
+
+### Cursor / Copilot / Codex CLI / Windsurf / Gemini / ChatGPT
+
+Same config block — all support stdio MCP.
+
+---
+
+## Links
+
+- GitHub: https://github.com/jtalk22/slack-mcp-server
+- Hosted: https://mcp.revasserlabs.com
+- Pricing: https://mcp.revasserlabs.com/pricing
+- Full changelog: [CHANGELOG.md](../CHANGELOG.md)
+- Previous release: [v4.1.2](RELEASE-NOTES-v4.1.2.md)

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -31,7 +31,7 @@ If `--version` fails here, the issue is install/runtime path, not Slack credenti
 
 ## Hosted Version
 
-The hosted version is live at [mcp.revasserlabs.com](https://mcp.revasserlabs.com). Free tier (no card) ships 10 smart_search/mo + 3 catch_me_up/mo + 5 triage/day + all 5 workflow profile types. Pro at $9/mo unlocks unlimited AI tools, the scheduled morning catch-up DM at 8am workspace time, permanent OAuth (no 2-week token rotation), and 90-day Vectorize retention. Team at $49/mo flat covers 5 workspaces with shared workflow profiles and audit log. Ops engagement starts at $199/mo (custom) for 10+ workspace organizations with SLA, custom retention, SOC2 evidence, or multi-tenant isolation.
+The hosted version is live at [mcp.revasserlabs.com](https://mcp.revasserlabs.com). Free tier (no card) ships 10 smart_search/mo + 3 catch_me_up/mo + 5 triage/day + all 5 workflow profile types. Pro at $9/mo unlocks unlimited AI tools, the scheduled morning catch-up DM at 8am workspace time *(rolling out Q2 2026)*, permanent OAuth (no 2-week token rotation), and 90-day Vectorize retention. Team at $49/mo flat covers 5 workspaces with shared workflow profiles and audit log. Ops engagement starts at $199/mo (custom) for 10+ workspace organizations with SLA, custom retention, SOC2 evidence, or multi-tenant isolation.
 
 The OSS package keeps the local-machine path. The hosted version adds the AI brain (smart_search, catch_me_up, triage) — these tools also appear in the OSS package as discoverable upgrade stubs that point at the hosted signup.
 

--- a/glama.json
+++ b/glama.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "name": "slack-mcp-server",
-  "description": "Slack MCP without OAuth. 21 tools: 16 read/write Slack + 2 workflow profile primitives + 3 discoverable upgrade stubs to hosted AI brain. Free OSS or hosted (free tier, no card; $9/mo Pro adds scheduled morning catch-up DM).",
+  "description": "Slack MCP without OAuth. 21 tools: 16 read/write Slack + 2 workflow profile primitives + 3 discoverable upgrade stubs to hosted AI brain. Free OSS or hosted (free tier, no card; $9/mo Pro for unlimited AI tools — scheduled morning catch-up DM rolling out Q2 2026).",
   "repository": "https://github.com/jtalk22/slack-mcp-server",
   "homepage": "https://mcp.revasserlabs.com",
   "version": "4.2.0",

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -833,7 +833,7 @@ const HOSTED_UPGRADE_PAYLOAD = {
   signup_url: "https://mcp.revasserlabs.com/signup",
   upgrade_url: "https://mcp.revasserlabs.com/pricing",
   free_tier_quota: "10 smart_search + 3 catch_me_up per month, 5 triage per day",
-  pro_value_prop: "Pro $9/mo unlocks unlimited AI tools and the scheduled morning catch-up DM at 8am workspace time.",
+  pro_value_prop: "Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM at 8am workspace time rolling out Q2 2026).",
 };
 
 export async function handleSmartSearch(args) {

--- a/lib/public-pages.js
+++ b/lib/public-pages.js
@@ -63,7 +63,7 @@ function shareLinks() {
 }
 
 function shareNote() {
-  return `<strong>Verify in 30 seconds:</strong> <code>--version</code>, <code>--doctor</code>, <code>--status</code>. Self-host gives ${PUBLIC_METADATA.selfHostedToolCount} tools with session-based auth. Works with any MCP client — Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf. Hosted free tier (no card) live at <a href="${PUBLIC_METADATA.canonicalSiteUrl}">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools and the scheduled morning catch-up DM.`;
+  return `<strong>Verify in 30 seconds:</strong> <code>--version</code>, <code>--doctor</code>, <code>--status</code>. Self-host gives ${PUBLIC_METADATA.selfHostedToolCount} tools with session-based auth. Works with any MCP client — Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf. Hosted free tier (no card) live at <a href="${PUBLIC_METADATA.canonicalSiteUrl}">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM rolling out Q2 2026).`;
 }
 
 function demoLinks() {
@@ -75,7 +75,7 @@ function demoLinks() {
 }
 
 function demoNote() {
-  return `Self-host free for ${PUBLIC_METADATA.selfHostedToolCount} tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="${PUBLIC_METADATA.canonicalSiteUrl}" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools and the scheduled morning catch-up DM.`;
+  return `Self-host free for ${PUBLIC_METADATA.selfHostedToolCount} tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="${PUBLIC_METADATA.canonicalSiteUrl}" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM rolling out Q2 2026).`;
 }
 
 function demoFooterLinks() {

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -509,7 +509,7 @@ export const TOOLS = [
   },
   {
     name: "slack_catch_me_up",
-    description: "Run a structured catch-up against a saved workflow profile. Returns structured JSON per the profile's workflow_kind: support_inbox returns {open_threads, ack_lag, owner_gaps, escalations, next_actions}; incident_room returns {incident_summary, timeline, open_risks, owner_gaps, next_actions}; exec_brief returns {summary, decisions, risks, asks, action_items}; product_launch_watch returns {launch_signals, feedback_themes, blockers, metrics, next_actions}; custom returns {summary, highlights, open_questions, next_actions}. Hosted-only. Free tier ships 3 calls/month; Pro $9/mo unlocks unlimited + scheduled morning DM at 8am workspace tz.",
+    description: "Run a structured catch-up against a saved workflow profile. Returns structured JSON per the profile's workflow_kind: support_inbox returns {open_threads, ack_lag, owner_gaps, escalations, next_actions}; incident_room returns {incident_summary, timeline, open_risks, owner_gaps, next_actions}; exec_brief returns {summary, decisions, risks, asks, action_items}; product_launch_watch returns {launch_signals, feedback_themes, blockers, metrics, next_actions}; custom returns {summary, highlights, open_questions, next_actions}. Hosted-only. Free tier ships 3 calls/month; Pro $9/mo unlocks unlimited (scheduled morning DM at 8am workspace tz rolling out Q2 2026).",
     inputSchema: {
       type: "object",
       properties: {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@jtalk22/slack-mcp",
   "mcpName": "io.github.jtalk22/slack-mcp-server",
   "version": "4.2.0",
-  "description": "Slack MCP without OAuth. 21 tools: 16 read/write Slack + 2 workflow profile primitives + 3 discoverable upgrade stubs to hosted AI brain. Free OSS or hosted (free tier, no card; $9/mo Pro adds scheduled morning catch-up DM).",
+  "description": "Slack MCP without OAuth. 21 tools: 16 read/write Slack + 2 workflow profile primitives + 3 discoverable upgrade stubs to hosted AI brain. Free OSS or hosted (free tier, no card; $9/mo Pro for unlimited AI tools — scheduled morning catch-up DM rolling out Q2 2026).",
   "type": "module",
   "main": "src/server.js",
   "bin": {

--- a/public/demo-slack-mcp.html
+++ b/public/demo-slack-mcp.html
@@ -1312,7 +1312,7 @@
       <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md" target="_blank" rel="noopener noreferrer">Setup Guide</a>
     </div>
     <div class="note">
-      Self-host free for 21 tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools and the scheduled morning catch-up DM.
+      Self-host free for 21 tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM rolling out Q2 2026).
     </div>
   </div>
   <header class="page-header">

--- a/public/demo-video.html
+++ b/public/demo-video.html
@@ -216,7 +216,7 @@
       <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md" target="_blank" rel="noopener noreferrer">Setup Guide</a>
       </div>
       <div class="note">
-        Self-host free for 21 tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools and the scheduled morning catch-up DM.
+        Self-host free for 21 tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM rolling out Q2 2026).
       </div>
     </div>
 

--- a/public/demo.html
+++ b/public/demo.html
@@ -743,7 +743,7 @@
 <body>
   <!-- Preview Banner -->
   <div class="preview-banner">
-    INTERACTIVE DEMO — simulated data. Run <code>npm run web</code> for your live workspace, or try <a href="https://mcp.revasserlabs.com" style="color:#f0c246;font-weight:600">Hosted</a> — free tier (no card) live; Pro $9/mo unlocks unlimited AI tools and the scheduled morning catch-up DM.
+    INTERACTIVE DEMO — simulated data. Run <code>npm run web</code> for your live workspace, or try <a href="https://mcp.revasserlabs.com" style="color:#f0c246;font-weight:600">Hosted</a> — free tier (no card) live; Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM rolling out Q2 2026).
   </div>
   <div class="cta-strip">
     <div class="cta-links">
@@ -752,7 +752,7 @@
       <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md" target="_blank" rel="noopener noreferrer">Setup Guide</a>
     </div>
     <div class="cta-note">
-      Self-host free for 21 tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools and the scheduled morning catch-up DM.
+      Self-host free for 21 tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM rolling out Q2 2026).
     </div>
   </div>
 

--- a/public/share.html
+++ b/public/share.html
@@ -123,7 +123,7 @@
       <a href="https://mcp.revasserlabs.com" rel="noopener" style="background:rgba(240,194,70,0.18);border-color:rgba(240,194,70,0.45);color:#f0c246">Hosted</a>
     </div>
 
-    <p class="note"><strong>Verify in 30 seconds:</strong> <code>--version</code>, <code>--doctor</code>, <code>--status</code>. Self-host gives 21 tools with session-based auth. Works with any MCP client — Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools and the scheduled morning catch-up DM.</p>
+    <p class="note"><strong>Verify in 30 seconds:</strong> <code>--version</code>, <code>--doctor</code>, <code>--status</code>. Self-host gives 21 tools with session-based auth. Works with any MCP client — Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM rolling out Q2 2026).</p>
   </main>
 </body>
 </html>

--- a/scripts/apply-template.js
+++ b/scripts/apply-template.js
@@ -113,5 +113,5 @@ if (!profile.channels.length) {
   console.log("Or call slack_workflow_save from your MCP client to update.");
 } else {
   console.log("Profile is ready. Run slack_catch_me_up against it from your MCP client.");
-  console.log(`(Free tier: 3 catch_me_up calls/month. Pro $9/mo unlocks unlimited + scheduled morning DM.)`);
+  console.log(`(Free tier: 3 catch_me_up calls/month. Pro $9/mo unlocks unlimited; scheduled morning DM rolling out Q2 2026.)`);
 }

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.jtalk22/slack-mcp-server",
   "title": "Slack MCP Server",
-  "description": "Slack MCP without OAuth. 21 tools: 16 read/write Slack + 2 workflow profile primitives + 3 discoverable upgrade stubs to hosted AI brain. Free OSS or hosted (free tier, no card; $9/mo Pro adds scheduled morning catch-up DM).",
+  "description": "Slack MCP without OAuth. 21 tools: 16 read/write Slack + 2 workflow profile primitives + 3 discoverable upgrade stubs to hosted AI brain. Free OSS or hosted (free tier, no card; $9/mo Pro for unlimited AI tools — scheduled morning catch-up DM rolling out Q2 2026).",
   "websiteUrl": "https://mcp.revasserlabs.com",
   "icons": [
     {

--- a/templates/public-pages/demo.html.tpl
+++ b/templates/public-pages/demo.html.tpl
@@ -743,7 +743,7 @@
 <body>
   <!-- Preview Banner -->
   <div class="preview-banner">
-    INTERACTIVE DEMO — simulated data. Run <code>npm run web</code> for your live workspace, or try <a href="{{CANONICAL_SITE_URL}}" style="color:#f0c246;font-weight:600">Hosted</a> — free tier (no card) live; Pro $9/mo unlocks unlimited AI tools and the scheduled morning catch-up DM.
+    INTERACTIVE DEMO — simulated data. Run <code>npm run web</code> for your live workspace, or try <a href="{{CANONICAL_SITE_URL}}" style="color:#f0c246;font-weight:600">Hosted</a> — free tier (no card) live; Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM rolling out Q2 2026).
   </div>
   <div class="cta-strip">
     <div class="cta-links">

--- a/templates/workflow-profiles/support-triage.json
+++ b/templates/workflow-profiles/support-triage.json
@@ -6,5 +6,5 @@
   "retention_mode": "ephemeral",
   "summary_cadence": "daily_8am",
   "structured_keys": ["open_threads", "ack_lag", "owner_gaps", "escalations", "next_actions"],
-  "_template_notes": "Apply with: slack-mcp --apply-template support-triage --channels C0SUPPORT,C0ESCALATIONS. summary_cadence=daily_8am needs Pro or Team for the scheduled morning DM. Free tier can run on_demand."
+  "_template_notes": "Apply with: slack-mcp --apply-template support-triage --channels C0SUPPORT,C0ESCALATIONS. summary_cadence=daily_8am needs Pro or Team for the scheduled morning DM (rolling out Q2 2026). Free tier can run on_demand."
 }


### PR DESCRIPTION
## Summary

- Drafts `docs/RELEASE-NOTES-v4.2.0.md` modeled on the v4.1.2 structure: workflow primitives, `workflow_kind` taxonomy, 6 templates, 3 hosted upgrade stubs, v5 hosted pricing, explicit Q2 2026 callout for the morning DM.
- Adds `(rolling out Q2 2026)` caveat to every customer-facing mention of the scheduled morning catch-up DM — descriptions in `package.json` / `server.json` / `glama.json`, README, TROUBLESHOOTING, `lib/{tools,handlers,public-pages}.js`, `templates/public-pages/demo.html.tpl`, regenerated `public/*.html`, `templates/workflow-profiles/support-triage.json`, `scripts/apply-template.js`.
- The Cloudflare Cron handler that posts the morning brief ships in **v4.3.0 (Q2 2026)**. Pro at $9/mo today is the real upgrade: unlimited tools, permanent OAuth, 90-day Vectorize, 2 workspaces.

## Why now

Trace this turn confirmed: zero current Stripe subscriptions, hosted prod surface live, magic-link delivery working end-to-end. The only gating risk for publishing v4.2.0 was the morning-DM claim implying a feature that isn't built. The caveat collapses that risk to zero and lets v4.2.0 ship today instead of waiting on the v4.3.0 build.

## Verification (local)

- [x] `npm run verify:public-surface` → wrote integrity report
- [x] `npm run verify:public-pages` → "Generated public pages are up to date."
- [x] `npm run verify:version-parity` → local parity OK; npm + MCP registry mismatch is expected pre-publish, will resolve when 4.2.0 lands
- [x] `npm pack --dry-run` → 33 files, 83.1 kB, version 4.2.0
- [x] Smoke regex `/scheduled morning catch-up DM/i` still matches — phrase preserved verbatim, only caveat added after

## Out of scope (separate work)

- Tag + GitHub release fires `publish.yml` after this lands.
- Hosted-side caveat ships in `slack-mcp-hosted#XX` (separate PR, deploys to mcp.revasserlabs.com).
- v4.3.0 morning-DM cron handler build is the next sprint.

## Test plan

- [ ] CI green on this PR
- [ ] Squash-merge after green
- [ ] Hosted PR also green + merged + deployed before tagging
- [ ] Tag `v4.2.0` from updated main → fires `publish.yml` → `npm @latest = 4.2.0`
- [ ] Live Browser Smoke goes green (was red on `npm @latest != 4.2.0` assertion)
- [ ] Close issue #121 (Codex CLI Pydantic, third-party) as not planned

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Pro tier messaging across documentation and marketing materials to clarify that the scheduled morning catch-up DM feature is rolling out in Q2 2026, replacing previous messaging about feature availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->