### PR TITLE
chore(changelog): backfill v4.2.0 through v4.3.0 compare links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -390,6 +390,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.0.6]: https://github.com/jtalk22/slack-mcp-server/compare/v1.0.5...v1.0.6
 [1.0.5]: https://github.com/jtalk22/slack-mcp-server/compare/v1.0.0...v1.0.5
 [1.0.0]: https://github.com/jtalk22/slack-mcp-server/releases/tag/v1.0.0
+[4.3.0]: https://github.com/jtalk22/slack-mcp-server/compare/v4.2.2...v4.3.0
+[4.2.2]: https://github.com/jtalk22/slack-mcp-server/compare/v4.2.1...v4.2.2
+[4.2.1]: https://github.com/jtalk22/slack-mcp-server/compare/v4.2.0...v4.2.1
+[4.2.0]: https://github.com/jtalk22/slack-mcp-server/compare/v4.1.2...v4.2.0
 [4.1.2]: https://github.com/jtalk22/slack-mcp-server/compare/v4.1.1...v4.1.2
 [4.1.1]: https://github.com/jtalk22/slack-mcp-server/compare/v4.1.0...v4.1.1
 [4.1.0]: https://github.com/jtalk22/slack-mcp-server/compare/v4.0.0...v4.1.0


### PR DESCRIPTION
Backfills the four missing version-compare link references at the bottom of `CHANGELOG.md` (4.2.0, 4.2.1, 4.2.2, 4.3.0). Docs-only; no source, package, or surface changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog with version reference links for recent releases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jtalk22/slack-mcp-server/pull/136)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->