### PR TITLE
release: 4.4.0 — rich message fields (#143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.4.0] - 2026-06-09
 
 ### Added
-- **Rich message fields** — opt-in `include_rich_message_fields` on `slack_conversations_history`, `slack_get_full_conversation`, `slack_get_thread`, and `slack_search_messages`. Surfaces the Slack fields that live outside `text` — `attachments`, `blocks`, `files`, `reactions`, `metadata`, plus `subtype`/`bot_id`/`app_id`/`team` — so attachment-only and bot/app messages no longer read as empty. Opt-in per call to keep client context lean. The independent `include_all_metadata` flag additionally returns the full developer `event_payload`. Patch by @rvandam (#143).
-- **First unit tests** (`node --test`, wired into CI) — cover the rich-message-fields merge helper and tool-schema shape (opt-in present on the four read tools; `include_all_metadata` correctly absent from search).
+- `include_rich_message_fields` (opt-in) on `slack_conversations_history`, `slack_get_full_conversation`, `slack_get_thread`, and `slack_search_messages`: surfaces `attachments`, `blocks`, `files`, `reactions`, `metadata`, `subtype`, `bot_id`, `app_id`, and `team`. Independent `include_all_metadata` adds the full `event_payload`. (#143, thanks @rvandam)
+- Unit test suite (`node --test`, wired into CI) covering the rich-fields merge helper and tool schemas.
 
 ## [4.3.0] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.4.0] - 2026-06-09
+
+### Added
+- **Rich message fields** — opt-in `include_rich_message_fields` on `slack_conversations_history`, `slack_get_full_conversation`, `slack_get_thread`, and `slack_search_messages`. Surfaces the Slack fields that live outside `text` — `attachments`, `blocks`, `files`, `reactions`, `metadata`, plus `subtype`/`bot_id`/`app_id`/`team` — so attachment-only and bot/app messages no longer read as empty. Opt-in per call to keep client context lean. The independent `include_all_metadata` flag additionally returns the full developer `event_payload`. Patch by @rvandam (#143).
+- **First unit tests** (`node --test`, wired into CI) — cover the rich-message-fields merge helper and tool-schema shape (opt-in present on the four read tools; `include_all_metadata` correctly absent from search).
+
 ## [4.3.0] - 2026-05-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ Or via CLI: `codex mcp add slack -- npx -y @jtalk22/slack-mcp`
 | `slack_token_status` | Token age, health, and cache stats | read-only |
 | `slack_refresh_tokens` | Auto-extract fresh tokens from Chrome | read-only* |
 | `slack_list_conversations` | List DMs and channels | read-only |
-| `slack_conversations_history` | Get messages from a channel or DM | read-only |
-| `slack_get_full_conversation` | Export full history with threads | read-only |
-| `slack_search_messages` | Search across workspace | read-only |
-| `slack_get_thread` | Get thread replies | read-only |
+| `slack_conversations_history` ‡ | Get messages from a channel or DM | read-only |
+| `slack_get_full_conversation` ‡ | Export full history with threads | read-only |
+| `slack_search_messages` ‡ | Search across workspace | read-only |
+| `slack_get_thread` ‡ | Get thread replies | read-only |
 | `slack_users_info` | Get user details | read-only |
 | `slack_list_users` | List workspace users (paginated, 500+) | read-only |
 | `slack_users_search` | Search users by name, display name, or email | read-only |
@@ -161,6 +161,8 @@ Or via CLI: `codex mcp add slack -- npx -y @jtalk22/slack-mcp`
 
 † Hosted stubs return a structured upgrade payload (`signup_url`, `free_tier_quota`, `pro_value_prop`) — no Slack write occurs from OSS. Activate the brain at [mcp.revasserlabs.com](https://mcp.revasserlabs.com) (free tier, no card).
 
+‡ Also accepts `include_rich_message_fields` to return attachments, blocks, files, reactions, and metadata — see [Rich Message Fields](#rich-message-fields).
+
 ## Install
 
 **Node.js 20+**
@@ -170,6 +172,8 @@ npx -y @jtalk22/slack-mcp --setup
 ```
 
 The setup wizard handles token extraction and validation.
+
+After setup, have your client run `slack_health_check` — a workspace name in the response confirms you are connected.
 
 <details>
 <summary><strong>Claude Desktop (macOS)</strong></summary>
@@ -318,6 +322,20 @@ Full release notes on [GitHub releases/latest](https://github.com/jtalk22/slack-
 
 </details>
 
+## Rich Message Fields
+
+Added in 4.4.0. The four read tools marked ‡ above accept `include_rich_message_fields: true`, which surfaces the parts of a message that live outside `text`:
+
+- `attachments`, `blocks`, `files`, `reactions`, `metadata`
+- `subtype`, `bot_id`, `app_id` — markers that flag automated, bot, or app messages
+- `team` — the workspace id, present on every message
+
+This changes output shape only and requires no extra permissions. `blocks` in particular can be large, so it is opt-in per call to keep client context lean. For the full developer payload inside `metadata`, also set `include_all_metadata: true` (an independent Slack flag).
+
+`slack_search_messages` accepts the flag, but Slack's search API does not return rich fields on matches — read the full content with `slack_conversations_history` or `slack_get_thread` on the match's channel and timestamp.
+
+Patch by [@rvandam](https://github.com/rvandam) (#143).
+
 ## Hosted HTTP Mode
 
 For remote MCP endpoints (Cloudflare Worker, VPS, etc.):
@@ -346,6 +364,7 @@ More: [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)
 
 - [Setup Guide](docs/SETUP.md)
 - [API Reference](docs/API.md)
+- [Roadmap](docs/ROADMAP.md)
 - [Architecture](docs/ARCHITECTURE.md)
 - [Deployment Modes](docs/DEPLOYMENT-MODES.md)
 - [Use Case Recipes](docs/USE_CASE_RECIPES.md)

--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ Add to `~/.claude.json`:
 }
 ```
 
+Or via CLI: `claude mcp add slack -- npx -y @jtalk22/slack-mcp`
+
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -324,15 +324,30 @@ Full release notes on [GitHub releases/latest](https://github.com/jtalk22/slack-
 
 ## Rich Message Fields
 
-Added in 4.4.0. The four read tools marked ‡ above accept `include_rich_message_fields: true`, which surfaces the parts of a message that live outside `text`:
+Added in 4.4.0. The four read tools marked ‡ above accept `include_rich_message_fields: true`, which surfaces the parts of a message that live outside `text` — `attachments`, `blocks`, `files`, `reactions`, `metadata`, plus `subtype`/`bot_id`/`app_id` (automated/bot/app markers) and `team` (workspace id).
 
-- `attachments`, `blocks`, `files`, `reactions`, `metadata`
-- `subtype`, `bot_id`, `app_id` — markers that flag automated, bot, or app messages
-- `team` — the workspace id, present on every message
+An attachment-only alert reads as empty without the flag:
 
-This changes output shape only and requires no extra permissions. `blocks` in particular can be large, so it is opt-in per call to keep client context lean. For the full developer payload inside `metadata`, also set `include_all_metadata: true` (an independent Slack flag).
+```json
+{ "ts": "1767368030.607599", "user": "incident-bot", "text": "" }
+```
 
-`slack_search_messages` accepts the flag, but Slack's search API does not return rich fields on matches — read the full content with `slack_conversations_history` or `slack_get_thread` on the match's channel and timestamp.
+With `include_rich_message_fields: true`, the content is surfaced:
+
+```json
+{
+  "ts": "1767368030.607599",
+  "user": "incident-bot",
+  "text": "",
+  "subtype": "bot_message",
+  "bot_id": "B012345",
+  "attachments": [{ "title": "PagerDuty", "text": "P1 — API latency > 2s" }]
+}
+```
+
+Output shape only — no extra permissions. `blocks` can be large, so it is opt-in per call to keep client context lean. For the full developer payload inside `metadata`, also set `include_all_metadata: true` (an independent Slack flag).
+
+`slack_search_messages` accepts the flag, but Slack's search API does not return rich fields on matches — read full content with `slack_conversations_history` or `slack_get_thread` on the match's channel and timestamp.
 
 Patch by [@rvandam](https://github.com/rvandam) (#143).
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,7 +18,7 @@ Wraps `chat.update` and `chat.delete`. The server can post via `chat.postMessage
 
 ## Deferred (real competitor gaps, wrong investment for a maybe-retired OSS copy)
 
-Stealth/no-scope posting, OAuth `xoxp`/`xoxb`, canvas CRUD, SSE/proxy transport, usergroups CRUD, `conversations.create`/`invite`/`join`. Note: `reminders.*` and `canvases.*` are increasingly bot-token gated — verify session-token support before touching.
+Read-state-preserving fetches (no read-receipts), OAuth `xoxp`/`xoxb` token modes, canvas CRUD, SSE/proxy transport, usergroups CRUD, `conversations.create`/`invite`/`join`. Note: `reminders.*` and `canvases.*` are increasingly bot-token gated — verify session-token support before touching.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,25 @@
+# Roadmap
+
+Next-feature priorities for slack-mcp-server, ranked by (value × differentiation) ÷ effort. The OSS package is a funnel toward the hosted brain at [mcp.revasserlabs.com](https://mcp.revasserlabs.com), so cheap, funnel-feeding moves are weighted highest.
+
+## Next up — 4.5.0 candidate
+
+**`slack_update_message` + `slack_delete_message`** (effort: S)
+
+Wraps `chat.update` and `chat.delete`. The server can post via `chat.postMessage` but cannot edit or delete — the most-felt gap for any agent that writes to Slack. The handlers are structurally identical to the existing send path; a session token can only edit or delete the user's own messages, so the blast radius is contained, and both reuse the `destructive` annotation already in place. No new auth, transport, or dependency. Maximum user-pain relief for near-zero investment.
+
+## Runners-up (all cheap, all funnel-feeding)
+
+| Feature | Effort | Why |
+|---|---|---|
+| `slack_schedule_message` | S–M | Wraps `chat.scheduleMessage`. An OSS teaser for the hosted Pro "scheduled morning catch-up DM" — proves cadence value before the upsell. |
+| Complete pagination / cursor passthrough | S | Correctness fix across `conversations_history` / `replies` / `search` / `unreads`, not a new tool. Makes every read complete and every corpus indexed for `smart_search` complete — the cheapest thing that raises hosted quality. |
+| `slack_upload_file` | M | `files.getUploadURLExternal` → `completeUploadExternal` (legacy `files.upload` is deprecated). Indexed file content feeds `smart_search`. Heaviest of the cheap tier; defer behind the two above. |
+
+## Deferred (real competitor gaps, wrong investment for a maybe-retired OSS copy)
+
+Stealth/no-scope posting, OAuth `xoxp`/`xoxb`, canvas CRUD, SSE/proxy transport, usergroups CRUD, `conversations.create`/`invite`/`join`. Note: `reminders.*` and `canvases.*` are increasingly bot-token gated — verify session-token support before touching.
+
+---
+
+Generated 2026-06-09 from a competitive scan + feature-gap audit. Backlog tracked locally via beads (`bd list`).

--- a/glama.json
+++ b/glama.json
@@ -4,7 +4,7 @@
   "description": "Slack MCP without OAuth. 21 tools (16 read/write Slack + 2 workflow profile primitives + 3 hosted-brain upgrade stubs). Free OSS or hosted (free tier no card; $9/mo Pro = unlimited; morning DM rolling out Q2 2026).",
   "repository": "https://github.com/jtalk22/slack-mcp-server",
   "homepage": "https://mcp.revasserlabs.com",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "license": "MIT",
   "maintainers": ["jtalk22"],
   "categories": ["communication", "productivity"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jtalk22/slack-mcp",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jtalk22/slack-mcp",
-      "version": "4.3.0",
+      "version": "4.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jtalk22/slack-mcp",
   "mcpName": "io.github.jtalk22/slack-mcp-server",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Slack MCP without OAuth. 21 tools (16 read/write Slack + 2 workflow profile primitives + 3 hosted-brain upgrade stubs). Free OSS or hosted (free tier no card; $9/mo Pro = unlimited; morning DM rolling out Q2 2026).",
   "type": "module",
   "main": "src/server.js",

--- a/server.json
+++ b/server.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/jtalk22/slack-mcp-server",
     "source": "github"
   },
-  "version": "4.3.0",
+  "version": "4.4.0",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
     {
       "registryType": "npm",
       "identifier": "@jtalk22/slack-mcp",
-      "version": "4.3.0",
+      "version": "4.4.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## 4.4.0

Ships the absorbed-and-improved rich message fields feature (originally PR #143 by @rvandam) to npm consumers, plus README discoverability and a roadmap.

### Included
- **Version bump** 4.3.0 → 4.4.0 (package.json, server.json ×2, glama.json — parity checked)
- **CHANGELOG** [4.4.0] entry crediting @rvandam (#143)
- **README** — surfaces `include_rich_message_fields` (4 tool markers + footnote + new Rich Message Fields section), adds a first-call `slack_health_check` line, links the roadmap
- **docs/ROADMAP.md** — next-feature priorities; 4.5.0 candidate = `slack_update_message` + `slack_delete_message`

### Notes
- All 4 required checks expected green (attribution authored jtalk22, 7 unit tests pass, version parity clean).
- Merging does NOT publish — npm release fires on creating a GitHub Release. That step is held for the operator.

Closes the merged-but-unpublished gap: npm still serves 4.3.0, so `npx @jtalk22/slack-mcp` users do not yet have the feature.