### PR TITLE
Smoke two-invariants split + review follow-ups + live cloud-health tile fix

### DIFF
--- a/.github/workflows/live-browser-smoke.yml
+++ b/.github/workflows/live-browser-smoke.yml
@@ -1,8 +1,16 @@
 name: Live Browser Smoke
 
+# Two invariants, two triggers:
+#   push (main)          — deployment integrity: the page renders live upstream truth.
+#                          package.json ahead of the latest release = expected window.
+#   release (published)  — surface convergence: page + npm + releases API must all
+#                          equal the released version (strict; retries cover npm
+#                          propagation right after publish).
 on:
   push:
     branches: [main]
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:
@@ -25,4 +33,9 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Run deployed GitHub Pages smoke
-        run: node scripts/browser-smoke.js --mode live --base-url https://jtalk22.github.io/slack-mcp-server --retries 12 --retry-delay-ms 10000
+        run: >-
+          node scripts/browser-smoke.js --mode live
+          --base-url https://jtalk22.github.io/slack-mcp-server
+          --retries ${{ github.event_name == 'release' && '30' || '12' }}
+          --retry-delay-ms 10000
+          ${{ github.event_name == 'release' && '--strict-version' || '' }}

--- a/index.html
+++ b/index.html
@@ -449,8 +449,13 @@
         .then((data) => {
           cloudHealthEl.textContent = data.status || 'ok';
           const hostedVersion = data.version ? `v${data.version}` : 'version unavailable';
-          const standardTools = data.tools && typeof data.tools.standard === 'number' ? data.tools.standard : 'Unavailable';
-          const aiTools = data.tools && typeof data.tools.ai_compound === 'number' ? data.tools.ai_compound : 'Unavailable';
+          // Hosted /status emits tools:{free,paid,total} (v5 shape); accept the
+          // legacy {standard,ai_compound} keys too so neither side can strand the tile.
+          const toolCounts = data.tools || {};
+          const standardTools = typeof toolCounts.free === 'number' ? toolCounts.free
+            : (typeof toolCounts.standard === 'number' ? toolCounts.standard : 'Unavailable');
+          const aiTools = typeof toolCounts.paid === 'number' ? toolCounts.paid
+            : (typeof toolCounts.ai_compound === 'number' ? toolCounts.ai_compound : 'Unavailable');
           const remoteDocsUrl = data.docs && typeof data.docs.docs_url === 'string' ? data.docs.docs_url : '';
           const docsUrl = remoteDocsUrl.startsWith('https://') ? remoteDocsUrl : 'https://mcp.revasserlabs.com/docs';
           // Remote /status fields are untrusted input: build the note from

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -21,7 +21,7 @@ import {
   ALLOWED_WORKFLOW_KINDS_LIST,
 } from "./workflow-store.js";
 import { withRichMessageFields } from "./rich-message-fields.js";
-import { isAuthDeath, buildLifeboatPayload } from "./lifeboat.js";
+import { isAuthDeath, lifeboatResponse } from "./lifeboat.js";
 
 // ============ Utilities ============
 
@@ -172,8 +172,9 @@ export async function handleHealthCheck() {
   } catch (e) {
     // OAuth Lifeboat: a dead session token here is the most common first
     // signal of token death — hand back recovery guidance, not a bare error.
+    // lifeboatResponse keeps the shape identical across all three call sites.
     if (isAuthDeath(e)) {
-      return asMcpJson(buildLifeboatPayload(e), true);
+      return lifeboatResponse(e);
     }
     return asMcpJson({
       status: "error",

--- a/lib/lifeboat.js
+++ b/lib/lifeboat.js
@@ -63,10 +63,10 @@ export function authDeathCode(err) {
   }
 
   const slackCode =
-    typeof err.slack_error === "string" ? err.slack_error.trim().toLowerCase() : null;
+    typeof err?.slack_error === "string" ? err.slack_error.trim().toLowerCase() : null;
   if (slackCode && AUTH_DEATH_SLACK_CODES.has(slackCode)) return slackCode;
 
-  const msg = typeof err.message === "string" ? err.message.trim().toLowerCase() : "";
+  const msg = typeof err?.message === "string" ? err.message.trim().toLowerCase() : "";
   if (AUTH_DEATH_SLACK_CODES.has(msg)) return msg;
   for (const code of AUTH_DEATH_SLACK_CODES) {
     if (msg.includes(code)) return code;
@@ -93,9 +93,9 @@ export function isAuthDeath(err) {
     const s = err.trim().toLowerCase();
     return s === "401" || s.includes("http 401") || s.includes("status 401");
   }
-  const status = err.status ?? err.statusCode ?? err.httpStatus ?? null;
+  const status = typeof err === "number" ? err : (err?.status ?? err?.statusCode ?? err?.httpStatus ?? null);
   if (status === 401) return true;
-  const msg = typeof err.message === "string" ? err.message.toLowerCase() : "";
+  const msg = typeof err?.message === "string" ? err.message.toLowerCase() : "";
   return msg.includes("http 401") || msg.includes("status 401");
 }
 
@@ -105,7 +105,7 @@ export function isAuthDeath(err) {
  * return the one-line form. Honors SLACK_MCP_NO_UPSELL.
  */
 export function buildLifeboatPayload(err, options = {}) {
-  const now = options.now ?? Date.now();
+  const now = options?.now ?? Date.now();
   const slackError = authDeathCode(err);
   const upsell = upsellEnabled();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -645,9 +645,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@jtalk22/slack-mcp",
   "mcpName": "io.github.jtalk22/slack-mcp-server",
   "version": "4.4.3",
-  "description": "Slack MCP without OAuth — 21 tools, session-based, local-first. Free OSS + hosted tier from $19/mo.",
+  "description": "Slack MCP without OAuth \u2014 21 tools, session-based, local-first. Free OSS + hosted tier from $19/mo.",
   "type": "module",
   "main": "src/server.js",
   "bin": {
@@ -115,5 +115,8 @@
   ],
   "devDependencies": {
     "playwright": "^1.57.0"
+  },
+  "overrides": {
+    "ip-address": "^10.1.1"
   }
 }

--- a/scripts/browser-smoke.js
+++ b/scripts/browser-smoke.js
@@ -24,6 +24,18 @@ const liveBaseUrl = argValue("--base-url", "https://jtalk22.github.io/slack-mcp-
 const retries = Number(argValue("--retries", mode === "live" ? "8" : "1"));
 const retryDelayMs = Number(argValue("--retry-delay-ms", "10000"));
 
+// Two distinct invariants, two modes (the old single assertion conflated them and
+// went red on every version-bump merge during the normal merge→release window):
+//   default (push-to-main) — DEPLOYMENT INTEGRITY: the page must render what its
+//     upstream sources (GitHub releases API, npm registry) actually say right now.
+//     package.json being ahead of the latest release is the expected pre-release
+//     state, logged, never failed.
+//   --strict-version (release-published) — SURFACE CONVERGENCE: releases API, npm,
+//     and the page must all agree on RELEASE_VERSION. Upstreams are re-resolved on
+//     every retry so npm-publish propagation is covered by the retry budget.
+const strictVersion = process.argv.includes("--strict-version");
+const expectTagOverride = argValue("--expect-tag", null);
+
 const MIME_TYPES = {
   ".css": "text/css; charset=utf-8",
   ".gif": "image/gif",
@@ -37,14 +49,18 @@ const MIME_TYPES = {
 };
 
 function statusFixture() {
+  // Mirrors the LIVE hosted /status contract (buildHostedStatusPayload in the
+  // hosted repo): tools are {free,paid,total}. The old fixture pinned the dead
+  // {standard,ai_compound} shape, which is exactly how the landing-page tile
+  // drifted to "Unavailable managed tools" in production without a red test.
   return {
     status: "ok",
     server: "slack-mcp-hosted",
-    version: "0.6.7-local",
+    version: "5.0.0",
     timestamp: "2026-03-11T00:00:00.000Z",
     tools: {
-      standard: 15,
-      ai_compound: 3,
+      free: 15,
+      paid: 3,
       total: 18,
     },
     docs: {
@@ -160,7 +176,40 @@ function normalizeErrors(errors, { allowHostedStatusFallback = false } = {}) {
   });
 }
 
-async function checkRoot(page, url, { allowHostedStatusFallback = false } = {}) {
+// Resolve what the page's upstream sources say RIGHT NOW (same endpoints the page
+// itself fetches at runtime). Falls back to RELEASE_VERSION when an upstream is
+// unreachable (e.g. anonymous API rate limits on shared runners) so the smoke
+// degrades to the old strict behavior instead of a false failure.
+async function resolveExpectedVersions() {
+  let expectedTag = expectTagOverride;
+  let expectedNpm = null;
+
+  if (!expectedTag) {
+    try {
+      const res = await fetch("https://api.github.com/repos/jtalk22/slack-mcp-server/releases/latest", {
+        headers: { Accept: "application/vnd.github+json", "User-Agent": "browser-smoke" },
+      });
+      if (res.ok) expectedTag = (await res.json()).tag_name || null;
+    } catch {}
+  }
+  try {
+    const res = await fetch("https://registry.npmjs.org/@jtalk22/slack-mcp/latest", {
+      headers: { "User-Agent": "browser-smoke" },
+    });
+    if (res.ok) expectedNpm = `v${(await res.json()).version}` || null;
+  } catch {}
+
+  return {
+    expectedTag: expectedTag || `v${RELEASE_VERSION}`,
+    expectedNpm: expectedNpm || `v${RELEASE_VERSION}`,
+  };
+}
+
+function literalPattern(value) {
+  return new RegExp(`^${value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`);
+}
+
+async function checkRoot(page, url, { allowHostedStatusFallback = false, expectedNpm = `v${RELEASE_VERSION}`, expectedTag = `v${RELEASE_VERSION}` } = {}) {
   await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30000 });
   await page.waitForFunction(() => {
     const npm = document.querySelector("#npmLatest")?.textContent?.trim();
@@ -177,8 +226,8 @@ async function checkRoot(page, url, { allowHostedStatusFallback = false } = {}) 
     decision: document.querySelector(".decision-grid")?.textContent?.trim() || "",
   }));
 
-  assertText(snapshot.npm, new RegExp(`^v${RELEASE_VERSION.replace(/\./g, "\\.")}$`), "#npmLatest");
-  assertText(snapshot.release, new RegExp(`^v${RELEASE_VERSION.replace(/\./g, "\\.")}$`), "#releaseTag");
+  assertText(snapshot.npm, literalPattern(expectedNpm), "#npmLatest");
+  assertText(snapshot.release, literalPattern(expectedTag), "#releaseTag");
   assertText(snapshot.decision, new RegExp(`${PUBLIC_METADATA.selfHostedToolCount} tools and full operator control`, "i"), "decision guide");
 
   if (/^ok$/i.test(snapshot.cloud)) {
@@ -246,10 +295,20 @@ async function runLive() {
       const errors = await collectErrors(page);
 
       try {
+        // Re-resolve upstream truth on every attempt: in strict mode this lets the
+        // retry budget absorb npm-publish / releases-API propagation after a release.
+        const { expectedTag, expectedNpm } = await resolveExpectedVersions();
+        if (strictVersion) {
+          assertText(expectedTag, literalPattern(`v${RELEASE_VERSION}`), "latest release tag (strict convergence)");
+          assertText(expectedNpm, literalPattern(`v${RELEASE_VERSION}`), "npm latest version (strict convergence)");
+        } else if (expectedTag !== `v${RELEASE_VERSION}`) {
+          console.log(`note: package version v${RELEASE_VERSION} is ahead of the latest release ${expectedTag} — expected merge→release window; asserting the page against live upstream truth.`);
+        }
+
         // The public page explicitly supports a raw-status fallback when cross-origin
         // fetches to the hosted site are blocked. GitHub-hosted runners can hit that
         // path even when the public site is rendering correctly for real users.
-        const snapshot = await checkRoot(page, `${liveBaseUrl.replace(/\/$/, "")}/`, { allowHostedStatusFallback: true });
+        const snapshot = await checkRoot(page, `${liveBaseUrl.replace(/\/$/, "")}/`, { allowHostedStatusFallback: true, expectedNpm, expectedTag });
         await checkStaticPage(page, `${liveBaseUrl.replace(/\/$/, "")}/public/share.html`, ".note", /Hosted free tier \(no card\) live/i, "live share note");
         const normalizedErrors = normalizeErrors(errors, { allowHostedStatusFallback: snapshot.cloudState === "fallback" });
         if (normalizedErrors.length > 0) {

--- a/templates/public-pages/index.html.tpl
+++ b/templates/public-pages/index.html.tpl
@@ -435,8 +435,13 @@
         .then((data) => {
           cloudHealthEl.textContent = data.status || 'ok';
           const hostedVersion = data.version ? `v${data.version}` : 'version unavailable';
-          const standardTools = data.tools && typeof data.tools.standard === 'number' ? data.tools.standard : 'Unavailable';
-          const aiTools = data.tools && typeof data.tools.ai_compound === 'number' ? data.tools.ai_compound : 'Unavailable';
+          // Hosted /status emits tools:{free,paid,total} (v5 shape); accept the
+          // legacy {standard,ai_compound} keys too so neither side can strand the tile.
+          const toolCounts = data.tools || {};
+          const standardTools = typeof toolCounts.free === 'number' ? toolCounts.free
+            : (typeof toolCounts.standard === 'number' ? toolCounts.standard : 'Unavailable');
+          const aiTools = typeof toolCounts.paid === 'number' ? toolCounts.paid
+            : (typeof toolCounts.ai_compound === 'number' ? toolCounts.ai_compound : 'Unavailable');
           const remoteDocsUrl = data.docs && typeof data.docs.docs_url === 'string' ? data.docs.docs_url : '';
           const docsUrl = remoteDocsUrl.startsWith('https://') ? remoteDocsUrl : '{{CLOUD_DOCS_URL}}';
           // Remote /status fields are untrusted input: build the note from

--- a/test/lifeboat.test.js
+++ b/test/lifeboat.test.js
@@ -56,7 +56,9 @@ test("HTTP 401 responses are classified as AUTH-DEATH", () => {
   assert.equal(isAuthDeath({ httpStatus: 401 }), true, "httpStatus field");
   assert.equal(isAuthDeath(new Error("Slack API users.info returned non-JSON (HTTP 401): ...")), true, "message");
   assert.equal(isAuthDeath("401"), true, "bare 401 string");
+  assert.equal(isAuthDeath(401), true, "raw 401 number");
   assert.equal(isAuthDeath({ status: 500 }), false, "HTTP 500 is not auth-death");
+  assert.equal(isAuthDeath(500), false, "raw 500 number is not auth-death");
 });
 
 test("authDeathCode extracts the specific Slack code (or null)", () => {


### PR DESCRIPTION
Three follow-ups from the 4.4.3 ship:

1. **Smoke redesign** — the live smoke asserted deployed-page == checked-out package version on every push, guaranteeing red during the normal merge→release window. Now: push runs assert the page renders live upstream truth (releases API + npm, re-resolved per retry); a new `release: published` trigger runs strict all-surfaces convergence with a bigger retry budget for npm propagation.
2. **Review follow-ups on #160** — optional chaining on error property access, raw numeric 401 classified as auth-death (+500 negative), null-safe options, health check unified on `lifeboatResponse`. 21 tests green.
3. **Live defect** — the landing page's cloud-health tile has been rendering 'Unavailable managed tools + Unavailable AI workflows': hosted `/status` moved to `tools:{free,paid,total}` and the tile still read `{standard,ai_compound}`. Reader accepts the v5 shape with legacy fallback; the local smoke fixture now mirrors the LIVE contract (the pinned-dead fixture is why nothing went red).