### PR TITLE
ci(publish): publish to the MCP registry via GitHub OIDC on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,9 +63,10 @@ jobs:
 
       - name: Verify server.json matches release version
         shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          VERSION="${{ steps.version.outputs.version }}"
           SJ_VERSION="$(jq -r '.version' server.json)"
           if [[ "$SJ_VERSION" != "$VERSION" ]]; then
             echo "server.json version ($SJ_VERSION) does not match release version ($VERSION)" >&2
@@ -75,11 +76,24 @@ jobs:
       - name: Check MCP registry for existing version
         id: registry_check
         shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          VERSION="${{ steps.version.outputs.version }}"
           VERSIONS_URL="https://registry.modelcontextprotocol.io/v0/servers/io.github.jtalk22%2Fslack-mcp-server/versions"
-          if curl -fsSL "$VERSIONS_URL" | jq -e --arg v "$VERSION" '[.servers[] | (.server.version // .version)] | index($v) != null' >/dev/null; then
+          # Distinguish "version not listed" from a failed lookup: only a 200 with the
+          # version absent (or a 404 for a never-published server) may proceed to publish.
+          HTTP_CODE="$(curl -sSL -o /tmp/registry-versions.json -w '%{http_code}' "$VERSIONS_URL")" || {
+            echo "MCP registry lookup failed (network error)" >&2
+            exit 1
+          }
+          if [[ "$HTTP_CODE" == "404" ]]; then
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+            echo "Server not found in the MCP registry. Proceeding with first registry publish."
+          elif [[ "$HTTP_CODE" != "200" ]]; then
+            echo "MCP registry lookup failed with HTTP $HTTP_CODE" >&2
+            exit 1
+          elif jq -e --arg v "$VERSION" '[.servers[] | (.server.version // .version)] | index($v) != null' /tmp/registry-versions.json >/dev/null; then
             echo "already_published=true" >> "$GITHUB_OUTPUT"
             echo "Version $VERSION already exists in the MCP registry. Skipping registry publish."
           else
@@ -90,9 +104,10 @@ jobs:
       - name: Wait for npm propagation
         if: steps.registry_check.outputs.already_published != 'true'
         shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          VERSION="${{ steps.version.outputs.version }}"
           # The registry validates the exact npm version exists before accepting a publish.
           for i in $(seq 1 10); do
             if npm view "@jtalk22/slack-mcp@$VERSION" version >/dev/null 2>&1; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,3 +60,56 @@ jobs:
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_SECRET_TOKEN }}
+
+      - name: Verify server.json matches release version
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          SJ_VERSION="$(jq -r '.version' server.json)"
+          if [[ "$SJ_VERSION" != "$VERSION" ]]; then
+            echo "server.json version ($SJ_VERSION) does not match release version ($VERSION)" >&2
+            exit 1
+          fi
+
+      - name: Check MCP registry for existing version
+        id: registry_check
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          VERSIONS_URL="https://registry.modelcontextprotocol.io/v0/servers/io.github.jtalk22%2Fslack-mcp-server/versions"
+          if curl -fsSL "$VERSIONS_URL" | jq -e --arg v "$VERSION" '[.servers[] | (.server.version // .version)] | index($v) != null' >/dev/null; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+            echo "Version $VERSION already exists in the MCP registry. Skipping registry publish."
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+            echo "Version $VERSION not found in the MCP registry. Proceeding with registry publish."
+          fi
+
+      - name: Wait for npm propagation
+        if: steps.registry_check.outputs.already_published != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          # The registry validates the exact npm version exists before accepting a publish.
+          for i in $(seq 1 10); do
+            if npm view "@jtalk22/slack-mcp@$VERSION" version >/dev/null 2>&1; then
+              echo "npm has $VERSION."
+              exit 0
+            fi
+            echo "npm does not show $VERSION yet (attempt $i/10); waiting 15s..."
+            sleep 15
+          done
+          echo "npm version $VERSION not visible after 10 attempts" >&2
+          exit 1
+
+      - name: Publish to MCP registry
+        if: steps.registry_check.outputs.already_published != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish


### PR DESCRIPTION
Registry publishes previously required an interactive GitHub device-flow login for every release because registry JWTs are short-lived and `mcp-publisher` has no refresh path.

This wires the registry publish into the existing release workflow using GitHub Actions OIDC (`mcp-publisher login github-oidc`), so a GitHub release publishes npm and the registry with no interactive step.

Guards:
- **Version parity** — fails if `server.json` doesn't match the release tag.
- **Idempotent** — skipped when the version already exists in the registry (mirrors the existing npm guard), so re-running a release never 4xxs.
- **npm propagation wait** — the registry validates the exact npm version exists, so the publish polls `npm view` (up to 150s) before pushing the registry entry.

No change to the npm publish path; `id-token: write` was already present for provenance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Releases are now also published to the MCP registry after npm publish, making new versions available in more places.
* **Bug Fixes**
  * Added version validation and retry checks to help prevent incomplete or duplicated release publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->