### PR TITLE
v4.2.2: harden shell-exec surface — argv arrays + native chmodSync

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -4,7 +4,7 @@
   "description": "Slack MCP without OAuth. 21 tools (16 read/write Slack + 2 workflow profile primitives + 3 hosted-brain upgrade stubs). Free OSS or hosted (free tier no card; $9/mo Pro = unlimited; morning DM rolling out Q2 2026).",
   "repository": "https://github.com/jtalk22/slack-mcp-server",
   "homepage": "https://mcp.revasserlabs.com",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "license": "MIT",
   "maintainers": ["jtalk22"],
   "categories": ["communication", "productivity"],

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -4,8 +4,7 @@
  * Implementation of all MCP tool handlers.
  */
 
-import { writeFileSync, readFileSync, existsSync, renameSync, unlinkSync, mkdirSync } from "fs";
-import { execSync } from "child_process";
+import { writeFileSync, readFileSync, existsSync, renameSync, unlinkSync, mkdirSync, chmodSync } from "fs";
 import { homedir, platform } from "os";
 import { join } from "path";
 import {
@@ -55,7 +54,7 @@ function atomicWriteSync(filePath, content) {
   try {
     writeFileSync(tempPath, content);
     if (platform() === 'darwin' || platform() === 'linux') {
-      try { execSync(`chmod 600 "${tempPath}"`); } catch {}
+      try { chmodSync(tempPath, 0o600); } catch {}
     }
     renameSync(tempPath, filePath);
   } catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jtalk22/slack-mcp",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jtalk22/slack-mcp",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jtalk22/slack-mcp",
   "mcpName": "io.github.jtalk22/slack-mcp-server",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Slack MCP without OAuth. 21 tools (16 read/write Slack + 2 workflow profile primitives + 3 hosted-brain upgrade stubs). Free OSS or hosted (free tier no card; $9/mo Pro = unlimited; morning DM rolling out Q2 2026).",
   "type": "module",
   "main": "src/server.js",

--- a/scripts/token-cli.js
+++ b/scripts/token-cli.js
@@ -133,7 +133,7 @@ async function autoExtract() {
 
 async function clearTokens() {
   const fs = await import("fs");
-  const { execSync } = await import("child_process");
+  const { spawnSync } = await import("child_process");
 
   try {
     fs.unlinkSync(TOKEN_FILE);
@@ -142,11 +142,12 @@ async function clearTokens() {
     console.log("No token file to delete");
   }
 
-  try {
-    execSync(`security delete-generic-password -s "${KEYCHAIN_SERVICE}" -a "token" 2>/dev/null`);
-    execSync(`security delete-generic-password -s "${KEYCHAIN_SERVICE}" -a "cookie" 2>/dev/null`);
+  const securityArgs = (account) => ["delete-generic-password", "-s", KEYCHAIN_SERVICE, "-a", account];
+  const tokenResult = spawnSync("security", securityArgs("token"), { stdio: "ignore" });
+  const cookieResult = spawnSync("security", securityArgs("cookie"), { stdio: "ignore" });
+  if (tokenResult.status === 0 || cookieResult.status === 0) {
     console.log("Deleted keychain entries");
-  } catch (e) {
+  } else {
     console.log("No keychain entries to delete");
   }
 

--- a/server.json
+++ b/server.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/jtalk22/slack-mcp-server",
     "source": "github"
   },
-  "version": "4.2.1",
+  "version": "4.2.2",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
     {
       "registryType": "npm",
       "identifier": "@jtalk22/slack-mcp",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## TL;DR

AgentScore advisory [AGENTSCORE-2026-0016](https://dev.to/) flagged v4.2.0 for `command_injection: shell execution with template literal input`. Score 90→80, LOW→MODERATE.

**Verdict: static-analysis false positive on both surfaces** — every variable inside the flagged template literals is a hardcoded internal constant. Shipping the defensive cleanup anyway because eliminating the pattern entirely is cheap and forward-proof.

## Why it's a false positive

| Site | Variable | Source | User-reachable? |
|---|---|---|---|
| `scripts/token-cli.js:146-147` | `KEYCHAIN_SERVICE` | `const KEYCHAIN_SERVICE = "slack-mcp-server"` (lib/token-store.js:18) | No — hardcoded literal |
| `lib/handlers.js:58` | `tempPath` | `\`\${filePath}.\${process.pid}.tmp\`` where `filePath` is an internal cache/token path | No — never from MCP tool input |

AgentScore is pattern-matching `execSync(\`...\${var}...\`)` without taint analysis. The pattern is real; the exploit path isn't.

## Why ship the fix anyway

1. Restores AgentScore to LOW.
2. Eliminates the class — any future refactor that accidentally introduces user-controlled input into these paths can't regress into a real injection.
3. ~5 minutes of work and 14 lines changed.

## Changes

- **`lib/handlers.js`** — atomicWriteSync()'s POSIX permission tightening drops the subprocess entirely. `execSync(\`chmod 600 \"\${tempPath}\"\`)` → `chmodSync(tempPath, 0o600)`. Pure-node, no shell context. `child_process` import removed.
- **`scripts/token-cli.js`** — `clearTokens()` keychain delete uses argv-array `spawnSync`. `execSync(\`security delete-generic-password ...\`)` → `spawnSync(\"security\", [\"delete-generic-password\", \"-s\", KEYCHAIN_SERVICE, \"-a\", \"token\"])`. Argv form bypasses shell parsing entirely.

## Verification

- `grep \"execSync\\|exec(\"` across all `package.json` `files` entries → **0 matches**
- `grep \"spawn(Sync)?(\\s*\\\`\"` (template literal as command argument) → **0 matches**
- `node -c lib/handlers.js && node -c scripts/token-cli.js` → both OK
- `import('./lib/handlers.js')` → loads clean
- `node scripts/check-public-surface-integrity.js` → EXIT 0

## Test plan
- [ ] CI green on lint + test (20.x) + test (22.x) + browser-smoke + attribution
- [ ] After publish: `npm view @jtalk22/slack-mcp dist-tags` → `latest: 4.2.2`
- [ ] After publish + AgentScore re-scan: score returns to ≥90, risk LOW