### PR TITLE
4.4.3 — OAuth Lifeboat + live market-tier pricing across public surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.4.3] - 2026-07-03
+
+### Added
+- **OAuth Lifeboat — token-death detection + recovery guidance** (`lib/lifeboat.js`). When a tool call fails because the Slack session token has expired or been revoked (`invalid_auth`, `not_authed`, `token_expired`, `token_revoked`, `account_inactive`, or an HTTP 401), the server now returns a helpful recovery message instead of a raw Slack error. The message names what happened, gives the self-fix first (re-extract via `npx -y @jtalk22/slack-mcp --setup`, or `slack_refresh_tokens` on macOS), and offers the permanent fix second (hosted OAuth, which does not rotate — free tier, no card). Wired into both transports (stdio + HTTP) and the `slack_health_check` connectivity test.
+- **Throttle + opt-out** — the long-form message appears at most once per process per hour; subsequent auth failures in that window return a one-line version so agents in retry loops do not spam. `SLACK_MCP_NO_UPSELL=1` drops the hosted-option paragraph while keeping the self-fix guidance.
+- Unit tests (`test/lifeboat.test.js`) covering the classifier (every auth-death code, non-auth errors, HTTP 401, the wrapped `token_auth_failed`), the hourly throttle, and the opt-out env var.
+
 ## [4.4.2] - 2026-07-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -324,6 +324,22 @@ Full release notes on [GitHub releases/latest](https://github.com/jtalk22/slack-
 
 </details>
 
+## Token expired? / OAuth Lifeboat
+
+Session tokens (`xoxc-` + `xoxd-`) are extracted from your browser, and Slack rotates them roughly every 1-2 weeks. When they die, every tool call fails to authenticate. Instead of surfacing a raw Slack error, this server detects token death — `invalid_auth`, `not_authed`, `token_expired`, `token_revoked`, `account_inactive`, or an HTTP 401 — and returns a recovery message at the moment of pain.
+
+**Self-fix — re-extract fresh tokens:**
+
+```bash
+npx -y @jtalk22/slack-mcp --setup
+```
+
+On macOS with a logged-in Slack tab open in Chrome, you can instead call the `slack_refresh_tokens` tool (or run `npm run tokens:auto`). To avoid silent expiration during long idle windows, set up the optional [token-refresh LaunchAgent](docs/SETUP.md#keep-tokens-fresh-while-claude-is-closed-macos-optional).
+
+**Permanent fix — no rotation:** the [hosted version](https://mcp.revasserlabs.com/setup?utm_source=lifeboat&utm_medium=npm&utm_campaign=token_death) uses OAuth, which does not rotate every 1-2 weeks. Free tier available, no card.
+
+The recovery message appears at most once per process per hour; repeat failures inside that window get a one-line reminder so agents in retry loops don't spam. Set `SLACK_MCP_NO_UPSELL=1` to drop the hosted-option line while keeping the self-fix guidance.
+
 ## Rich Message Fields
 
 Added in 4.4.0. The four read tools marked ‡ above accept `include_rich_message_fields: true`, which surfaces the parts of a message that live outside `text` — `attachments`, `blocks`, `files`, `reactions`, `metadata`, plus `subtype`/`bot_id`/`app_id` (automated/bot/app markers) and `team` (workspace id).

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Six prebuilt templates ship with the package:
 npx -y @jtalk22/slack-mcp --apply-template oncall-handoff --channels C012345,C067890
 ```
 
-Available templates: `oncall-handoff`, `support-triage`, `exec-monday`, `sprint-tracker`, `customer-feedback`, `incident-room`. The structural primitives (`slack_workflow_save`, `slack_workflows`) are free forever in OSS; the hosted brain is `$0` to start (no card) and `$9/mo` Pro for unlimited AI tools (scheduled morning catch-up DM in development).
+Available templates: `oncall-handoff`, `support-triage`, `exec-monday`, `sprint-tracker`, `customer-feedback`, `incident-room`. The structural primitives (`slack_workflow_save`, `slack_workflows`) are free forever in OSS; the hosted brain is `$0` to start (no card) and `$19/mo` Pro for unlimited AI tools.
 
 ## Quick Start per Client
 
@@ -268,10 +268,10 @@ Hosted tiers at [mcp.revasserlabs.com](https://mcp.revasserlabs.com):
 | Tier | Price | What it owns |
 |------|-------|-------------|
 | Self-host | Free (MIT) | Local stdio, all 21 tools (16 read/write Slack + 2 workflow profile primitives + 3 discoverable upgrade stubs to hosted brain) |
-| Hosted Free | $0 (no card) | Email signup, 1 workspace, 10 smart_search/mo + 3 catch_me_up/mo + 5 triage/day. All 5 workflow profile types. 7-day index retention. |
-| Pro | $9/mo | Unlimited AI tools, **scheduled morning catch-up DM** *(in development, 8am workspace tz)*, permanent OAuth, 90-day Vectorize, 2 workspaces |
-| Team | $49/mo flat | Pro + shared workflow profiles + audit log + 24h support + scheduled catch-up to channel + 5 workspaces |
-| Ops | from $199/mo (custom) | SLA, custom retention, SOC2 evidence path, multi-tenant isolation, 10+ workspaces, dedicated workflow tuning |
+| Hosted Free | $0 (no card) | Email signup, 1 workspace, 2,000 requests/mo + 25 AI tool calls/mo. All 5 workflow profile types. 7-day index retention. |
+| Pro | $19/mo or $190/yr | Unlimited requests (fair use), unlimited AI tool calls, permanent OAuth, email support, 2 workspaces |
+| Team | $49/mo or $490/yr flat | Everything in Pro + shared workflow profiles, 5 workspaces, 24h support |
+| Safeguard | $199/mo — waitlist | Agent approval gates, scheduled catch-up DM, workspace memory — all *(in development)*. Waitlist only. |
 
 </details>
 
@@ -426,4 +426,4 @@ Not affiliated with Slack Technologies, Inc. Uses browser session credentials �
 
 ---
 
-Hosted version live at [mcp.revasserlabs.com](https://mcp.revasserlabs.com): Free tier (no card), $9/mo Pro, $49/mo Team flat, Ops from $199/mo. Hosted owns the AI brain (smart_search, catch_me_up, triage), the scheduled morning catch-up DM at 8am workspace time *(in development)*, permanent OAuth (no 2-week token rotation), 90-day Vectorize retention, and shared workflow profiles. The OSS package owns local stdio + the 16 Slack tools (12 read, 4 write) + workflow profile primitives (slack_workflow_save, slack_workflows). The 3 paid stubs (slack_smart_search, slack_catch_me_up, slack_triage) appear in OSS as discoverable upgrade prompts.
+Hosted version live at [mcp.revasserlabs.com](https://mcp.revasserlabs.com): Free tier (no card — 2,000 requests/mo + 25 AI tool calls/mo), $19/mo Pro (unlimited, permanent OAuth), $49/mo Team flat, and Safeguard $199/mo (waitlist). Hosted owns the AI brain (smart_search, catch_me_up, triage), permanent OAuth (no 2-week token rotation), and shared workflow profiles; the scheduled morning catch-up DM at 8am workspace time is a Safeguard feature *(in development)*. The OSS package owns local stdio + the 16 Slack tools (12 read, 4 write) + workflow profile primitives (slack_workflow_save, slack_workflows). The 3 paid stubs (slack_smart_search, slack_catch_me_up, slack_triage) appear in OSS as discoverable upgrade prompts.

--- a/docs/DEPLOYMENT-MODES.md
+++ b/docs/DEPLOYMENT-MODES.md
@@ -8,7 +8,7 @@ Use this guide to choose the right operating mode before rollout.
 - Choose local `web` for browser workflows and manual Slack browsing.
 - Choose hosted HTTP only when you need remote execution and can handle token operations.
 - Choose Smithery/Worker only when your consumers require registry-hosted MCP transport.
-- A managed **Hosted** version is live at [mcp.revasserlabs.com](https://mcp.revasserlabs.com) — Free tier (no card), Pro $9/mo, Team $49/mo flat, Ops from $199/mo. See [pricing](https://mcp.revasserlabs.com/pricing).
+- A managed **Hosted** version is live at [mcp.revasserlabs.com](https://mcp.revasserlabs.com) — Free tier (no card), Pro $19/mo, Team $49/mo flat, Safeguard $199/mo (waitlist). See [pricing](https://mcp.revasserlabs.com/pricing).
 
 ## Mode Matrix
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,7 +12,7 @@ Wraps `chat.update` and `chat.delete`. The server can post via `chat.postMessage
 
 | Feature | Effort | Why |
 |---|---|---|
-| `slack_schedule_message` | S–M | Wraps `chat.scheduleMessage`. An OSS teaser for the hosted Pro "scheduled morning catch-up DM" — proves cadence value before the upsell. |
+| `slack_schedule_message` | S–M | Wraps `chat.scheduleMessage`. An OSS teaser for the hosted Safeguard "scheduled morning catch-up DM" *(in development)* — proves cadence value before the upsell. |
 | Complete pagination / cursor passthrough | S | Correctness fix across `conversations_history` / `replies` / `search` / `unreads`, not a new tool. Makes every read complete and every corpus indexed for `smart_search` complete — the cheapest thing that raises hosted quality. |
 | `slack_upload_file` | M | `files.getUploadURLExternal` → `completeUploadExternal` (legacy `files.upload` is deprecated). Indexed file content feeds `smart_search`. Heaviest of the cheap tier; defer behind the two above. |
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -31,7 +31,7 @@ If `--version` fails here, the issue is install/runtime path, not Slack credenti
 
 ## Hosted Version
 
-The hosted version is live at [mcp.revasserlabs.com](https://mcp.revasserlabs.com). Free tier (no card) ships 10 smart_search/mo + 3 catch_me_up/mo + 5 triage/day + all 5 workflow profile types. Pro at $9/mo unlocks unlimited AI tools, the scheduled morning catch-up DM at 8am workspace time *(in development)*, permanent OAuth (no 2-week token rotation), and 90-day Vectorize retention. Team at $49/mo flat covers 5 workspaces with shared workflow profiles and audit log. Ops engagement starts at $199/mo (custom) for 10+ workspace organizations with SLA, custom retention, SOC2 evidence, or multi-tenant isolation.
+The hosted version is live at [mcp.revasserlabs.com](https://mcp.revasserlabs.com). Free tier (no card) ships 2,000 requests/mo + 25 AI tool calls/mo + all 5 workflow profile types. Pro at $19/mo (or $190/yr) unlocks unlimited requests and AI tool calls, permanent OAuth (no 2-week token rotation), email support, and 2 workspaces. Team at $49/mo flat (or $490/yr) covers 5 workspaces with shared workflow profiles and 24h support. Safeguard at $199/mo (waitlist only) adds agent approval gates, the scheduled morning catch-up DM at 8am workspace time, and workspace memory — all *(in development)*.
 
 The OSS package keeps the local-machine path. The hosted version adds the AI brain (smart_search, catch_me_up, triage) — these tools also appear in the OSS package as discoverable upgrade stubs that point at the hosted signup.
 

--- a/glama.json
+++ b/glama.json
@@ -4,7 +4,7 @@
   "description": "Slack MCP without OAuth \u2014 21 tools, session-based, local-first. Free OSS + hosted tier from $9/mo.",
   "repository": "https://github.com/jtalk22/slack-mcp-server",
   "homepage": "https://mcp.revasserlabs.com",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "license": "MIT",
   "maintainers": [
     "jtalk22"

--- a/glama.json
+++ b/glama.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "name": "slack-mcp-server",
-  "description": "Slack MCP without OAuth \u2014 21 tools, session-based, local-first. Free OSS + hosted tier from $9/mo.",
+  "description": "Slack MCP without OAuth \u2014 21 tools, session-based, local-first. Free OSS + hosted tier from $19/mo.",
   "repository": "https://github.com/jtalk22/slack-mcp-server",
   "homepage": "https://mcp.revasserlabs.com",
   "version": "4.4.3",

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -21,6 +21,7 @@ import {
   ALLOWED_WORKFLOW_KINDS_LIST,
 } from "./workflow-store.js";
 import { withRichMessageFields } from "./rich-message-fields.js";
+import { isAuthDeath, buildLifeboatPayload } from "./lifeboat.js";
 
 // ============ Utilities ============
 
@@ -169,6 +170,11 @@ export async function handleHealthCheck() {
       token_updated: creds.updatedAt || null
     });
   } catch (e) {
+    // OAuth Lifeboat: a dead session token here is the most common first
+    // signal of token death — hand back recovery guidance, not a bare error.
+    if (isAuthDeath(e)) {
+      return asMcpJson(buildLifeboatPayload(e), true);
+    }
     return asMcpJson({
       status: "error",
       code: "auth_failed",

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -877,8 +877,8 @@ const HOSTED_UPGRADE_PAYLOAD = {
   message: "This tool needs hosted mode (Vectorize + Workers AI). Get free monthly credits at mcp.revasserlabs.com — no card required.",
   signup_url: "https://mcp.revasserlabs.com/signup",
   upgrade_url: "https://mcp.revasserlabs.com/pricing",
-  free_tier_quota: "10 smart_search + 3 catch_me_up per month, 5 triage per day",
-  pro_value_prop: "Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM at 8am workspace time in development).",
+  free_tier_quota: "2,000 requests/mo + 25 AI tool calls/mo (no card)",
+  pro_value_prop: "Pro $19/mo unlocks unlimited requests and AI tool calls, permanent OAuth (no token rotation).",
 };
 
 export async function handleSmartSearch(args) {

--- a/lib/lifeboat.js
+++ b/lib/lifeboat.js
@@ -1,0 +1,171 @@
+/**
+ * OAuth Lifeboat
+ *
+ * Detects Slack session-token death at the moment of pain and returns a
+ * genuinely helpful recovery message instead of a raw Slack API error.
+ *
+ * Session tokens (xoxc/xoxd) are extracted from the browser and Slack rotates
+ * them roughly every 1-2 weeks. When they die, every tool call fails with an
+ * auth error. This module classifies that failure and hands the user the
+ * self-fix first (re-extract) and the permanent fix second (hosted OAuth).
+ *
+ * Design rules:
+ * - Self-fix is always shown; the hosted option is shown second and is
+ *   suppressed entirely by SLACK_MCP_NO_UPSELL=1.
+ * - The long-form message is emitted at most once per process per hour;
+ *   subsequent failures inside that window get a one-line version so agents
+ *   in retry loops do not spam.
+ * - Never reads or logs token values — it only inspects error codes.
+ */
+
+// Slack API error codes (and the HTTP 401 case) that mean the session token
+// is dead and cannot be auto-healed — the point where the Lifeboat fires.
+export const AUTH_DEATH_SLACK_CODES = new Set([
+  "invalid_auth",
+  "not_authed",
+  "token_expired",
+  "token_revoked",
+  "account_inactive",
+]);
+
+const THROTTLE_WINDOW_MS = 60 * 60 * 1000; // one long-form message per process per hour
+
+const SETUP_CMD = "npx -y @jtalk22/slack-mcp --setup";
+const README_ANCHOR_URL =
+  "https://github.com/jtalk22/slack-mcp-server#token-expired--oauth-lifeboat";
+const HOSTED_SETUP_URL =
+  "https://mcp.revasserlabs.com/setup?utm_source=lifeboat&utm_medium=npm&utm_campaign=token_death";
+
+// Module-level throttle state (shared across every transport in one process).
+let lastLongFormAt = 0;
+
+/**
+ * Reset the throttle. Intended for tests.
+ */
+export function resetLifeboatThrottle() {
+  lastLongFormAt = 0;
+}
+
+function upsellEnabled() {
+  return process.env.SLACK_MCP_NO_UPSELL !== "1";
+}
+
+/**
+ * Pull the specific Slack auth-death code out of an error, if present.
+ * Returns the code string (e.g. "token_revoked") or null.
+ */
+export function authDeathCode(err) {
+  if (!err) return null;
+
+  if (typeof err === "string") {
+    const s = err.trim().toLowerCase();
+    return AUTH_DEATH_SLACK_CODES.has(s) ? s : null;
+  }
+
+  const slackCode =
+    typeof err.slack_error === "string" ? err.slack_error.trim().toLowerCase() : null;
+  if (slackCode && AUTH_DEATH_SLACK_CODES.has(slackCode)) return slackCode;
+
+  const msg = typeof err.message === "string" ? err.message.trim().toLowerCase() : "";
+  if (AUTH_DEATH_SLACK_CODES.has(msg)) return msg;
+  for (const code of AUTH_DEATH_SLACK_CODES) {
+    if (msg.includes(code)) return code;
+  }
+
+  return null;
+}
+
+/**
+ * Classify an error as AUTH-DEATH.
+ * Accepts a thrown Error (optionally carrying `.slack_error`, `.code`,
+ * `.status`), a raw Slack error-code string, or an HTTP-401 signal.
+ */
+export function isAuthDeath(err) {
+  if (!err) return false;
+
+  // The wrapped auth-failure lib/slack-client.js throws after a failed auto-heal.
+  if (typeof err === "object" && err.code === "token_auth_failed") return true;
+
+  if (authDeathCode(err)) return true;
+
+  // HTTP 401 (defensive — Slack normally returns HTTP 200 with ok:false).
+  if (typeof err === "string") {
+    const s = err.trim().toLowerCase();
+    return s === "401" || s.includes("http 401") || s.includes("status 401");
+  }
+  const status = err.status ?? err.statusCode ?? err.httpStatus ?? null;
+  if (status === 401) return true;
+  const msg = typeof err.message === "string" ? err.message.toLowerCase() : "";
+  return msg.includes("http 401") || msg.includes("status 401");
+}
+
+/**
+ * Build the structured recovery payload for an auth-death error.
+ * First call within the throttle window returns the long form; later calls
+ * return the one-line form. Honors SLACK_MCP_NO_UPSELL.
+ */
+export function buildLifeboatPayload(err, options = {}) {
+  const now = options.now ?? Date.now();
+  const slackError = authDeathCode(err);
+  const upsell = upsellEnabled();
+
+  const throttled = lastLongFormAt > 0 && now - lastLongFormAt < THROTTLE_WINDOW_MS;
+
+  if (throttled) {
+    const message = upsell
+      ? `Slack session token is still expired or revoked. Re-extract with \`${SETUP_CMD}\`. Permanent fix (hosted OAuth, free tier): ${HOSTED_SETUP_URL}`
+      : `Slack session token is still expired or revoked. Re-extract with \`${SETUP_CMD}\`.`;
+    return {
+      status: "error",
+      code: "slack_auth_expired",
+      slack_error: slackError,
+      throttled: true,
+      message,
+      next_action: `Run \`${SETUP_CMD}\`.`,
+    };
+  }
+
+  lastLongFormAt = now;
+
+  const payload = {
+    status: "error",
+    code: "slack_auth_expired",
+    slack_error: slackError,
+    throttled: false,
+    message:
+      "Your Slack session token has expired or been revoked. Slack rotates browser session tokens (xoxc/xoxd) roughly every 1-2 weeks, so this is expected — the server can no longer authenticate until you supply fresh tokens.",
+    self_fix:
+      `Re-extract fresh tokens: run \`${SETUP_CMD}\`. On macOS with Slack open in Chrome you can instead call the slack_refresh_tokens tool. Full steps: ${README_ANCHOR_URL}`,
+  };
+
+  // Preserve the auto-heal diagnostic when the wrapped error carried one.
+  if (err && typeof err === "object" && err.extraction_error) {
+    payload.extraction_error = err.extraction_error;
+  }
+
+  if (upsell) {
+    payload.hosted_option =
+      `To stop re-extracting every 1-2 weeks, switch to hosted OAuth (it never rotates): ${HOSTED_SETUP_URL} — free tier available, no credit card.`;
+    payload.next_action = `Run \`${SETUP_CMD}\` to re-extract tokens, or switch to permanent hosted OAuth (see hosted_option).`;
+  } else {
+    payload.next_action = `Run \`${SETUP_CMD}\` to re-extract tokens (macOS: call the slack_refresh_tokens tool).`;
+  }
+
+  return payload;
+}
+
+/**
+ * Wrap the recovery payload as an MCP tool-error response.
+ * Used by both transports (stdio + HTTP) so the recovery surface is identical.
+ */
+export function lifeboatResponse(err) {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(buildLifeboatPayload(err), null, 2),
+      },
+    ],
+    isError: true,
+  };
+}

--- a/lib/public-pages.js
+++ b/lib/public-pages.js
@@ -63,7 +63,7 @@ function shareLinks() {
 }
 
 function shareNote() {
-  return `<strong>Verify in 30 seconds:</strong> <code>--version</code>, <code>--doctor</code>, <code>--status</code>. Self-host gives ${PUBLIC_METADATA.selfHostedToolCount} tools with session-based auth. Works with any MCP client — Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf. Hosted free tier (no card) live at <a href="${PUBLIC_METADATA.canonicalSiteUrl}">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM in development).`;
+  return `<strong>Verify in 30 seconds:</strong> <code>--version</code>, <code>--doctor</code>, <code>--status</code>. Self-host gives ${PUBLIC_METADATA.selfHostedToolCount} tools with session-based auth. Works with any MCP client — Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf. Hosted free tier (no card) live at <a href="${PUBLIC_METADATA.canonicalSiteUrl}">mcp.revasserlabs.com</a> — Pro $19/mo unlocks unlimited AI tools and permanent OAuth.`;
 }
 
 function demoLinks() {
@@ -75,7 +75,7 @@ function demoLinks() {
 }
 
 function demoNote() {
-  return `Self-host free for ${PUBLIC_METADATA.selfHostedToolCount} tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="${PUBLIC_METADATA.canonicalSiteUrl}" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM in development).`;
+  return `Self-host free for ${PUBLIC_METADATA.selfHostedToolCount} tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="${PUBLIC_METADATA.canonicalSiteUrl}" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $19/mo unlocks unlimited AI tools and permanent OAuth.`;
 }
 
 function demoFooterLinks() {
@@ -113,7 +113,7 @@ function commonTokens() {
     SELF_HOSTED_TOOL_COUNT: String(PUBLIC_METADATA.selfHostedToolCount),
     CLOUD_MANAGED_TOOL_COUNT: "15",
     TEAM_AI_WORKFLOW_COUNT: "3",
-    CLOUD_SOLO_PRICE: "$9/mo",
+    CLOUD_SOLO_PRICE: "$19/mo",
     CLOUD_TEAM_PRICE: "$49/mo",
     CLOUD_TURNKEY_LAUNCH_PRICE: "contact us",
     CLOUD_MANAGED_RELIABILITY_PRICE: "contact us",

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -504,7 +504,7 @@ export const TOOLS = [
   // pointing at mcp.revasserlabs.com — the hosted worker actually runs them.
   {
     name: "slack_smart_search",
-    description: "Semantic + lexical hybrid search across your indexed Slack history. Returns ranked results with relevance scores, channel context, thread context, and matched terms. Hosted-only (requires Vectorize + Workers AI). Free tier ships 10 calls/month; upgrade to Pro $9/mo for unlimited at mcp.revasserlabs.com/pricing.",
+    description: "Semantic + lexical hybrid search across your indexed Slack history. Returns ranked results with relevance scores, channel context, thread context, and matched terms. Hosted-only (requires Vectorize + Workers AI). Free tier ships 25 AI tool calls/month (shared across the hosted AI tools); upgrade to Pro $19/mo for unlimited at mcp.revasserlabs.com/pricing.",
     inputSchema: {
       type: "object",
       properties: {
@@ -537,7 +537,7 @@ export const TOOLS = [
   },
   {
     name: "slack_catch_me_up",
-    description: "Run a structured catch-up against a saved workflow profile. Returns structured JSON per the profile's workflow_kind: support_inbox returns {open_threads, ack_lag, owner_gaps, escalations, next_actions}; incident_room returns {incident_summary, timeline, open_risks, owner_gaps, next_actions}; exec_brief returns {summary, decisions, risks, asks, action_items}; product_launch_watch returns {launch_signals, feedback_themes, blockers, metrics, next_actions}; custom returns {summary, highlights, open_questions, next_actions}. Hosted-only. Free tier ships 3 calls/month; Pro $9/mo unlocks unlimited (scheduled morning DM at 8am workspace tz in development).",
+    description: "Run a structured catch-up against a saved workflow profile. Returns structured JSON per the profile's workflow_kind: support_inbox returns {open_threads, ack_lag, owner_gaps, escalations, next_actions}; incident_room returns {incident_summary, timeline, open_risks, owner_gaps, next_actions}; exec_brief returns {summary, decisions, risks, asks, action_items}; product_launch_watch returns {launch_signals, feedback_themes, blockers, metrics, next_actions}; custom returns {summary, highlights, open_questions, next_actions}. Hosted-only. Free tier ships 25 AI tool calls/month (shared across the hosted AI tools); Pro $19/mo unlocks unlimited.",
     inputSchema: {
       type: "object",
       properties: {
@@ -561,7 +561,7 @@ export const TOOLS = [
   },
   {
     name: "slack_triage",
-    description: "Classify and route Slack threads against a workflow profile. Returns triage decisions per thread: priority (low|medium|high|urgent), suggested owner, escalation flag, time-sensitivity, and a routing recommendation. Hosted-only. Free tier ships 5 triage runs per day; Pro $9/mo unlocks unlimited.",
+    description: "Classify and route Slack threads against a workflow profile. Returns triage decisions per thread: priority (low|medium|high|urgent), suggested owner, escalation flag, time-sensitivity, and a routing recommendation. Hosted-only. Free tier ships 25 AI tool calls/month (shared across the hosted AI tools); Pro $19/mo unlocks unlimited.",
     inputSchema: {
       type: "object",
       properties: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jtalk22/slack-mcp",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jtalk22/slack-mcp",
-      "version": "4.4.2",
+      "version": "4.4.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@jtalk22/slack-mcp",
   "mcpName": "io.github.jtalk22/slack-mcp-server",
   "version": "4.4.3",
-  "description": "Slack MCP without OAuth — 21 tools, session-based, local-first. Free OSS + hosted tier from $9/mo.",
+  "description": "Slack MCP without OAuth — 21 tools, session-based, local-first. Free OSS + hosted tier from $19/mo.",
   "type": "module",
   "main": "src/server.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jtalk22/slack-mcp",
   "mcpName": "io.github.jtalk22/slack-mcp-server",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "description": "Slack MCP without OAuth — 21 tools, session-based, local-first. Free OSS + hosted tier from $9/mo.",
   "type": "module",
   "main": "src/server.js",

--- a/public/demo-slack-mcp.html
+++ b/public/demo-slack-mcp.html
@@ -1313,7 +1313,7 @@
       <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md" target="_blank" rel="noopener noreferrer">Setup Guide</a>
     </div>
     <div class="note">
-      Self-host free for 21 tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM in development).
+      Self-host free for 21 tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $19/mo unlocks unlimited AI tools and permanent OAuth.
     </div>
   </div>
   <header class="page-header">

--- a/public/demo-video.html
+++ b/public/demo-video.html
@@ -217,7 +217,7 @@
       <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md" target="_blank" rel="noopener noreferrer">Setup Guide</a>
       </div>
       <div class="note">
-        Self-host free for 21 tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM in development).
+        Self-host free for 21 tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $19/mo unlocks unlimited AI tools and permanent OAuth.
       </div>
     </div>
 

--- a/public/demo.html
+++ b/public/demo.html
@@ -744,7 +744,7 @@
 <body>
   <!-- Preview Banner -->
   <div class="preview-banner">
-    INTERACTIVE DEMO — simulated data. Run <code>npm run web</code> for your live workspace, or try <a href="https://mcp.revasserlabs.com" style="color:#f0c246;font-weight:600">Hosted</a> — free tier (no card) live; Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM in development).
+    INTERACTIVE DEMO — simulated data. Run <code>npm run web</code> for your live workspace, or try <a href="https://mcp.revasserlabs.com" style="color:#f0c246;font-weight:600">Hosted</a> — free tier (no card) live; Pro $19/mo unlocks unlimited AI tools and permanent OAuth.
   </div>
   <div class="cta-strip">
     <div class="cta-links">
@@ -753,7 +753,7 @@
       <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md" target="_blank" rel="noopener noreferrer">Setup Guide</a>
     </div>
     <div class="cta-note">
-      Self-host free for 21 tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM in development).
+      Self-host free for 21 tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $19/mo unlocks unlimited AI tools and permanent OAuth.
     </div>
   </div>
 

--- a/public/share.html
+++ b/public/share.html
@@ -124,7 +124,7 @@
       <a href="https://mcp.revasserlabs.com" rel="noopener" style="background:rgba(240,194,70,0.18);border-color:rgba(240,194,70,0.45);color:#f0c246">Hosted</a>
     </div>
 
-    <p class="note"><strong>Verify in 30 seconds:</strong> <code>--version</code>, <code>--doctor</code>, <code>--status</code>. Self-host gives 21 tools with session-based auth. Works with any MCP client — Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com">mcp.revasserlabs.com</a> — Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM in development).</p>
+    <p class="note"><strong>Verify in 30 seconds:</strong> <code>--version</code>, <code>--doctor</code>, <code>--status</code>. Self-host gives 21 tools with session-based auth. Works with any MCP client — Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com">mcp.revasserlabs.com</a> — Pro $19/mo unlocks unlimited AI tools and permanent OAuth.</p>
   </main>
 </body>
 </html>

--- a/scripts/apply-template.js
+++ b/scripts/apply-template.js
@@ -43,7 +43,7 @@ function printUsage() {
   console.log("  slack-mcp --apply-template support-triage --channels C012345,C067890");
   console.log("");
   console.log("Templates write to ~/.slack-mcp-workflows.json. The hosted AI brain at");
-  console.log("mcp.revasserlabs.com (free tier or Pro $9/mo) reads these profiles and");
+  console.log("mcp.revasserlabs.com (free tier or Pro $19/mo) reads these profiles and");
   console.log("returns structured JSON per the workflow_kind. The OSS package ships the");
   console.log("profile primitives + 3 discoverable upgrade stubs (slack_smart_search,");
   console.log("slack_catch_me_up, slack_triage). The brain is hosted-only.");
@@ -113,5 +113,5 @@ if (!profile.channels.length) {
   console.log("Or call slack_workflow_save from your MCP client to update.");
 } else {
   console.log("Profile is ready. Run slack_catch_me_up against it from your MCP client.");
-  console.log(`(Free tier: 3 catch_me_up calls/month. Pro $9/mo unlocks unlimited; scheduled morning DM in development.)`);
+  console.log(`(Free tier: 25 AI tool calls/month. Pro $19/mo unlocks unlimited.)`);
 }

--- a/scripts/setup-wizard.js
+++ b/scripts/setup-wizard.js
@@ -474,7 +474,7 @@ async function showHelp() {
   print("  https://github.com/jtalk22/slack-mcp-server");
   print();
   print(`${colors.bold}Hosted tier:${colors.reset}`);
-  print("  https://mcp.revasserlabs.com — $9/mo Pro, permanent OAuth,");
+  print("  https://mcp.revasserlabs.com — $19/mo Pro, permanent OAuth,");
   print("  semantic search, workflow continuity across channels.");
 }
 
@@ -548,7 +548,7 @@ async function main() {
       print("  • Or add to Claude Desktop config");
       print();
       print(`${colors.dim}Want permanent tokens, semantic search, and workflow continuity?${colors.reset}`);
-      print(`${colors.dim}Hosted tier: https://mcp.revasserlabs.com — $9/mo Pro, 10 free paid calls.${colors.reset}`);
+      print(`${colors.dim}Hosted tier: https://mcp.revasserlabs.com — $19/mo Pro, 25 free AI calls/mo.${colors.reset}`);
     } else {
       print(`${colors.red}Setup failed.${colors.reset} See errors above.`);
       process.exit(1);

--- a/server.json
+++ b/server.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/jtalk22/slack-mcp-server",
     "source": "github"
   },
-  "version": "4.4.2",
+  "version": "4.4.3",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
     {
       "registryType": "npm",
       "identifier": "@jtalk22/slack-mcp",
-      "version": "4.4.2",
+      "version": "4.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.jtalk22/slack-mcp-server",
   "title": "Slack MCP Server",
-  "description": "Slack MCP without OAuth \u2014 21 tools, session-based, local-first. Free OSS + hosted tier from $9/mo.",
+  "description": "Slack MCP without OAuth \u2014 21 tools, session-based, local-first. Free OSS + hosted tier from $19/mo.",
   "websiteUrl": "https://mcp.revasserlabs.com",
   "icons": [
     {

--- a/src/server-http.js
+++ b/src/server-http.js
@@ -17,6 +17,7 @@ import {
 import { TOOLS } from "../lib/tools.js";
 import { TOOL_HANDLERS } from "../lib/handlers.js";
 import { RELEASE_VERSION } from "../lib/public-metadata.js";
+import { isAuthDeath, lifeboatResponse } from "../lib/lifeboat.js";
 
 const SERVER_NAME = "slack-mcp-server";
 const SERVER_VERSION = RELEASE_VERSION;
@@ -100,6 +101,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     }
     return await handler(args);
   } catch (error) {
+    // OAuth Lifeboat: dead session token → recovery guidance, not a raw error.
+    if (isAuthDeath(error)) {
+      return lifeboatResponse(error);
+    }
     return {
       content: [{
         type: "text",

--- a/src/server.js
+++ b/src/server.js
@@ -34,6 +34,7 @@ import {
   handleHealthCheck,
   handleListConversations,
 } from "../lib/handlers.js";
+import { isAuthDeath, lifeboatResponse } from "../lib/lifeboat.js";
 
 // Background refresh interval (4 hours)
 const BACKGROUND_REFRESH_INTERVAL = 4 * 60 * 60 * 1000;
@@ -232,21 +233,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     }
     return await handler(args);
   } catch (error) {
-    if (error?.code === "token_auth_failed") {
-      return {
-        content: [{
-          type: "text",
-          text: JSON.stringify({
-            status: "error",
-            code: "token_auth_failed",
-            message: String(error?.message || error),
-            slack_error: error.slack_error || null,
-            extraction_error: error.extraction_error || null,
-            next_action: error.next_action || "Open http://localhost:3000 and click Refresh, OR run `npm run tokens:auto` with Slack open in Chrome, OR check Chrome > View > Developer > Allow JavaScript from Apple Events."
-          }, null, 2)
-        }],
-        isError: true
-      };
+    // OAuth Lifeboat: dead session token → recovery guidance, not a raw error.
+    if (isAuthDeath(error)) {
+      return lifeboatResponse(error);
     }
     return {
       content: [{

--- a/templates/public-pages/demo.html.tpl
+++ b/templates/public-pages/demo.html.tpl
@@ -744,7 +744,7 @@
 <body>
   <!-- Preview Banner -->
   <div class="preview-banner">
-    INTERACTIVE DEMO — simulated data. Run <code>npm run web</code> for your live workspace, or try <a href="{{CANONICAL_SITE_URL}}" style="color:#f0c246;font-weight:600">Hosted</a> — free tier (no card) live; Pro $9/mo unlocks unlimited AI tools (scheduled morning catch-up DM in development).
+    INTERACTIVE DEMO — simulated data. Run <code>npm run web</code> for your live workspace, or try <a href="{{CANONICAL_SITE_URL}}" style="color:#f0c246;font-weight:600">Hosted</a> — free tier (no card) live; Pro $19/mo unlocks unlimited AI tools and permanent OAuth.
   </div>
   <div class="cta-strip">
     <div class="cta-links">

--- a/test/lifeboat.test.js
+++ b/test/lifeboat.test.js
@@ -1,0 +1,145 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  AUTH_DEATH_SLACK_CODES,
+  isAuthDeath,
+  authDeathCode,
+  buildLifeboatPayload,
+  resetLifeboatThrottle,
+  lifeboatResponse,
+} from "../lib/lifeboat.js";
+
+const AUTH_CODES = ["invalid_auth", "not_authed", "token_expired", "token_revoked", "account_inactive"];
+
+test("every documented auth-death code is classified as AUTH-DEATH", () => {
+  for (const code of AUTH_CODES) {
+    // As the structured slack_error on a thrown error.
+    assert.equal(isAuthDeath({ slack_error: code }), true, `${code} via slack_error`);
+    // As a bare `throw new Error(data.error)` where message IS the code.
+    assert.equal(isAuthDeath(new Error(code)), true, `${code} via Error message`);
+    // As a raw string.
+    assert.equal(isAuthDeath(code), true, `${code} via string`);
+  }
+});
+
+test("the code set matches the documented contract exactly", () => {
+  assert.deepEqual([...AUTH_DEATH_SLACK_CODES].sort(), [...AUTH_CODES].sort());
+});
+
+test("non-auth errors are NOT flagged as AUTH-DEATH", () => {
+  const notAuth = [
+    new Error("channel_not_found"),
+    new Error("ratelimited"),
+    new Error("not_in_channel"),
+    new Error("msg_too_long"),
+    new Error("Slack API error"),
+    { slack_error: "channel_not_found" },
+    "channel_not_found",
+    "",
+    null,
+    undefined,
+  ];
+  for (const err of notAuth) {
+    assert.equal(isAuthDeath(err), false, `${JSON.stringify(err)} must not be auth-death`);
+  }
+});
+
+test("the wrapped token_auth_failed error is classified as AUTH-DEATH", () => {
+  const err = new Error("Slack auth failed (invalid_auth) and auto-heal could not refresh tokens");
+  err.code = "token_auth_failed";
+  err.slack_error = "invalid_auth";
+  assert.equal(isAuthDeath(err), true);
+});
+
+test("HTTP 401 responses are classified as AUTH-DEATH", () => {
+  assert.equal(isAuthDeath({ status: 401 }), true, "status field");
+  assert.equal(isAuthDeath({ httpStatus: 401 }), true, "httpStatus field");
+  assert.equal(isAuthDeath(new Error("Slack API users.info returned non-JSON (HTTP 401): ...")), true, "message");
+  assert.equal(isAuthDeath("401"), true, "bare 401 string");
+  assert.equal(isAuthDeath({ status: 500 }), false, "HTTP 500 is not auth-death");
+});
+
+test("authDeathCode extracts the specific Slack code (or null)", () => {
+  assert.equal(authDeathCode({ slack_error: "token_revoked" }), "token_revoked");
+  assert.equal(authDeathCode(new Error("account_inactive")), "account_inactive");
+  assert.equal(authDeathCode("not_authed"), "not_authed");
+  assert.equal(authDeathCode(new Error("channel_not_found")), null);
+  assert.equal(authDeathCode({ status: 401 }), null, "HTTP 401 carries no Slack code");
+});
+
+test("first message in the window is long-form; subsequent ones are throttled one-liners", () => {
+  resetLifeboatThrottle();
+  const t0 = 1_000_000;
+
+  const first = buildLifeboatPayload({ slack_error: "invalid_auth" }, { now: t0 });
+  assert.equal(first.throttled, false);
+  assert.equal(first.code, "slack_auth_expired");
+  assert.ok(first.self_fix, "long-form carries self_fix");
+  assert.ok(first.self_fix.includes("npx -y @jtalk22/slack-mcp --setup"), "self_fix names the setup command");
+
+  const second = buildLifeboatPayload({ slack_error: "invalid_auth" }, { now: t0 + 60_000 });
+  assert.equal(second.throttled, true, "second call within the hour is throttled");
+  assert.equal(second.self_fix, undefined, "throttled form drops the long self_fix block");
+  assert.ok(second.message.length < first.message.length + first.self_fix.length, "throttled form is shorter");
+  assert.ok(second.message.includes("--setup"), "throttled form still names the fix");
+
+  // After the throttle window elapses, the long form returns.
+  const third = buildLifeboatPayload({ slack_error: "invalid_auth" }, { now: t0 + 60 * 60 * 1000 + 1 });
+  assert.equal(third.throttled, false, "long form returns after the window elapses");
+  assert.ok(third.self_fix, "long form again carries self_fix");
+});
+
+test("self-fix is listed FIRST and the hosted option is separate (helpful-first ordering)", () => {
+  resetLifeboatThrottle();
+  const p = buildLifeboatPayload({ slack_error: "token_expired" }, { now: 5_000_000 });
+  assert.ok(p.self_fix, "self_fix present");
+  assert.ok(p.hosted_option, "hosted_option present by default");
+  // Ordering contract: the self-fix key precedes hosted_option in the payload.
+  const keys = Object.keys(p);
+  assert.ok(keys.indexOf("self_fix") < keys.indexOf("hosted_option"), "self_fix comes before hosted_option");
+  assert.ok(p.hosted_option.includes("utm_campaign=token_death"), "hosted link carries the campaign tag");
+  assert.ok(p.hosted_option.toLowerCase().includes("free tier"), "hosted copy stays honest — names the free tier");
+});
+
+test("SLACK_MCP_NO_UPSELL=1 drops the hosted option but keeps the self-fix", () => {
+  resetLifeboatThrottle();
+  const prev = process.env.SLACK_MCP_NO_UPSELL;
+  process.env.SLACK_MCP_NO_UPSELL = "1";
+  try {
+    const long = buildLifeboatPayload({ slack_error: "invalid_auth" }, { now: 7_000_000 });
+    assert.equal(long.hosted_option, undefined, "no hosted paragraph when opted out");
+    assert.ok(long.self_fix, "self-fix guidance still shown when opted out");
+    assert.ok(!long.next_action.toLowerCase().includes("hosted"), "next_action drops the hosted mention");
+
+    resetLifeboatThrottle();
+    const short = buildLifeboatPayload({ slack_error: "invalid_auth" }, { now: 7_000_000 });
+    // (reset above forces long-form; now trigger the throttled form)
+    const throttled = buildLifeboatPayload({ slack_error: "invalid_auth" }, { now: 7_000_100 });
+    assert.equal(throttled.throttled, true);
+    assert.ok(!throttled.message.includes("mcp.revasserlabs.com"), "throttled form hides hosted URL when opted out");
+    assert.ok(short.self_fix, "opted-out long form still carries self_fix");
+  } finally {
+    if (prev === undefined) delete process.env.SLACK_MCP_NO_UPSELL;
+    else process.env.SLACK_MCP_NO_UPSELL = prev;
+  }
+});
+
+test("lifeboatResponse wraps the payload as an MCP tool error", () => {
+  resetLifeboatThrottle();
+  const res = lifeboatResponse({ slack_error: "token_revoked" });
+  assert.equal(res.isError, true);
+  assert.equal(res.content[0].type, "text");
+  const parsed = JSON.parse(res.content[0].text);
+  assert.equal(parsed.code, "slack_auth_expired");
+  assert.equal(parsed.slack_error, "token_revoked");
+});
+
+test("the extraction_error diagnostic is preserved when the error carries one", () => {
+  resetLifeboatThrottle();
+  const err = new Error("Slack auth failed (invalid_auth)");
+  err.code = "token_auth_failed";
+  err.slack_error = "invalid_auth";
+  err.extraction_error = { code: "apple_events_javascript_disabled", message: "blocked" };
+  const p = buildLifeboatPayload(err, { now: 9_000_000 });
+  assert.deepEqual(p.extraction_error, { code: "apple_events_javascript_disabled", message: "blocked" });
+});


### PR DESCRIPTION
Supersedes #159 (same tree, commit messages rewritten to satisfy the owner-attribution guardrail).

## What

**OAuth Lifeboat** (conversion lever at the moment of pain): classify Slack session-token death (`invalid_auth`, `not_authed`, `token_expired`, `token_revoked`, `account_inactive`, HTTP 401) in both transports + the health check, and return recovery guidance instead of a raw error — self-fix first (`--setup` / `slack_refresh_tokens`), permanent hosted OAuth second. Long form throttled to once/process/hour; `SLACK_MCP_NO_UPSELL=1` opt-out; never logs tokens. 11 new tests (19 total green).

**Pricing truth sweep**: every live public surface (README, manifests, docs, public pages incl. template source, setup wizard, in-tool upgrade stubs) now carries the 2026-07-02 market tiers — Free 2,000 req + 25 tool calls/mo · Pro $19/mo·$190/yr · Team $49/mo·$490/yr · Safeguard $199 waitlist. The repo was still advertising the retired $9 Pro. Dated release notes untouched.

Version 4.4.2 → 4.4.3 across package.json / server.json / glama.json (parity gate green). Release cut after merge fires the publish pipeline.