### PR TITLE
test: complete the 4.4.0 unit suite (tool-schema invariants)

### DIFF
--- a/test/tools-schema.test.js
+++ b/test/tools-schema.test.js
@@ -1,0 +1,25 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { TOOLS } from "../lib/tools.js";
+
+const byName = Object.fromEntries(TOOLS.map((t) => [t.name, t]));
+function props(name) {
+  const t = byName[name] || {};
+  const s = t.inputSchema || t.parameters || t.input_schema || t;
+  return s.properties || {};
+}
+
+test("include_rich_message_fields is exposed on the four read tools", () => {
+  for (const name of ["slack_conversations_history", "slack_get_full_conversation", "slack_search_messages", "slack_get_thread"]) {
+    assert.ok(byName[name], `tool ${name} exists`);
+    assert.equal(props(name).include_rich_message_fields?.type, "boolean", `${name} exposes include_rich_message_fields`);
+  }
+});
+
+test("include_all_metadata is on history/replies tools but NOT on search (orthogonality guard)", () => {
+  for (const name of ["slack_conversations_history", "slack_get_full_conversation", "slack_get_thread"]) {
+    assert.equal(props(name).include_all_metadata?.type, "boolean", `${name} exposes include_all_metadata`);
+  }
+  assert.equal(props("slack_search_messages").include_all_metadata, undefined,
+    "search.messages must NOT expose include_all_metadata (Slack search has no such option)");
+});


### PR DESCRIPTION
Adds `test/tools-schema.test.js` — authored alongside the 4.4.0 feature but missed from git, so CI was running 5 tests instead of 7. Locks the schema invariants the rich-fields feature relies on: `include_rich_message_fields` present on the four read tools, and `include_all_metadata` absent from `slack_search_messages`. Makes the 4.4.0 changelog's 'tool-schema shape' claim true on main. No effect on the published npm tarball (tests aren't shipped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Added schema validation tests for Slack tool configurations to verify proper data structure and consistency across tool definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->