### PR TITLE
fix: tool dispatch parity, worker contracts, token extraction robustness, page hardening

### DIFF
--- a/index.html
+++ b/index.html
@@ -451,12 +451,26 @@
           const hostedVersion = data.version ? `v${data.version}` : 'version unavailable';
           const standardTools = data.tools && typeof data.tools.standard === 'number' ? data.tools.standard : 'Unavailable';
           const aiTools = data.tools && typeof data.tools.ai_compound === 'number' ? data.tools.ai_compound : 'Unavailable';
-          const docsUrl = data.docs && data.docs.docs_url ? data.docs.docs_url : 'https://mcp.revasserlabs.com/docs';
-          cloudHealthNoteEl.innerHTML = `${hostedVersion} · ${standardTools} managed tools + ${aiTools} AI workflows. OSS has 21 self-hosted tools; <a href="${docsUrl}">Hosted docs</a>`;
+          const remoteDocsUrl = data.docs && typeof data.docs.docs_url === 'string' ? data.docs.docs_url : '';
+          const docsUrl = remoteDocsUrl.startsWith('https://') ? remoteDocsUrl : 'https://mcp.revasserlabs.com/docs';
+          // Remote /status fields are untrusted input: build the note from
+          // text nodes + setAttribute — never innerHTML string interpolation.
+          cloudHealthNoteEl.textContent = '';
+          cloudHealthNoteEl.append(`${hostedVersion} · ${standardTools} managed tools + ${aiTools} AI workflows. OSS has 21 self-hosted tools; `);
+          const docsLink = document.createElement('a');
+          docsLink.setAttribute('href', docsUrl);
+          docsLink.textContent = 'Hosted docs';
+          cloudHealthNoteEl.append(docsLink);
         })
         .catch((error) => {
           cloudHealthEl.textContent = 'Status available';
-          cloudHealthNoteEl.innerHTML = `Cross-origin status lookup unavailable: ${error.message}. Use <a href="https://mcp.revasserlabs.com/status">raw status JSON</a>.`;
+          cloudHealthNoteEl.textContent = '';
+          cloudHealthNoteEl.append(`Cross-origin status lookup unavailable: ${error.message}. Use `);
+          const statusLink = document.createElement('a');
+          statusLink.setAttribute('href', 'https://mcp.revasserlabs.com/status');
+          statusLink.textContent = 'raw status JSON';
+          cloudHealthNoteEl.append(statusLink);
+          cloudHealthNoteEl.append('.');
         });
 
       await Promise.allSettled([npmPromise, releasePromise, cloudPromise]);

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -336,14 +336,17 @@ export async function handleListConversations(args) {
 export async function handleConversationsHistory(args) {
   const resolveUsers = args.resolve_users !== false;
   const includeRichMessageFields = parseBool(args.include_rich_message_fields);
-  const result = await slackAPI("conversations.history", {
+  const historyParams = {
     channel: args.channel_id,
     limit: args.limit || 50,
     oldest: args.oldest,
     latest: args.latest,
-    inclusive: true,
     include_all_metadata: parseBool(args.include_all_metadata)
-  });
+  };
+  // Only opt into boundary-inclusive reads when a boundary was actually
+  // provided — otherwise leave Slack's default behavior untouched.
+  if (args.oldest || args.latest) historyParams.inclusive = true;
+  const result = await slackAPI("conversations.history", historyParams);
 
   const messages = await Promise.all((result.messages || []).map(async (msg) => {
     const userName = resolveUsers ? await resolveUser(msg.user) : msg.user;
@@ -384,15 +387,18 @@ export async function handleGetFullConversation(args) {
 
   // Fetch all messages with pagination
   while (hasMore && allMessages.length < maxMessages) {
-    const result = await slackAPI("conversations.history", {
+    const historyParams = {
       channel: args.channel_id,
       limit: Math.min(100, maxMessages - allMessages.length),
       oldest: args.oldest,
       latest: args.latest,
       cursor,
-      inclusive: true,
       include_all_metadata: parseBool(args.include_all_metadata)
-    });
+    };
+    // Boundary-inclusive only when a boundary was actually provided —
+    // otherwise leave Slack's default behavior untouched.
+    if (args.oldest || args.latest) historyParams.inclusive = true;
+    const result = await slackAPI("conversations.history", historyParams);
 
     for (const msg of result.messages || []) {
       const userName = await resolveUser(msg.user);
@@ -738,13 +744,32 @@ export async function handleConversationsUnreads(args) {
 /**
  * Search users handler - client-side filter on users.list
  */
+// Explicit scan cap for client-side user search: stop paginating after
+// scanning this many workspace users (or when the cursor is exhausted) and
+// flag the result as truncated so total_matches is never misreported as
+// complete.
+const USERS_SEARCH_MAX_SCANNED = 1000;
+
 export async function handleUsersSearch(args) {
-  const query = (args.query || "").toLowerCase();
+  const rawQuery = typeof args.query === "string" ? args.query : "";
+  const query = rawQuery.trim().toLowerCase();
   const limit = args.limit || 20;
 
-  // Fetch all users (paginated)
+  // An empty/whitespace query would match every user in the workspace.
+  if (!query) {
+    return asMcpJson({
+      status: "error",
+      code: "invalid_arguments",
+      message: "query must be a non-empty string (an empty query would match all users).",
+      next_action: "Provide a name, display name, real name, or email fragment to search for."
+    }, true);
+  }
+
+  // Fetch users (paginated) and filter client-side
   const allUsers = [];
   let cursor;
+  let scannedUsers = 0;
+  let truncated = false;
 
   do {
     const result = await slackAPI("users.list", {
@@ -753,6 +778,7 @@ export async function handleUsersSearch(args) {
     });
 
     for (const u of (result.members || [])) {
+      scannedUsers++;
       if (u.deleted || u.is_bot || u.id === "USLACKBOT") continue;
 
       const searchFields = [
@@ -776,13 +802,18 @@ export async function handleUsersSearch(args) {
     }
 
     cursor = result.response_metadata?.next_cursor;
+    if (cursor && scannedUsers >= USERS_SEARCH_MAX_SCANNED) {
+      truncated = true;
+      break;
+    }
     if (cursor) await sleep(100);
-  } while (cursor && allUsers.length < 500);
+  } while (cursor);
 
   return asMcpJson({
     query: args.query,
     count: Math.min(allUsers.length, limit),
     total_matches: allUsers.length,
+    truncated,
     users: allUsers.slice(0, limit)
   });
 }

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -873,3 +873,36 @@ export async function handleTriage(args) {
     true
   );
 }
+
+// ============ Shared Tool Dispatch Map ============
+// Single source of truth mapping every advertised tool name (lib/tools.js)
+// to its handler. Both transports — stdio (src/server.js) and HTTP
+// (src/server-http.js) — dispatch through this map so the advertised tool
+// list and the dispatch surface cannot drift apart (review backlog #30/#123,
+// where the HTTP switch handled 16 of the 21 advertised tools).
+
+export const TOOL_HANDLERS = Object.freeze({
+  slack_token_status: handleTokenStatus,
+  slack_health_check: handleHealthCheck,
+  slack_refresh_tokens: handleRefreshTokens,
+  slack_list_conversations: handleListConversations,
+  slack_conversations_history: handleConversationsHistory,
+  slack_get_full_conversation: handleGetFullConversation,
+  slack_search_messages: handleSearchMessages,
+  slack_users_info: handleUsersInfo,
+  slack_send_message: handleSendMessage,
+  slack_get_thread: handleGetThread,
+  slack_list_users: handleListUsers,
+  slack_add_reaction: handleAddReaction,
+  slack_remove_reaction: handleRemoveReaction,
+  slack_conversations_mark: handleConversationsMark,
+  slack_conversations_unreads: handleConversationsUnreads,
+  slack_users_search: handleUsersSearch,
+  // Workflow profile primitives (OSS local JSON store)
+  slack_workflow_save: handleWorkflowSave,
+  slack_workflows: handleWorkflows,
+  // Hosted-only AI tools (OSS = upgrade stubs)
+  slack_smart_search: handleSmartSearch,
+  slack_catch_me_up: handleCatchMeUp,
+  slack_triage: handleTriage,
+});

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -841,7 +841,7 @@ const HOSTED_UPGRADE_PAYLOAD = {
   signup_url: "https://mcp.revasserlabs.com/signup",
   upgrade_url: "https://mcp.revasserlabs.com/pricing",
   free_tier_quota: "10 smart_search + 3 catch_me_up per month, 5 triage per day",
-  pro_value_prop: "Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM at 8am workspace time rolling out Q2 2026).",
+  pro_value_prop: "Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM at 8am workspace time in development).",
 };
 
 export async function handleSmartSearch(args) {

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -909,8 +909,7 @@ export async function handleTriage(args) {
 // Single source of truth mapping every advertised tool name (lib/tools.js)
 // to its handler. Both transports — stdio (src/server.js) and HTTP
 // (src/server-http.js) — dispatch through this map so the advertised tool
-// list and the dispatch surface cannot drift apart (review backlog #30/#123,
-// where the HTTP switch handled 16 of the 21 advertised tools).
+// list and the dispatch surface cannot drift apart.
 
 export const TOOL_HANDLERS = Object.freeze({
   slack_token_status: handleTokenStatus,

--- a/lib/public-pages.js
+++ b/lib/public-pages.js
@@ -63,7 +63,7 @@ function shareLinks() {
 }
 
 function shareNote() {
-  return `<strong>Verify in 30 seconds:</strong> <code>--version</code>, <code>--doctor</code>, <code>--status</code>. Self-host gives ${PUBLIC_METADATA.selfHostedToolCount} tools with session-based auth. Works with any MCP client — Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf. Hosted free tier (no card) live at <a href="${PUBLIC_METADATA.canonicalSiteUrl}">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM rolling out Q2 2026).`;
+  return `<strong>Verify in 30 seconds:</strong> <code>--version</code>, <code>--doctor</code>, <code>--status</code>. Self-host gives ${PUBLIC_METADATA.selfHostedToolCount} tools with session-based auth. Works with any MCP client — Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf. Hosted free tier (no card) live at <a href="${PUBLIC_METADATA.canonicalSiteUrl}">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM in development).`;
 }
 
 function demoLinks() {
@@ -75,7 +75,7 @@ function demoLinks() {
 }
 
 function demoNote() {
-  return `Self-host free for ${PUBLIC_METADATA.selfHostedToolCount} tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="${PUBLIC_METADATA.canonicalSiteUrl}" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM rolling out Q2 2026).`;
+  return `Self-host free for ${PUBLIC_METADATA.selfHostedToolCount} tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="${PUBLIC_METADATA.canonicalSiteUrl}" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM in development).`;
 }
 
 function demoFooterLinks() {

--- a/lib/token-store.js
+++ b/lib/token-store.js
@@ -8,7 +8,7 @@
  * 4. Chrome auto-extraction (fallback)
  */
 
-import { readFileSync, writeFileSync, existsSync, renameSync, unlinkSync, chmodSync, copyFileSync, mkdtempSync, statSync, readdirSync } from "fs";
+import { readFileSync, writeFileSync, existsSync, renameSync, unlinkSync, rmSync, chmodSync, copyFileSync, mkdtempSync, statSync, readdirSync } from "fs";
 import { homedir, platform, tmpdir } from "os";
 import { join } from "path";
 import { execFileSync } from "child_process";
@@ -265,13 +265,22 @@ function extractCookieForProfile(profileDir) {
   const tmpDb = join(tmpDir, 'Cookies');
   try {
     copyFileSync(cookiesPath, tmpDb);
+    // Chrome keeps recent writes in the SQLite WAL sidecar until the next
+    // checkpoint — copy Cookies-wal (and -shm) too when present so the
+    // snapshot isn't stale.
+    for (const suffix of ['-wal', '-shm']) {
+      const sidecarPath = `${cookiesPath}${suffix}`;
+      if (existsSync(sidecarPath)) {
+        try { copyFileSync(sidecarPath, `${tmpDb}${suffix}`); } catch {}
+      }
+    }
 
     const queryResult = execFileSync('sqlite3', [
       tmpDb,
       "SELECT hex(encrypted_value) FROM cookies WHERE host_key LIKE '%.slack.com%' AND name = 'd' LIMIT 1;"
     ], { encoding: 'utf-8', timeout: 5000 }).trim();
 
-    try { unlinkSync(tmpDb); unlinkSync(tmpDir); } catch {}
+    try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
 
     if (!queryResult) return null;
 
@@ -304,7 +313,7 @@ function extractCookieForProfile(profileDir) {
     if (xoxdIndex < 0) return null;
     return text.substring(xoxdIndex);
   } catch {
-    try { unlinkSync(tmpDb); unlinkSync(tmpDir); } catch {}
+    try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
     return null;
   }
 }
@@ -358,7 +367,10 @@ function extractTokenFromLevelDB(profileDir) {
       const txt = readFileSync(f.path).toString('binary');
       XOXC_TOKEN_RE.lastIndex = 0;
       const matches = txt.match(XOXC_TOKEN_RE);
-      if (matches && matches.length) return matches[0];
+      // LevelDB .log/.ldb files append newer records after older ones, so
+      // the LAST match in a file is the most recently cached token — the
+      // first match can be a stale, already-rotated token.
+      if (matches && matches.length) return matches[matches.length - 1];
     } catch {
       continue;
     }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -537,7 +537,7 @@ export const TOOLS = [
   },
   {
     name: "slack_catch_me_up",
-    description: "Run a structured catch-up against a saved workflow profile. Returns structured JSON per the profile's workflow_kind: support_inbox returns {open_threads, ack_lag, owner_gaps, escalations, next_actions}; incident_room returns {incident_summary, timeline, open_risks, owner_gaps, next_actions}; exec_brief returns {summary, decisions, risks, asks, action_items}; product_launch_watch returns {launch_signals, feedback_themes, blockers, metrics, next_actions}; custom returns {summary, highlights, open_questions, next_actions}. Hosted-only. Free tier ships 3 calls/month; Pro $9/mo unlocks unlimited (scheduled morning DM at 8am workspace tz rolling out Q2 2026).",
+    description: "Run a structured catch-up against a saved workflow profile. Returns structured JSON per the profile's workflow_kind: support_inbox returns {open_threads, ack_lag, owner_gaps, escalations, next_actions}; incident_room returns {incident_summary, timeline, open_risks, owner_gaps, next_actions}; exec_brief returns {summary, decisions, risks, asks, action_items}; product_launch_watch returns {launch_signals, feedback_themes, blockers, metrics, next_actions}; custom returns {summary, highlights, open_questions, next_actions}. Hosted-only. Free tier ships 3 calls/month; Pro $9/mo unlocks unlimited (scheduled morning DM at 8am workspace tz in development).",
     inputSchema: {
       type: "object",
       properties: {

--- a/lib/workflow-store.js
+++ b/lib/workflow-store.js
@@ -70,32 +70,47 @@ export function loadStore() {
   try {
     const data = JSON.parse(raw);
     if (!data || typeof data !== "object" || !data.profiles) {
-      backupCorruptStore(raw, "shape-invalid");
+      quarantineCorruptStore("shape-invalid");
       return emptyStore();
     }
     if (data.version !== STORE_VERSION) {
-      // Future: migration logic. For now, back up the unrecognized version
-      // before falling back to empty so the old data is recoverable.
-      backupCorruptStore(raw, `version-${data.version}`);
+      // Future: migration logic. For now, quarantine the unrecognized
+      // version before falling back to empty so the old data is recoverable.
+      quarantineCorruptStore(`version-${data.version}`);
       return emptyStore();
     }
     return data;
   } catch {
-    backupCorruptStore(raw, "json-parse-error");
+    quarantineCorruptStore("json-parse-error");
     return emptyStore();
   }
 }
 
-function backupCorruptStore(raw, reasonTag) {
+/**
+ * Move an unreadable store aside to <store>.corrupt-<timestamp> before
+ * loadStore falls back to an empty store. MOVING (not copying) matters:
+ * it guarantees the next saveStore cannot clobber the user's only copy of
+ * their profiles, and repeated loads don't spawn one backup per call.
+ * Warns on stderr (stdout belongs to the MCP stdio protocol).
+ */
+function quarantineCorruptStore(reasonTag) {
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const quarantinePath = `${STORE_FILE}.corrupt-${stamp}`;
   try {
-    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-    const backupPath = `${STORE_FILE}.bak.${reasonTag}.${stamp}`;
-    writeFileSync(backupPath, raw);
+    renameSync(STORE_FILE, quarantinePath);
     if (platform() === "darwin" || platform() === "linux") {
-      try { chmodSync(backupPath, 0o600); } catch {}
+      try { chmodSync(quarantinePath, 0o600); } catch {}
     }
-  } catch {
-    // Backup is best-effort; do not throw on backup failure.
+    console.error(
+      `[slack-mcp] WARNING: workflow store ${STORE_FILE} is unreadable (${reasonTag}). ` +
+      `Quarantined it to ${quarantinePath} and continuing with an empty store.`
+    );
+  } catch (e) {
+    // Quarantine is best-effort; never let it break loadStore.
+    console.error(
+      `[slack-mcp] WARNING: workflow store ${STORE_FILE} is unreadable (${reasonTag}) ` +
+      `and could not be quarantined: ${e?.message || e}`
+    );
   }
 }
 

--- a/public/demo-slack-mcp.html
+++ b/public/demo-slack-mcp.html
@@ -1313,7 +1313,7 @@
       <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md" target="_blank" rel="noopener noreferrer">Setup Guide</a>
     </div>
     <div class="note">
-      Self-host free for 21 tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM rolling out Q2 2026).
+      Self-host free for 21 tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM in development).
     </div>
   </div>
   <header class="page-header">

--- a/public/demo-video.html
+++ b/public/demo-video.html
@@ -217,7 +217,7 @@
       <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md" target="_blank" rel="noopener noreferrer">Setup Guide</a>
       </div>
       <div class="note">
-        Self-host free for 21 tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM rolling out Q2 2026).
+        Self-host free for 21 tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM in development).
       </div>
     </div>
 

--- a/public/demo.html
+++ b/public/demo.html
@@ -744,7 +744,7 @@
 <body>
   <!-- Preview Banner -->
   <div class="preview-banner">
-    INTERACTIVE DEMO — simulated data. Run <code>npm run web</code> for your live workspace, or try <a href="https://mcp.revasserlabs.com" style="color:#f0c246;font-weight:600">Hosted</a> — free tier (no card) live; Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM rolling out Q2 2026).
+    INTERACTIVE DEMO — simulated data. Run <code>npm run web</code> for your live workspace, or try <a href="https://mcp.revasserlabs.com" style="color:#f0c246;font-weight:600">Hosted</a> — free tier (no card) live; Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM in development).
   </div>
   <div class="cta-strip">
     <div class="cta-links">
@@ -753,7 +753,7 @@
       <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md" target="_blank" rel="noopener noreferrer">Setup Guide</a>
     </div>
     <div class="cta-note">
-      Self-host free for 21 tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM rolling out Q2 2026).
+      Self-host free for 21 tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM in development).
     </div>
   </div>
 

--- a/public/share.html
+++ b/public/share.html
@@ -124,7 +124,7 @@
       <a href="https://mcp.revasserlabs.com" rel="noopener" style="background:rgba(240,194,70,0.18);border-color:rgba(240,194,70,0.45);color:#f0c246">Hosted</a>
     </div>
 
-    <p class="note"><strong>Verify in 30 seconds:</strong> <code>--version</code>, <code>--doctor</code>, <code>--status</code>. Self-host gives 21 tools with session-based auth. Works with any MCP client — Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM rolling out Q2 2026).</p>
+    <p class="note"><strong>Verify in 30 seconds:</strong> <code>--version</code>, <code>--doctor</code>, <code>--status</code>. Self-host gives 21 tools with session-based auth. Works with any MCP client — Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM in development).</p>
   </main>
 </body>
 </html>

--- a/scripts/apply-template.js
+++ b/scripts/apply-template.js
@@ -113,5 +113,5 @@ if (!profile.channels.length) {
   console.log("Or call slack_workflow_save from your MCP client to update.");
 } else {
   console.log("Profile is ready. Run slack_catch_me_up against it from your MCP client.");
-  console.log(`(Free tier: 3 catch_me_up calls/month. Pro $9/mo unlocks unlimited; scheduled morning DM rolling out Q2 2026.)`);
+  console.log(`(Free tier: 3 catch_me_up calls/month. Pro $9/mo unlocks unlimited; scheduled morning DM in development.)`);
 }

--- a/src/server-http.js
+++ b/src/server-http.js
@@ -82,7 +82,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
   try {
     // Shared dispatch map keeps this transport in lockstep with the stdio
-    // server and the advertised TOOLS list (review backlog #30/#123).
+    // server and the advertised TOOLS list.
     const handler = TOOL_HANDLERS[name];
     if (!handler) {
       return {

--- a/src/server-http.js
+++ b/src/server-http.js
@@ -15,24 +15,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 
 import { TOOLS } from "../lib/tools.js";
-import {
-  handleTokenStatus,
-  handleHealthCheck,
-  handleRefreshTokens,
-  handleListConversations,
-  handleConversationsHistory,
-  handleGetFullConversation,
-  handleSearchMessages,
-  handleUsersInfo,
-  handleSendMessage,
-  handleGetThread,
-  handleListUsers,
-  handleAddReaction,
-  handleRemoveReaction,
-  handleConversationsMark,
-  handleConversationsUnreads,
-  handleUsersSearch,
-} from "../lib/handlers.js";
+import { TOOL_HANDLERS } from "../lib/handlers.js";
 import { RELEASE_VERSION } from "../lib/public-metadata.js";
 
 const SERVER_NAME = "slack-mcp-server";
@@ -98,53 +81,24 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
 
   try {
-    switch (name) {
-      case "slack_token_status":
-        return await handleTokenStatus();
-      case "slack_health_check":
-        return await handleHealthCheck();
-      case "slack_refresh_tokens":
-        return await handleRefreshTokens();
-      case "slack_list_conversations":
-        return await handleListConversations(args);
-      case "slack_conversations_history":
-        return await handleConversationsHistory(args);
-      case "slack_get_full_conversation":
-        return await handleGetFullConversation(args);
-      case "slack_search_messages":
-        return await handleSearchMessages(args);
-      case "slack_users_info":
-        return await handleUsersInfo(args);
-      case "slack_send_message":
-        return await handleSendMessage(args);
-      case "slack_get_thread":
-        return await handleGetThread(args);
-      case "slack_list_users":
-        return await handleListUsers(args);
-      case "slack_add_reaction":
-        return await handleAddReaction(args);
-      case "slack_remove_reaction":
-        return await handleRemoveReaction(args);
-      case "slack_conversations_mark":
-        return await handleConversationsMark(args);
-      case "slack_conversations_unreads":
-        return await handleConversationsUnreads(args);
-      case "slack_users_search":
-        return await handleUsersSearch(args);
-      default:
-        return {
-          content: [{
-            type: "text",
-            text: JSON.stringify({
-              status: "error",
-              code: "unknown_tool",
-              message: `Unknown tool: ${name}`,
-              next_action: "Call tools/list to inspect available tool names."
-            }, null, 2)
-          }],
-          isError: true
-        };
+    // Shared dispatch map keeps this transport in lockstep with the stdio
+    // server and the advertised TOOLS list (review backlog #30/#123).
+    const handler = TOOL_HANDLERS[name];
+    if (!handler) {
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            status: "error",
+            code: "unknown_tool",
+            message: `Unknown tool: ${name}`,
+            next_action: "Call tools/list to inspect available tool names."
+          }, null, 2)
+        }],
+        isError: true
+      };
     }
+    return await handler(args);
   } catch (error) {
     return {
       content: [{

--- a/src/server.js
+++ b/src/server.js
@@ -30,27 +30,9 @@ import { RELEASE_VERSION } from "../lib/public-metadata.js";
 import { checkTokenHealth } from "../lib/slack-client.js";
 import { TOOLS } from "../lib/tools.js";
 import {
-  handleTokenStatus,
+  TOOL_HANDLERS,
   handleHealthCheck,
-  handleRefreshTokens,
   handleListConversations,
-  handleConversationsHistory,
-  handleGetFullConversation,
-  handleSearchMessages,
-  handleUsersInfo,
-  handleSendMessage,
-  handleGetThread,
-  handleListUsers,
-  handleAddReaction,
-  handleRemoveReaction,
-  handleConversationsMark,
-  handleConversationsUnreads,
-  handleUsersSearch,
-  handleWorkflowSave,
-  handleWorkflows,
-  handleSmartSearch,
-  handleCatchMeUp,
-  handleTriage,
 } from "../lib/handlers.js";
 
 // Background refresh interval (4 hours)
@@ -231,86 +213,25 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
 
   try {
-    switch (name) {
-      case "slack_token_status":
-        return await handleTokenStatus();
-
-      case "slack_health_check":
-        return await handleHealthCheck();
-
-      case "slack_refresh_tokens":
-        return await handleRefreshTokens();
-
-      case "slack_list_conversations":
-        return await handleListConversations(args);
-
-      case "slack_conversations_history":
-        return await handleConversationsHistory(args);
-
-      case "slack_get_full_conversation":
-        return await handleGetFullConversation(args);
-
-      case "slack_search_messages":
-        return await handleSearchMessages(args);
-
-      case "slack_users_info":
-        return await handleUsersInfo(args);
-
-      case "slack_send_message":
-        return await handleSendMessage(args);
-
-      case "slack_get_thread":
-        return await handleGetThread(args);
-
-      case "slack_list_users":
-        return await handleListUsers(args);
-
-      case "slack_add_reaction":
-        return await handleAddReaction(args);
-
-      case "slack_remove_reaction":
-        return await handleRemoveReaction(args);
-
-      case "slack_conversations_mark":
-        return await handleConversationsMark(args);
-
-      case "slack_conversations_unreads":
-        return await handleConversationsUnreads(args);
-
-      case "slack_users_search":
-        return await handleUsersSearch(args);
-
-      // Workflow profile primitives (OSS local JSON store)
-      case "slack_workflow_save":
-        return await handleWorkflowSave(args);
-
-      case "slack_workflows":
-        return await handleWorkflows(args);
-
-      // Hosted-only AI tools (OSS = upgrade stubs)
-      case "slack_smart_search":
-        return await handleSmartSearch(args);
-
-      case "slack_catch_me_up":
-        return await handleCatchMeUp(args);
-
-      case "slack_triage":
-        return await handleTriage(args);
-
-      default:
-        return {
-          content: [{
-            type: "text",
-            text: JSON.stringify({
-              status: "error",
-              code: "unknown_tool",
-              message: `Unknown tool: ${name}`,
-              next_action: "Use tools/list to discover available tools."
-            }, null, 2)
-          }],
-          isError: true
-        };
+    // Shared dispatch map (lib/handlers.js) keeps this transport in lockstep
+    // with the HTTP server and the advertised TOOLS list (review backlog
+    // #30/#123).
+    const handler = TOOL_HANDLERS[name];
+    if (!handler) {
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            status: "error",
+            code: "unknown_tool",
+            message: `Unknown tool: ${name}`,
+            next_action: "Use tools/list to discover available tools."
+          }, null, 2)
+        }],
+        isError: true
+      };
     }
+    return await handler(args);
   } catch (error) {
     if (error?.code === "token_auth_failed") {
       return {

--- a/src/server.js
+++ b/src/server.js
@@ -214,8 +214,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
   try {
     // Shared dispatch map (lib/handlers.js) keeps this transport in lockstep
-    // with the HTTP server and the advertised TOOLS list (review backlog
-    // #30/#123).
+    // with the HTTP server and the advertised TOOLS list.
     const handler = TOOL_HANDLERS[name];
     if (!handler) {
       return {

--- a/templates/public-pages/demo.html.tpl
+++ b/templates/public-pages/demo.html.tpl
@@ -744,7 +744,7 @@
 <body>
   <!-- Preview Banner -->
   <div class="preview-banner">
-    INTERACTIVE DEMO — simulated data. Run <code>npm run web</code> for your live workspace, or try <a href="{{CANONICAL_SITE_URL}}" style="color:#f0c246;font-weight:600">Hosted</a> — free tier (no card) live; Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM rolling out Q2 2026).
+    INTERACTIVE DEMO — simulated data. Run <code>npm run web</code> for your live workspace, or try <a href="{{CANONICAL_SITE_URL}}" style="color:#f0c246;font-weight:600">Hosted</a> — free tier (no card) live; Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM in development).
   </div>
   <div class="cta-strip">
     <div class="cta-links">

--- a/templates/public-pages/index.html.tpl
+++ b/templates/public-pages/index.html.tpl
@@ -437,12 +437,26 @@
           const hostedVersion = data.version ? `v${data.version}` : 'version unavailable';
           const standardTools = data.tools && typeof data.tools.standard === 'number' ? data.tools.standard : 'Unavailable';
           const aiTools = data.tools && typeof data.tools.ai_compound === 'number' ? data.tools.ai_compound : 'Unavailable';
-          const docsUrl = data.docs && data.docs.docs_url ? data.docs.docs_url : '{{CLOUD_DOCS_URL}}';
-          cloudHealthNoteEl.innerHTML = `${hostedVersion} · ${standardTools} managed tools + ${aiTools} AI workflows. OSS has {{SELF_HOSTED_TOOL_COUNT}} self-hosted tools; <a href="${docsUrl}">Hosted docs</a>`;
+          const remoteDocsUrl = data.docs && typeof data.docs.docs_url === 'string' ? data.docs.docs_url : '';
+          const docsUrl = remoteDocsUrl.startsWith('https://') ? remoteDocsUrl : '{{CLOUD_DOCS_URL}}';
+          // Remote /status fields are untrusted input: build the note from
+          // text nodes + setAttribute — never innerHTML string interpolation.
+          cloudHealthNoteEl.textContent = '';
+          cloudHealthNoteEl.append(`${hostedVersion} · ${standardTools} managed tools + ${aiTools} AI workflows. OSS has {{SELF_HOSTED_TOOL_COUNT}} self-hosted tools; `);
+          const docsLink = document.createElement('a');
+          docsLink.setAttribute('href', docsUrl);
+          docsLink.textContent = 'Hosted docs';
+          cloudHealthNoteEl.append(docsLink);
         })
         .catch((error) => {
           cloudHealthEl.textContent = 'Status available';
-          cloudHealthNoteEl.innerHTML = `Cross-origin status lookup unavailable: ${error.message}. Use <a href="{{CLOUD_STATUS_URL}}">raw status JSON</a>.`;
+          cloudHealthNoteEl.textContent = '';
+          cloudHealthNoteEl.append(`Cross-origin status lookup unavailable: ${error.message}. Use `);
+          const statusLink = document.createElement('a');
+          statusLink.setAttribute('href', '{{CLOUD_STATUS_URL}}');
+          statusLink.textContent = 'raw status JSON';
+          cloudHealthNoteEl.append(statusLink);
+          cloudHealthNoteEl.append('.');
         });
 
       await Promise.allSettled([npmPromise, releasePromise, cloudPromise]);

--- a/test/tools-schema.test.js
+++ b/test/tools-schema.test.js
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { TOOLS } from "../lib/tools.js";
+import { TOOL_HANDLERS } from "../lib/handlers.js";
 
 const byName = Object.fromEntries(TOOLS.map((t) => [t.name, t]));
 function props(name) {
@@ -13,6 +14,16 @@ test("include_rich_message_fields is exposed on the four read tools", () => {
   for (const name of ["slack_conversations_history", "slack_get_full_conversation", "slack_search_messages", "slack_get_thread"]) {
     assert.ok(byName[name], `tool ${name} exists`);
     assert.equal(props(name).include_rich_message_fields?.type, "boolean", `${name} exposes include_rich_message_fields`);
+  }
+});
+
+test("every advertised tool has a dispatch handler and vice versa (drift guard, #30/#123)", () => {
+  const advertised = TOOLS.map((t) => t.name).sort();
+  const dispatchable = Object.keys(TOOL_HANDLERS).sort();
+  assert.deepEqual(dispatchable, advertised,
+    "TOOLS (lib/tools.js) and TOOL_HANDLERS (lib/handlers.js) must list the same tool names");
+  for (const name of advertised) {
+    assert.equal(typeof TOOL_HANDLERS[name], "function", `${name} handler is a function`);
   }
 });
 

--- a/workers/mcp-worker.js
+++ b/workers/mcp-worker.js
@@ -216,6 +216,7 @@ const TOOLS = [
     inputSchema: {
       type: "object",
       properties: {
+        types: { type: "string", description: "Comma-separated types: im, mpim, public_channel, private_channel (default all)", default: "im,mpim,public_channel,private_channel" },
         limit: { type: "number", description: "Maximum conversations to return (default 50)" }
       }
     },
@@ -415,23 +416,139 @@ async function handleToolCall(name, args, env, queryParams) {
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
       case "slack_conversations_unreads": {
-        const result = await slackApi('client.counts', {}, token, cookie);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
-      }
-      case "slack_users_search": {
-        const result = await slackApi('users.list', { limit: args.limit || 100 }, token, cookie);
+        // Mirrors the stdio implementation (lib/handlers.js
+        // handleConversationsUnreads): list conversations, keep the ones
+        // with unreads, resolve DM display names, sort by unread count
+        // descending, and honor `limit` (review backlog #83/#84).
+        const types = args.types || "im,mpim,public_channel,private_channel";
+        const limit = args.limit || 50;
+        const result = await slackApi('conversations.list', {
+          types,
+          limit: 200,
+          exclude_archived: true
+        }, token, cookie);
         if (!result.ok) {
           return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
         }
-        const query = (args.query || "").toLowerCase();
-        const matches = (result.members || []).filter(u => {
-          const name = (u.name || "").toLowerCase();
-          const realName = (u.real_name || "").toLowerCase();
-          const displayName = (u.profile?.display_name || "").toLowerCase();
-          const email = (u.profile?.email || "").toLowerCase();
-          return name.includes(query) || realName.includes(query) || displayName.includes(query) || email.includes(query);
-        });
-        return { content: [{ type: "text", text: JSON.stringify({ ok: true, members: matches, count: matches.length }, null, 2) }] };
+
+        // Per-request users.info cache for DM display-name resolution
+        const userNameCache = new Map();
+        const resolveUserName = async (userId) => {
+          if (userNameCache.has(userId)) return userNameCache.get(userId);
+          let name = userId;
+          try {
+            const info = await slackApi('users.info', { user: userId }, token, cookie);
+            if (info.ok && info.user) {
+              name = info.user.real_name || info.user.name || userId;
+            }
+          } catch (e) {
+            // Fall back to the raw user ID on lookup failure
+          }
+          userNameCache.set(userId, name);
+          return name;
+        };
+
+        const unreads = [];
+        for (const c of (result.channels || [])) {
+          const unreadCount = c.unread_count_display || c.unread_count || 0;
+          if (unreadCount === 0) continue;
+
+          let displayName = c.name;
+          if (c.is_im && c.user) {
+            displayName = await resolveUserName(c.user);
+          }
+
+          unreads.push({
+            id: c.id,
+            name: displayName,
+            type: c.is_im ? "dm" : c.is_mpim ? "group_dm" : c.is_private ? "private_channel" : "public_channel",
+            unread_count: unreadCount,
+            latest_ts: c.latest?.ts || null
+          });
+        }
+
+        unreads.sort((a, b) => b.unread_count - a.unread_count);
+
+        return { content: [{ type: "text", text: JSON.stringify({
+          total_unread_conversations: unreads.length,
+          conversations: unreads.slice(0, limit)
+        }, null, 2) }] };
+      }
+      case "slack_users_search": {
+        // Mirrors the stdio implementation (lib/handlers.js
+        // handleUsersSearch): paginate users.list, filter client-side,
+        // explicit scan cap + truncated flag, slice to `limit`
+        // (review backlog #83/#84).
+        const rawQuery = typeof args.query === "string" ? args.query : "";
+        const query = rawQuery.trim().toLowerCase();
+        const limit = args.limit || 20;
+
+        if (!query) {
+          return {
+            content: [{
+              type: "text",
+              text: JSON.stringify({
+                status: "error",
+                code: "invalid_arguments",
+                message: "query must be a non-empty string (an empty query would match all users).",
+                next_action: "Provide a name, display name, real name, or email fragment to search for."
+              }, null, 2)
+            }],
+            isError: true
+          };
+        }
+
+        const MAX_SCANNED_USERS = 1000;
+        const matches = [];
+        let cursor;
+        let scannedUsers = 0;
+        let truncated = false;
+
+        do {
+          const result = await slackApi('users.list', { limit: 200, cursor }, token, cookie);
+          if (!result.ok) {
+            return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+          }
+
+          for (const u of (result.members || [])) {
+            scannedUsers++;
+            if (u.deleted || u.is_bot || u.id === "USLACKBOT") continue;
+
+            const searchFields = [
+              u.name,
+              u.real_name,
+              u.profile?.display_name,
+              u.profile?.email
+            ].filter(Boolean).map(s => s.toLowerCase());
+
+            if (searchFields.some(f => f.includes(query))) {
+              matches.push({
+                id: u.id,
+                name: u.name,
+                real_name: u.real_name,
+                display_name: u.profile?.display_name,
+                email: u.profile?.email,
+                title: u.profile?.title,
+                is_admin: u.is_admin
+              });
+            }
+          }
+
+          cursor = result.response_metadata?.next_cursor;
+          if (cursor && scannedUsers >= MAX_SCANNED_USERS) {
+            truncated = true;
+            break;
+          }
+          if (cursor) await new Promise(resolve => setTimeout(resolve, 100));
+        } while (cursor);
+
+        return { content: [{ type: "text", text: JSON.stringify({
+          query: args.query,
+          count: Math.min(matches.length, limit),
+          total_matches: matches.length,
+          truncated,
+          users: matches.slice(0, limit)
+        }, null, 2) }] };
       }
       default:
         return {

--- a/workers/mcp-worker.js
+++ b/workers/mcp-worker.js
@@ -419,7 +419,7 @@ async function handleToolCall(name, args, env, queryParams) {
         // Mirrors the stdio implementation (lib/handlers.js
         // handleConversationsUnreads): list conversations, keep the ones
         // with unreads, resolve DM display names, sort by unread count
-        // descending, and honor `limit` (review backlog #83/#84).
+        // descending, and honor `limit`.
         const types = args.types || "im,mpim,public_channel,private_channel";
         const limit = args.limit || 50;
         const result = await slackApi('conversations.list', {
@@ -448,24 +448,25 @@ async function handleToolCall(name, args, env, queryParams) {
           return name;
         };
 
-        const unreads = [];
-        for (const c of (result.channels || [])) {
-          const unreadCount = c.unread_count_display || c.unread_count || 0;
-          if (unreadCount === 0) continue;
+        const withUnreads = (result.channels || []).filter(
+          (c) => (c.unread_count_display || c.unread_count || 0) > 0
+        );
 
-          let displayName = c.name;
-          if (c.is_im && c.user) {
-            displayName = await resolveUserName(c.user);
-          }
+        // Resolve DM display names concurrently (deduped) — sequential awaits here
+        // would add one Slack round-trip of latency per unread DM.
+        const dmUserIds = [...new Set(withUnreads.filter((c) => c.is_im && c.user).map((c) => c.user))];
+        const nameEntries = await Promise.all(
+          dmUserIds.map(async (userId) => [userId, await resolveUserName(userId)])
+        );
+        const dmNames = new Map(nameEntries);
 
-          unreads.push({
-            id: c.id,
-            name: displayName,
-            type: c.is_im ? "dm" : c.is_mpim ? "group_dm" : c.is_private ? "private_channel" : "public_channel",
-            unread_count: unreadCount,
-            latest_ts: c.latest?.ts || null
-          });
-        }
+        const unreads = withUnreads.map((c) => ({
+          id: c.id,
+          name: c.is_im && c.user ? (dmNames.get(c.user) || c.name) : c.name,
+          type: c.is_im ? "dm" : c.is_mpim ? "group_dm" : c.is_private ? "private_channel" : "public_channel",
+          unread_count: c.unread_count_display || c.unread_count || 0,
+          latest_ts: c.latest?.ts || null
+        }));
 
         unreads.sort((a, b) => b.unread_count - a.unread_count);
 
@@ -478,7 +479,7 @@ async function handleToolCall(name, args, env, queryParams) {
         // Mirrors the stdio implementation (lib/handlers.js
         // handleUsersSearch): paginate users.list, filter client-side,
         // explicit scan cap + truncated flag, slice to `limit`
-        // (review backlog #83/#84).
+        //.
         const rawQuery = typeof args.query === "string" ? args.query : "";
         const query = rawQuery.trim().toLowerCase();
         const limit = args.limit || 20;


### PR DESCRIPTION
Hardening pass across the runtime and public pages:

- **HTTP transport now dispatches all 21 advertised tools** through a shared handler map (stdio and HTTP can no longer drift apart; the workflow-profile tools and upgrade stubs previously returned unknown_tool over HTTP)
- **Worker parity**: `slack_users_search` paginates with an explicit scan cap + truncated flag and honors `limit`; `slack_conversations_unreads` returns the documented contract instead of a raw counts dump
- **Token extraction robustness**: newest LevelDB token wins (stale-token invalid_auth fix), Chrome cookie snapshots include WAL/SHM sidecars, temp dirs are actually removed
- **Workflow store**: corrupt store files are quarantined aside with a warning instead of silently clobbered on next save
- **Public pages**: /status fields render as text nodes with https-validated links; remaining out-of-date rollout phrasing aligned to "in development"
- Handler correctness: `inclusive` only when a boundary is set; empty user-search queries rejected

Gates: node --test 8/8 · release preflight all-pass · public-surface integrity ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Slack unread conversation and user search results, with more complete matching, better sorting, and clearer result counts.
  * Tool routing is now more consistent across the app, reducing missing-tool errors.

* **Bug Fixes**
  * Search now handles empty queries more reliably and can indicate when results are truncated.
  * Hosted status pages now render links more safely and consistently.
  * Corrupt workflow data is now isolated more cleanly to avoid repeated startup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->