### PR TITLE
docs(diagram): polish session-token framing + remove dead text

### DIFF
--- a/docs/images/diagram-oauth-comparison.svg
+++ b/docs/images/diagram-oauth-comparison.svg
@@ -128,15 +128,11 @@
   <!-- Arrow down -->
   <line x1="673" y1="224" x2="673" y2="250" stroke="#4ecdc4" stroke-width="2" marker-end="url(#arrowOrange)"/>
 
-  <!-- Step 3: Full Access + Session-Token badge -->
+  <!-- Step 3: Session Token artifact -->
   <text x="555" y="270" fill="#4ecdc4" font-family="'Space Grotesk', 'Segoe UI', sans-serif" font-size="11" font-weight="700" opacity="0.7">3</text>
   <rect x="568" y="256" width="210" height="52" rx="8" fill="rgba(78,205,196,0.12)" stroke="#4ecdc4" stroke-width="1"/>
-  <text x="673" y="276" text-anchor="middle" fill="#4ecdc4" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif" font-size="13" font-weight="700">Full Access</text>
-  <!-- Session-Token sub-badge -->
-  <rect x="636" y="283" width="74" height="16" rx="4" fill="rgba(78,205,196,0.2)" stroke="#4ecdc4" stroke-width="0.5"/>
-  <text x="673" y="294" text-anchor="middle" fill="#4ecdc4" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif" font-size="8" font-weight="600" letter-spacing="0.06em">SESSION TOKEN</text>
-  <!-- No admin visibility — positioned below the badge -->
-  <text x="673" y="270" text-anchor="middle" fill="#777777" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif" font-size="0" opacity="0">No admin visibility</text>
+  <text x="673" y="280" text-anchor="middle" fill="#ffffff" font-family="'IBM Plex Sans', 'Segoe UI', sans-serif" font-size="14" font-weight="700">Session Token</text>
+  <text x="673" y="298" text-anchor="middle" fill="rgba(78,205,196,0.85)" font-family="'IBM Plex Mono', 'SF Mono', Menlo, monospace" font-size="10" letter-spacing="0.04em">xoxc + xoxd pair</text>
 
   <!-- Arrow down to result -->
   <line x1="673" y1="312" x2="673" y2="324" stroke="#4ecdc4" stroke-width="2" marker-end="url(#arrowOrange)"/>


### PR DESCRIPTION
## Summary

Operator flagged the README's OAuth-vs-session-token diagram during the v4.2.0 ship review: *\"the actual session token thing and some of rendering just needs be polished as another task follow on.\"*

This PR addresses both surfaces.

### Before

Step 3 box content:

- Headline: **Full Access**
- Sub-badge: small \`SESSION TOKEN\` pill (74×16 px, font-size 8)

Plus a dead invisible text element at line 139 (\`font-size=\"0\" opacity=\"0\"\`).

Two problems:
1. **\"Full Access\" overpromises.** Actual access matches whatever the operator's browser session has, which is whatever their Slack permissions are — could be admin, could be member. The result box already says *\"Same access as your browser session\"* which is more accurate.
2. **The artifact name was visually subordinate.** The actual thing the server obtains is the session token (\`xoxc-\` + \`xoxd-\` cookie pair), but it lived in a tiny pill instead of being the headline.

### After

Step 3 box content:

- Headline: **Session Token** (font-size 14, white)
- Sub-line: \`xoxc + xoxd pair\` (monospace, teal)

Result box unchanged — \"Same access as your browser session\" carries the access claim.

Dead hidden text removed.

### Why header stays \`CHROME DB DECRYPTION\`

Technically accurate to the mechanism: Chrome's safe-storage cookie DB is decrypted with PBKDF2 + AES-128-CBC (already named in Step 2's box). The header isn't wrong; the operator's flag was about Step 3, not the header.

### No version bump

\`docs/images/diagram-oauth-comparison.svg\` is not in \`package.json\` \`files\` (only \`docs/SETUP.md\`, \`docs/API.md\`, \`docs/TROUBLESHOOTING.md\`, \`docs/DEPLOYMENT-MODES.md\`, \`docs/assets/icon.svg\`, \`docs/assets/icon-512.png\` are shipped). \`README.md\` text doesn't change. GitHub rewrites relative image paths to \`raw.githubusercontent.com\` on npm README rendering, so the polish lands on npmjs.com too without a v4.2.3.

### Render verification

\`rsvg-convert --width 1200 --background-color white docs/images/diagram-oauth-comparison.svg\` produces a clean render with the new Step 3 layout. SVG is well-formed (no schema changes, just text content + element removal).

## Test plan
- [ ] CI green on lint + test (20.x) + test (22.x) + browser-smoke + attribution
- [ ] After merge: README on github.com/jtalk22/slack-mcp-server renders the polished diagram
- [ ] After merge: same on npmjs.com/package/@jtalk22/slack-mcp (CDN cache may take a few minutes)