### PR TITLE
v4.3.0: --refresh-tokens flag + LaunchAgent docs + tool-count alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,8 @@ docs/release-health/social-proof-*/
 
 # Wrangler cache
 workers/.wrangler/
+
+# Local-only release/sync helper scripts (not part of public package)
+scripts/publish-public.sh
+scripts/sync-from-onedrive.sh
+scripts/sync-to-onedrive.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.0] - 2026-05-12
+
+### Added
+- **`--refresh-tokens` CLI flag** — `npx -y @jtalk22/slack-mcp --refresh-tokens` now runs the Chrome auto-extract path (equivalent to `npm run tokens:auto`). Closes the gap between the wizard-only `--setup` flag and the unscheduled-by-default token-refresh capability. Designed to be called from a LaunchAgent, cron, or CI to keep tokens fresh while Claude is closed for weeks at a time.
+- **Token-refresh LaunchAgent docs** (`docs/SETUP.md`) — Optional macOS LaunchAgent template that runs `--refresh-tokens` twice a day, regardless of whether Claude is running. Closes the "tokens expired after vacation" failure mode. Honest about the trade-off (Chrome must be running for extraction to succeed).
+
+### Changed
+- **Tool count in maintainer docs** — `CLAUDE.md` updated from 16 to 21 tools, regrouped into Slack reads (12) / Slack writes (4) / workflow primitives (2) / hosted-brain upgrade stubs (3). Aligns with README's Tools section.
+- **README clarity** — Workflow Primitives heading no longer pinned to "(new in 4.2)" — version info moved into body copy. Footer math clarified: "16 Slack tools (12 read, 4 write)" replaces the ambiguous "all 16 read/write Slack tools". "What's New in 4.2.0" section now collapsible (`<details>`) — sets a maintenance pattern for future release-note rollups.
+
+### Fixed
+- **SETUP.md troubleshooting** — "Verify the path to server.js is correct" replaced with "Verify JSON syntax in your client's MCP config", aligning with the npx invocation pattern that's already canonical elsewhere in the docs.
+
 ## [4.1.2] - 2026-04-12
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,26 +24,30 @@ npx -y @jtalk22/slack-mcp      # package entrypoint
 docker pull ghcr.io/jtalk22/slack-mcp-server:latest
 ```
 
-## MCP Tools
+## MCP Tools (21 total)
+
+**Slack reads (12):**
 
 | Tool | Purpose |
 |------|---------|
 | `slack_health_check` | Verify token validity and show workspace info |
-| `slack_token_status` | Check current token health |
-| `slack_refresh_tokens` | Auto-extract fresh tokens from Chrome |
+| `slack_token_status` | Token age, health, cache stats |
+| `slack_refresh_tokens` | Auto-extract fresh tokens from Chrome (macOS) |
 | `slack_list_conversations` | List DMs and channels with resolved names |
 | `slack_conversations_history` | Get messages from a channel or DM |
 | `slack_get_full_conversation` | Export full history with threads |
 | `slack_search_messages` | Search across workspace |
-| `slack_send_message` | Send a message |
 | `slack_get_thread` | Get thread replies |
 | `slack_users_info` | Get user details |
-| `slack_list_users` | List workspace users |
-| `slack_add_reaction` | Add emoji reaction to a message |
-| `slack_remove_reaction` | Remove emoji reaction from a message |
-| `slack_conversations_mark` | Mark conversation as read |
-| `slack_conversations_unreads` | Get channels/DMs with unread messages |
-| `slack_users_search` | Search users by name/email |
+| `slack_list_users` | List workspace users (paginated, 500+) |
+| `slack_users_search` | Search by name, display name, or email |
+| `slack_conversations_unreads` | Channels/DMs with unread messages |
+
+**Slack writes (4):** `slack_send_message`, `slack_add_reaction`, `slack_remove_reaction`, `slack_conversations_mark` — all carry MCP `destructive` safety annotation.
+
+**Workflow primitives (2):** `slack_workflow_save`, `slack_workflows` — bind a `workflow_kind` (`incident_room`, `exec_brief`, `support_inbox`, `product_launch_watch`, `custom`) to channels + priority people + retention + cadence. Stored locally at `~/.slack-mcp-workflows.json`.
+
+**Hosted-brain upgrade stubs (3):** `slack_smart_search`, `slack_catch_me_up`, `slack_triage` — return `{signup_url, free_tier_quota, pro_value_prop}` payloads pointing at `mcp.revasserlabs.com`. No Slack write occurs from OSS.
 
 ## Token Persistence Layers
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ This server uses your browser's session tokens instead. If you can see it in Sla
 | Tools | Limited | **21** |
 | Visible to admins | Yes | **No — session-token transport** |
 
-## Workflow Primitives (new in 4.2)
+## Workflow Primitives
 
-Save a workflow profile that binds a `workflow_kind` to channels + priority people + retention + cadence. Stored locally at `~/.slack-mcp-workflows.json`. The hosted brain at [mcp.revasserlabs.com](https://mcp.revasserlabs.com) reads these profiles and returns **structured JSON per workflow_kind** — downstream automation (Linear, Notion, status dashboards) consumes the JSON directly.
+Introduced in 4.2. Save a workflow profile that binds a `workflow_kind` to channels + priority people + retention + cadence. Stored locally at `~/.slack-mcp-workflows.json`. The hosted brain at [mcp.revasserlabs.com](https://mcp.revasserlabs.com) reads these profiles and returns **structured JSON per workflow_kind** — downstream automation (Linear, Notion, status dashboards) consumes the JSON directly.
 
 | `workflow_kind` | Returns (structured JSON) |
 |---|---|
@@ -305,7 +305,8 @@ Session tokens (`xoxc-` + `xoxd-`) from your browser. If you can see it in Slack
 
 Tokens expire. The server notices before you do — proactive health monitoring, automatic refresh on macOS, warnings when tokens age out. File writes are atomic (temp file → chmod → rename) to prevent corruption. Concurrent refresh attempts are mutex-locked.
 
-## What's New in 4.2.0
+<details>
+<summary><strong>What's New in 4.2.0</strong></summary>
 
 - **Workflow primitives** — `slack_workflow_save` + `slack_workflows` bind a `workflow_kind` (`incident_room`, `exec_brief`, `support_inbox`, `product_launch_watch`, `custom`) to channels, priority people, retention, and cadence. The hosted brain returns structured JSON per kind — `incident_room` returns `{incident_summary, timeline, open_risks, owner_gaps, next_actions}`, `exec_brief` returns `{summary, decisions, risks, asks, action_items}`. Downstream automation (Linear, Notion, dashboards) consumes the JSON directly.
 - **Discoverable upgrade stubs** — `slack_smart_search`, `slack_catch_me_up`, `slack_triage` appear in OSS as upgrade payloads pointing at the hosted brain. Response shape is `{signup_url, free_tier_quota, pro_value_prop}` — no interruptions, the AI routes the user cleanly.
@@ -314,6 +315,8 @@ Tokens expire. The server notices before you do — proactive health monitoring,
 - **Prior reliability fixes carried forward** — LevelDB token extraction, multi-profile enumeration, and explicit SIGTERM/SIGINT/SIGHUP/stdin shutdown handlers ship in 4.2.0 too.
 
 Full release notes on [GitHub releases/latest](https://github.com/jtalk22/slack-mcp-server/releases/latest).
+
+</details>
 
 ## Hosted HTTP Mode
 
@@ -331,7 +334,7 @@ Details: [docs/DEPLOYMENT-MODES.md](docs/DEPLOYMENT-MODES.md)
 
 ## Troubleshooting
 
-**Tokens expired:** Run `npx -y @jtalk22/slack-mcp --setup` or use `slack_refresh_tokens` (macOS).
+**Tokens expired:** Run `npx -y @jtalk22/slack-mcp --setup` or use `slack_refresh_tokens` (macOS). To prevent silent expiration during long Claude-idle windows, set up the optional [token-refresh LaunchAgent](docs/SETUP.md#keep-tokens-fresh-while-claude-is-closed-macos-optional).
 
 **DMs not showing:** Use `slack_list_conversations` with `discover_dms=true`.
 
@@ -371,4 +374,4 @@ Not affiliated with Slack Technologies, Inc. Uses browser session credentials �
 
 ---
 
-Hosted version live at [mcp.revasserlabs.com](https://mcp.revasserlabs.com): Free tier (no card), $9/mo Pro, $49/mo Team flat, Ops from $199/mo. Hosted owns the AI brain (smart_search, catch_me_up, triage), the scheduled morning catch-up DM at 8am workspace time *(rolling out Q2 2026)*, permanent OAuth (no 2-week token rotation), 90-day Vectorize retention, and shared workflow profiles. The OSS package owns local stdio + all 16 read/write Slack tools + workflow profile primitives (slack_workflow_save, slack_workflows). The 3 paid stubs (slack_smart_search, slack_catch_me_up, slack_triage) appear in OSS as discoverable upgrade prompts.
+Hosted version live at [mcp.revasserlabs.com](https://mcp.revasserlabs.com): Free tier (no card), $9/mo Pro, $49/mo Team flat, Ops from $199/mo. Hosted owns the AI brain (smart_search, catch_me_up, triage), the scheduled morning catch-up DM at 8am workspace time *(rolling out Q2 2026)*, permanent OAuth (no 2-week token rotation), 90-day Vectorize retention, and shared workflow profiles. The OSS package owns local stdio + the 16 Slack tools (12 read, 4 write) + workflow profile primitives (slack_workflow_save, slack_workflows). The 3 paid stubs (slack_smart_search, slack_catch_me_up, slack_triage) appear in OSS as discoverable upgrade prompts.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -138,6 +138,54 @@ slack_health_check
 
 You should see your username and team name.
 
+## Keep Tokens Fresh While Claude Is Closed (macOS, Optional)
+
+The MCP server auto-refreshes tokens every 4 hours while Claude is running. But if you keep Claude closed for a couple weeks, tokens expire silently — your next session opens with `invalid_auth`.
+
+A LaunchAgent fixes this. It runs token refresh twice a day regardless of whether Claude is open, as long as Chrome is running with a Slack tab somewhere.
+
+Create `~/Library/LaunchAgents/com.yourname.slack-token-refresh.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.yourname.slack-token-refresh</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>export NVM_DIR="$HOME/.nvm" &amp;&amp; [ -s "$NVM_DIR/nvm.sh" ] &amp;&amp; \. "$NVM_DIR/nvm.sh" &amp;&amp; exec npx -y @jtalk22/slack-mcp --refresh-tokens</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <array>
+        <dict><key>Hour</key><integer>6</integer><key>Minute</key><integer>17</integer></dict>
+        <dict><key>Hour</key><integer>18</integer><key>Minute</key><integer>17</integer></dict>
+    </array>
+    <key>RunAtLoad</key><true/>
+    <key>StandardErrorPath</key><string>/tmp/slack-token-refresh.log</string>
+</dict>
+</plist>
+```
+
+Load it:
+
+```bash
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.yourname.slack-token-refresh.plist
+```
+
+Check it ran:
+
+```bash
+tail /tmp/slack-token-refresh.log
+```
+
+**Why the `bash -c` wrapper:** LaunchAgents start without a TTY, so a bare `node` won't be on PATH if you use nvm. The wrapper sources `nvm.sh` first, then runs the refresher. (If you installed node via Homebrew, replace the whole inner command with `/opt/homebrew/bin/node /opt/homebrew/bin/npx -y @jtalk22/slack-mcp --refresh-tokens`.)
+
+**Trade-off:** Chrome must be running for extraction to succeed. If it's not, the LaunchAgent logs "Failed to extract" and tokens stay where they are — which is fine for another 12 hours.
+
 ## Troubleshooting
 
 ### "No credentials found"
@@ -151,7 +199,7 @@ Tokens have expired. Run `npx -y @jtalk22/slack-mcp --doctor` and follow the sug
 ### MCP Server Not Loading
 
 1. Check `~/.claude.json` syntax
-2. Verify the path to server.js is correct
+2. Verify JSON syntax in your client's MCP config
 3. Restart Claude Code
 
 ### Chrome Extraction Fails

--- a/glama.json
+++ b/glama.json
@@ -4,7 +4,7 @@
   "description": "Slack MCP without OAuth. 21 tools (16 read/write Slack + 2 workflow profile primitives + 3 hosted-brain upgrade stubs). Free OSS or hosted (free tier no card; $9/mo Pro = unlimited; morning DM rolling out Q2 2026).",
   "repository": "https://github.com/jtalk22/slack-mcp-server",
   "homepage": "https://mcp.revasserlabs.com",
-  "version": "4.2.2",
+  "version": "4.3.0",
   "license": "MIT",
   "maintainers": ["jtalk22"],
   "categories": ["communication", "productivity"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jtalk22/slack-mcp",
-  "version": "4.2.2",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jtalk22/slack-mcp",
-      "version": "4.2.2",
+      "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jtalk22/slack-mcp",
   "mcpName": "io.github.jtalk22/slack-mcp-server",
-  "version": "4.2.2",
+  "version": "4.3.0",
   "description": "Slack MCP without OAuth. 21 tools (16 read/write Slack + 2 workflow profile primitives + 3 hosted-brain upgrade stubs). Free OSS or hosted (free tier no card; $9/mo Pro = unlimited; morning DM rolling out Q2 2026).",
   "type": "module",
   "main": "src/server.js",

--- a/server.json
+++ b/server.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/jtalk22/slack-mcp-server",
     "source": "github"
   },
-  "version": "4.2.2",
+  "version": "4.3.0",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
     {
       "registryType": "npm",
       "identifier": "@jtalk22/slack-mcp",
-      "version": "4.2.2",
+      "version": "4.3.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/cli.js
+++ b/src/cli.js
@@ -37,6 +37,9 @@ if (firstArg === "web") {
 } else if (firstArg === "--apply-template" || firstArg === "apply-template") {
   scriptPath = join(__dirname, "../scripts/apply-template.js");
   scriptArgs = args.slice(1);
+} else if (firstArg === "--refresh-tokens" || firstArg === "refresh-tokens") {
+  scriptPath = join(__dirname, "../scripts/token-cli.js");
+  scriptArgs = ["auto"];
 } else if (WIZARD_ARGS.has(firstArg)) {
   scriptPath = join(__dirname, "../scripts/setup-wizard.js");
   scriptArgs = args;


### PR DESCRIPTION
## Summary

- New `--refresh-tokens` CLI flag in `src/cli.js` (4-line dispatcher branch) maps to `scripts/token-cli.js auto`, so `npx -y @jtalk22/slack-mcp --refresh-tokens` is a clean one-line LaunchAgent invocation.
- New optional macOS LaunchAgent template in `docs/SETUP.md` runs `--refresh-tokens` twice a day. Closes the "tokens expired after vacation" failure mode honestly (Chrome must be running for extraction to succeed).
- Visual review fixes: drop "(new in 4.2)" from Workflow Primitives heading, clarify footer math ("16 Slack tools (12 read, 4 write)"), wrap "What's New in 4.2.0" in `<details>`, surface LaunchAgent under Troubleshooting "Tokens expired".
- `CLAUDE.md` updated from 16 → 21 tools, regrouped (12 reads / 4 writes / 2 workflow primitives / 3 hosted-brain upgrade stubs).
- Version parity: `package.json`, `package-lock.json`, `server.json`, `glama.json` all bumped 4.2.2 → 4.3.0.

## Why MINOR (4.2 → 4.3, not 4.2.3)

`--refresh-tokens` adds documented, backwards-compatible user-facing functionality. SemVer says MINOR. Calling it a patch would under-flag the new flag in changelog scanning.

## Test plan

- [x] `node --check src/cli.js` clean
- [x] `node src/cli.js --refresh-tokens` routes to token-cli.js `auto` and exits 0 cleanly even when Chrome/Slack are closed (exactly the LaunchAgent failure-tolerant behavior we want)
- [x] `node src/cli.js --version` reports `slack-mcp-server v4.3.0`
- [x] `node src/cli.js --help` still renders existing usage block
- [x] `plutil -lint` on the LaunchAgent XML extracted from SETUP.md: OK
- [x] `npm pack --dry-run` shows both `src/cli.js` and `docs/SETUP.md` ship in tarball
- [x] `bash scripts/check-public-language.sh`: pass
- [x] `node scripts/verify-generated-public-pages.js`: pass (no drift)
- [x] `node scripts/verify-attribution-guardrail.js`: pass
- [x] `node scripts/check-public-surface-integrity.js`: pass (all version-parity, description-parity, tool-count, CLI-version, version-neutral HTML checks green)
- [ ] CI green on this PR
- [ ] After merge: `git tag v4.3.0`, GitHub Release named v4.3.0 triggers `publish.yml` for provenance-signed npm publish
- [ ] End-to-end: in fresh tmpdir, `npx -y @jtalk22/slack-mcp@4.3.0 --refresh-tokens` with Chrome+Slack open exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--refresh-tokens` CLI flag to support automated token refresh on macOS.

* **Documentation**
  * Added LaunchAgent setup and troubleshooting guidance for token refresh.
  * Clarified workflow primitives and Slack tool counts (12 read, 4 write).
  * Updated README and maintainer notes with wording and troubleshooting improvements.
  * Added changelog entry for v4.3.0.

* **Chores**
  * Bumped version to 4.3.0.
  * Updated ignore list to exclude local cache and helper scripts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jtalk22/slack-mcp-server/pull/135)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->