### PR TITLE
Expose rich Slack message fields

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -119,8 +119,8 @@ Get messages from a channel or DM.
 |------|------|---------|-------------|
 | channel_id | string | *required* | Channel or DM ID |
 | limit | number | 50 | Messages to fetch (max 100) |
-| oldest | string | - | Unix timestamp, get messages after |
-| latest | string | - | Unix timestamp, get messages before |
+| oldest | string | - | Unix timestamp, get messages after; matching boundary timestamp is included |
+| latest | string | - | Unix timestamp, get messages before; matching boundary timestamp is included |
 | resolve_users | boolean | true | Convert user IDs to names |
 | include_rich_message_fields | boolean | false | Include Slack attachments, blocks, metadata, files, and reactions when present |
 | include_all_metadata | boolean | false | Pass Slack's `include_all_metadata` option to `conversations.history` |
@@ -162,12 +162,12 @@ Export full conversation with threads.
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
 | channel_id | string | *required* | Channel or DM ID |
-| oldest | string | - | Unix timestamp start |
-| latest | string | - | Unix timestamp end |
+| oldest | string | - | Unix timestamp start; matching boundary timestamp is included |
+| latest | string | - | Unix timestamp end; matching boundary timestamp is included |
 | max_messages | number | 2000 | Max messages (up to 10000) |
 | include_threads | boolean | true | Fetch thread replies |
 | include_rich_message_fields | boolean | false | Include Slack attachments, blocks, metadata, files, and reactions when present |
-| include_all_metadata | boolean | false | Pass Slack's `include_all_metadata` option to `conversations.history` |
+| include_all_metadata | boolean | false | Pass Slack's `include_all_metadata` option to `conversations.history` and `conversations.replies` |
 | output_file | string | - | Filename (saved to ~/.slack-mcp-exports/) |
 
 **Timestamps:**

--- a/docs/API.md
+++ b/docs/API.md
@@ -122,6 +122,8 @@ Get messages from a channel or DM.
 | oldest | string | - | Unix timestamp, get messages after |
 | latest | string | - | Unix timestamp, get messages before |
 | resolve_users | boolean | true | Convert user IDs to names |
+| include_rich_message_fields | boolean | false | Include Slack attachments, blocks, metadata, files, and reactions when present |
+| include_all_metadata | boolean | false | Pass Slack's `include_all_metadata` option to `conversations.history` |
 
 **Returns:**
 ```json
@@ -136,11 +138,19 @@ Get messages from a channel or DM.
       "user_id": "U05GPEVH7J9",
       "text": "Hello!",
       "datetime": "2026-01-02T15:33:50.000Z",
-      "has_thread": false
+      "has_thread": false,
+      "attachments": [
+        {
+          "text": "Additional message context"
+        }
+      ]
     }
   ]
 }
 ```
+
+`attachments`, `blocks`, `metadata`, `files`, and `reactions` are returned only when
+`include_rich_message_fields` is true and Slack includes those fields in the API response.
 
 ---
 
@@ -156,6 +166,8 @@ Export full conversation with threads.
 | latest | string | - | Unix timestamp end |
 | max_messages | number | 2000 | Max messages (up to 10000) |
 | include_threads | boolean | true | Fetch thread replies |
+| include_rich_message_fields | boolean | false | Include Slack attachments, blocks, metadata, files, and reactions when present |
+| include_all_metadata | boolean | false | Pass Slack's `include_all_metadata` option to `conversations.history` |
 | output_file | string | - | Filename (saved to ~/.slack-mcp-exports/) |
 
 **Timestamps:**
@@ -188,6 +200,7 @@ Search messages across the workspace.
 |------|------|---------|-------------|
 | query | string | *required* | Search query |
 | count | number | 20 | Number of results (max 100) |
+| include_rich_message_fields | boolean | false | Include Slack attachments, blocks, metadata, files, and reactions when present |
 
 **Query Syntax:**
 - `from:@username` - From specific user
@@ -249,6 +262,8 @@ Get all replies in a thread.
 |------|------|---------|-------------|
 | channel_id | string | *required* | Channel or DM ID |
 | thread_ts | string | *required* | Thread parent timestamp |
+| include_rich_message_fields | boolean | false | Include Slack attachments, blocks, metadata, files, and reactions when present |
+| include_all_metadata | boolean | false | Pass Slack's `include_all_metadata` option to `conversations.replies` |
 
 **Returns:**
 ```json

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -46,6 +46,24 @@ function asMcpJson(payload, isError = false) {
   };
 }
 
+function withRichMessageFields(output, msg, includeRichMessageFields) {
+  if (!includeRichMessageFields) return output;
+
+  for (const key of ["attachments", "blocks", "metadata", "files", "reactions"]) {
+    if (msg[key] !== undefined) {
+      output[key] = msg[key];
+    }
+  }
+
+  for (const key of ["subtype", "bot_id", "app_id", "team"]) {
+    if (msg[key] !== undefined) {
+      output[key] = msg[key];
+    }
+  }
+
+  return output;
+}
+
 /**
  * Atomic write to prevent file corruption from concurrent writes
  */
@@ -334,17 +352,19 @@ export async function handleListConversations(args) {
  */
 export async function handleConversationsHistory(args) {
   const resolveUsers = args.resolve_users !== false;
+  const includeRichMessageFields = parseBool(args.include_rich_message_fields);
   const result = await slackAPI("conversations.history", {
     channel: args.channel_id,
     limit: args.limit || 50,
     oldest: args.oldest,
     latest: args.latest,
-    inclusive: true
+    inclusive: true,
+    include_all_metadata: parseBool(args.include_all_metadata)
   });
 
   const messages = await Promise.all((result.messages || []).map(async (msg) => {
     const userName = resolveUsers ? await resolveUser(msg.user) : msg.user;
-    return {
+    return withRichMessageFields({
       ts: msg.ts,
       user: userName,
       user_id: msg.user,
@@ -352,7 +372,7 @@ export async function handleConversationsHistory(args) {
       datetime: formatTimestamp(msg.ts),
       has_thread: !!msg.thread_ts && msg.reply_count > 0,
       reply_count: msg.reply_count
-    };
+    }, msg, includeRichMessageFields);
   }));
 
   return {
@@ -374,6 +394,7 @@ export async function handleConversationsHistory(args) {
 export async function handleGetFullConversation(args) {
   const maxMessages = Math.min(args.max_messages || 2000, 10000);
   const includeThreads = args.include_threads !== false;
+  const includeRichMessageFields = parseBool(args.include_rich_message_fields);
   const allMessages = [];
   let cursor;
   let hasMore = true;
@@ -386,19 +407,20 @@ export async function handleGetFullConversation(args) {
       oldest: args.oldest,
       latest: args.latest,
       cursor,
-      inclusive: true
+      inclusive: true,
+      include_all_metadata: parseBool(args.include_all_metadata)
     });
 
     for (const msg of result.messages || []) {
       const userName = await resolveUser(msg.user);
-      const message = {
+      const message = withRichMessageFields({
         ts: msg.ts,
         user: userName,
         user_id: msg.user,
         text: msg.text || "",
         datetime: formatTimestamp(msg.ts),
         replies: []
-      };
+      }, msg, includeRichMessageFields);
 
       // Fetch thread replies if present
       if (includeThreads && msg.reply_count > 0) {
@@ -410,12 +432,12 @@ export async function handleGetFullConversation(args) {
           // Skip first message (parent)
           for (const reply of (threadResult.messages || []).slice(1)) {
             const replyUserName = await resolveUser(reply.user);
-            message.replies.push({
+            message.replies.push(withRichMessageFields({
               ts: reply.ts,
               user: replyUserName,
               text: reply.text || "",
               datetime: formatTimestamp(reply.ts)
-            });
+            }, reply, includeRichMessageFields));
           }
           await sleep(50); // Rate limit
         } catch (e) {
@@ -470,6 +492,7 @@ export async function handleGetFullConversation(args) {
  * Search messages handler
  */
 export async function handleSearchMessages(args) {
+  const includeRichMessageFields = parseBool(args.include_rich_message_fields);
   const result = await slackAPI("search.messages", {
     query: args.query,
     count: args.count || 20,
@@ -477,7 +500,7 @@ export async function handleSearchMessages(args) {
     sort_dir: "desc"
   });
 
-  const matches = await Promise.all((result.messages?.matches || []).map(async (m) => ({
+  const matches = await Promise.all((result.messages?.matches || []).map(async (m) => withRichMessageFields({
     ts: m.ts,
     channel: m.channel?.name || m.channel?.id,
     channel_id: m.channel?.id,
@@ -485,7 +508,7 @@ export async function handleSearchMessages(args) {
     text: m.text,
     datetime: formatTimestamp(m.ts),
     permalink: m.permalink
-  })));
+  }, m, includeRichMessageFields)));
 
   return {
     content: [{
@@ -553,19 +576,21 @@ export async function handleSendMessage(args) {
  * Get thread handler
  */
 export async function handleGetThread(args) {
+  const includeRichMessageFields = parseBool(args.include_rich_message_fields);
   const result = await slackAPI("conversations.replies", {
     channel: args.channel_id,
-    ts: args.thread_ts
+    ts: args.thread_ts,
+    include_all_metadata: parseBool(args.include_all_metadata)
   });
 
-  const messages = await Promise.all((result.messages || []).map(async (msg) => ({
+  const messages = await Promise.all((result.messages || []).map(async (msg) => withRichMessageFields({
     ts: msg.ts,
     user: await resolveUser(msg.user),
     user_id: msg.user,
     text: msg.text || "",
     datetime: formatTimestamp(msg.ts),
     is_parent: msg.ts === args.thread_ts
-  })));
+  }, msg, includeRichMessageFields)));
 
   return {
     content: [{

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -46,16 +46,15 @@ function asMcpJson(payload, isError = false) {
   };
 }
 
+const RICH_MESSAGE_KEYS = [
+  "attachments", "blocks", "metadata", "files", "reactions",
+  "subtype", "bot_id", "app_id", "team"
+];
+
 function withRichMessageFields(output, msg, includeRichMessageFields) {
-  if (!includeRichMessageFields) return output;
+  if (!includeRichMessageFields || !msg) return output;
 
-  for (const key of ["attachments", "blocks", "metadata", "files", "reactions"]) {
-    if (msg[key] !== undefined) {
-      output[key] = msg[key];
-    }
-  }
-
-  for (const key of ["subtype", "bot_id", "app_id", "team"]) {
+  for (const key of RICH_MESSAGE_KEYS) {
     if (msg[key] !== undefined) {
       output[key] = msg[key];
     }
@@ -427,7 +426,8 @@ export async function handleGetFullConversation(args) {
         try {
           const threadResult = await slackAPI("conversations.replies", {
             channel: args.channel_id,
-            ts: msg.ts
+            ts: msg.ts,
+            include_all_metadata: parseBool(args.include_all_metadata)
           });
           // Skip first message (parent)
           for (const reply of (threadResult.messages || []).slice(1)) {

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -93,11 +93,11 @@ export const TOOLS = [
         },
         oldest: {
           type: "string",
-          description: "Unix timestamp - get messages after this time"
+          description: "Unix timestamp - get messages after this time (boundary timestamp included)"
         },
         latest: {
           type: "string",
-          description: "Unix timestamp - get messages before this time"
+          description: "Unix timestamp - get messages before this time (boundary timestamp included)"
         },
         resolve_users: {
           type: "boolean",
@@ -133,11 +133,11 @@ export const TOOLS = [
         },
         oldest: {
           type: "string",
-          description: "Unix timestamp start (e.g., 1733011200 = Dec 1, 2025)"
+          description: "Unix timestamp start (e.g., 1733011200 = Dec 1, 2025; boundary timestamp included)"
         },
         latest: {
           type: "string",
-          description: "Unix timestamp end"
+          description: "Unix timestamp end (boundary timestamp included)"
         },
         max_messages: {
           type: "number",
@@ -153,7 +153,7 @@ export const TOOLS = [
         },
         include_all_metadata: {
           type: "boolean",
-          description: "Pass Slack's include_all_metadata option to conversations.history"
+          description: "Pass Slack's include_all_metadata option to conversations.history and conversations.replies"
         },
         output_file: {
           type: "string",

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -102,6 +102,14 @@ export const TOOLS = [
         resolve_users: {
           type: "boolean",
           description: "Convert user IDs to names (default true)"
+        },
+        include_rich_message_fields: {
+          type: "boolean",
+          description: "Include Slack message attachments, blocks, metadata, files, and reactions when present"
+        },
+        include_all_metadata: {
+          type: "boolean",
+          description: "Pass Slack's include_all_metadata option to conversations.history"
         }
       },
       required: ["channel_id"]
@@ -139,6 +147,14 @@ export const TOOLS = [
           type: "boolean",
           description: "Fetch thread replies (default true)"
         },
+        include_rich_message_fields: {
+          type: "boolean",
+          description: "Include Slack message attachments, blocks, metadata, files, and reactions when present"
+        },
+        include_all_metadata: {
+          type: "boolean",
+          description: "Pass Slack's include_all_metadata option to conversations.history"
+        },
         output_file: {
           type: "string",
           description: "Filename to save export (saved to ~/.slack-mcp-exports/)"
@@ -166,6 +182,10 @@ export const TOOLS = [
         count: {
           type: "number",
           description: "Number of results (max 100, default 20)"
+        },
+        include_rich_message_fields: {
+          type: "boolean",
+          description: "Include Slack message attachments, blocks, metadata, files, and reactions when present"
         }
       },
       required: ["query"]
@@ -239,6 +259,14 @@ export const TOOLS = [
         thread_ts: {
           type: "string",
           description: "Thread parent message timestamp"
+        },
+        include_rich_message_fields: {
+          type: "boolean",
+          description: "Include Slack message attachments, blocks, metadata, files, and reactions when present"
+        },
+        include_all_metadata: {
+          type: "boolean",
+          description: "Pass Slack's include_all_metadata option to conversations.replies"
         }
       },
       required: ["channel_id", "thread_ts"]


### PR DESCRIPTION
Adds an opt-in include_rich_message_fields parameter to the local read tools so agents can access Slack attachments, blocks, metadata, files, and reactions when Slack returns them.\n\nThis preserves the existing default output shape while allowing alerting and incident workflows to read context that Slack stores outside message text, such as attachment-only alert details.\n\nAlso passes Slack's include_all_metadata option through to conversations.history and conversations.replies when requested.\n\nValidated locally by confirming conversations.history returns attachment text when include_rich_message_fields is true, and by running:\n- node --check lib/handlers.js\n- node --check lib/tools.js\n- npm run verify:public-surface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded API docs to describe new optional parameters for Slack message retrieval, including toggles for rich message fields and additional metadata.

* **New Features**
  * Conversation history, full conversation, thread, and search tools can now return enriched message data (attachments, blocks, metadata, files, reactions) when the new toggles are enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->