### PR TITLE
v4.5.0: keychain-only credential storage release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.5.0] - 2026-07-21
+
+### Keychain-Only Credential Storage — zero plaintext on disk, every failure loud
 
 ### Added
 - **Keychain-only credential storage** (`SLACK_MCP_TOKEN_STORAGE=keychain-only`, macOS) — credentials live exclusively in the macOS Keychain and no plaintext token file is ever written (#162). `--setup`, `slack_refresh_tokens`, and automatic refresh work unchanged. An existing `~/.slack-mcp-tokens.json` is migrated into the Keychain on first load and removed only after both entries verify by read-back; a failed migration leaves the file untouched and reports `keychain_migration_failed`, and a verified migration whose file removal fails reports `plaintext_removal_failed` with the exact cleanup command — removal is attempted, never assumed. Keychain writes are verified and fail loudly (`keychain_write_failed`) instead of falling back to plaintext. Non-secret bookkeeping (token timestamp, auto-heal telemetry) moves to `~/.slack-mcp-meta.json` so `slack_token_status` age reporting and stuck-detection keep working.

--- a/glama.json
+++ b/glama.json
@@ -4,7 +4,7 @@
   "description": "Slack MCP without OAuth \u2014 21 tools, session-based, local-first. Free OSS + hosted tier from $19/mo.",
   "repository": "https://github.com/jtalk22/slack-mcp-server",
   "homepage": "https://mcp.revasserlabs.com",
-  "version": "4.4.3",
+  "version": "4.5.0",
   "license": "MIT",
   "maintainers": [
     "jtalk22"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jtalk22/slack-mcp",
-  "version": "4.4.3",
+  "version": "4.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jtalk22/slack-mcp",
-      "version": "4.4.3",
+      "version": "4.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jtalk22/slack-mcp",
   "mcpName": "io.github.jtalk22/slack-mcp-server",
-  "version": "4.4.3",
+  "version": "4.5.0",
   "description": "Slack MCP without OAuth \u2014 21 tools, session-based, local-first. Free OSS + hosted tier from $19/mo.",
   "type": "module",
   "main": "src/server.js",

--- a/server.json
+++ b/server.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/jtalk22/slack-mcp-server",
     "source": "github"
   },
-  "version": "4.4.3",
+  "version": "4.5.0",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
     {
       "registryType": "npm",
       "identifier": "@jtalk22/slack-mcp",
-      "version": "4.4.3",
+      "version": "4.5.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Version bump (package.json, package-lock.json, server.json, glama.json) + CHANGELOG entry for the keychain-only storage feature merged in #163 (closes #162).

Release notes summary:
- Keychain-only credential storage (SLACK_MCP_TOKEN_STORAGE=keychain-only, macOS): zero plaintext credentials on disk, verified writes, migrate-then-remove with loud structured failures
- file mode: token file only, Keychain never touched
- Setup wizard storage prompt with persisted choice
- In-memory fallback for failed persists; honest auto-heal telemetry
- Cross-process write lock for token file + metadata sidecar
- slack_token_status storage block; hardened tokens:clear / tokens:status
- Storage-modes diagram + accurate docs

44 tests green; all public-surface verifiers pass.