### PR TITLE
v4.6.0: workspace profiles + Chrome extraction overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.6.0] - 2026-07-22
+
+### Workspace Profiles + Chrome Extraction Overhaul
+
+Two community-driven improvements: run work and personal Slack side-by-side, and extraction that tells you why it failed.
+
+### Added
+- **Workspace profiles** (`SLACK_MCP_PROFILE=work`, or `--profile work` on any CLI command) — every storage surface (token file, metadata sidecar, write lock, Keychain service) gets its own namespace, so multiple MCP server instances (work + personal) run side-by-side without sharing or overwriting each other's credentials (#164, requested by @iloveitaly). Pair with `SLACK_MCP_CHROME_PROFILE` to point each profile's extraction at the matching Chrome profile. Invalid profile names fail closed at startup. `slack_token_status` reports the active namespace under `storage.profile`; `--doctor` and `tokens:status` print it.
+- **`SLACK_MCP_KEYCHAIN_TIMEOUT_MS`** — configurable timeout for the Chrome Safe Storage Keychain lookup (default 15000, up from a hard 5000 that real-world Keychains were observed to exceed at 4.9s).
+- Chrome-extraction test rig (`test/chrome-extraction.test.js`) — builds a synthetic Chrome estate (real SQLite cookie DB with a genuine v10 AES-128-CBC-encrypted cookie, real LevelDB-style token log) and drives the actual extraction pipeline with only the Keychain lookup faked. Extraction was previously untestable without a live Chrome.
+
+### Fixed
+- **Chrome Safe Storage key looked up once per process, not once per profile per path** (#168) — the key is per-machine; it is now cached (refreshed once if a decrypt fails, in case Chrome re-keyed), and a fatal Keychain failure (timeout, denied) aborts the run instead of re-prompting for every profile and again in the AppleScript fallback.
+- **Extraction failures name their cause** (#168) — every cookie-extraction failure carries a machine-usable reason (`no_cookie_db`, `no_slack_cookie_row`, `keychain_timeout`, `keychain_lookup_failed`, `cookie_decrypt_failed`, `unsupported_cookie_format`, …) and the final error lists per-profile reasons instead of collapsing everything into `extraction_failed_all_paths`.
+- **AppleScript token read runs once per extraction, not once per profile** — it talks to the running Chrome app, not a profile directory, so repeating it per profile only multiplied prompts and wall-clock.
+
 ## [4.5.0] - 2026-07-21
 
 ### Keychain-Only Credential Storage — zero plaintext on disk, every failure loud

--- a/README.md
+++ b/README.md
@@ -130,6 +130,21 @@ args = ["-y", "@jtalk22/slack-mcp"]
 Or via CLI: `codex mcp add slack -- npx -y @jtalk22/slack-mcp`
 </details>
 
+## Multiple Workspaces
+
+Run work and personal Slack side-by-side — each server instance gets its own credential namespace (token file, Keychain entries, metadata), so setup or refresh in one never touches the other:
+
+```json
+{
+  "mcpServers": {
+    "slack-work":     { "command": "npx", "args": ["-y", "@jtalk22/slack-mcp"], "env": { "SLACK_MCP_PROFILE": "work" } },
+    "slack-personal": { "command": "npx", "args": ["-y", "@jtalk22/slack-mcp"], "env": { "SLACK_MCP_PROFILE": "personal" } }
+  }
+}
+```
+
+Set each profile up once: `npx -y @jtalk22/slack-mcp --setup --profile work`. If the workspaces live in different Chrome profiles, add `SLACK_MCP_CHROME_PROFILE` to point each one's extraction at the right browser profile. Invalid profile names fail closed at startup — same discipline as every other credential setting here.
+
 ## Tools
 
 | Tool | Description | Safety |
@@ -311,6 +326,8 @@ Session tokens (`xoxc-` + `xoxd-`) from your browser. If you can see it in Slack
 4. Chrome auto-extraction (macOS)
 
 Tokens expire. The server notices before you do — proactive health monitoring, automatic refresh on macOS, warnings when tokens age out. File writes are atomic (temp file → chmod → rename) to prevent corruption. Concurrent refresh attempts are mutex-locked.
+
+Chrome extraction is built to diagnose itself: every failure names its cause (`keychain_timeout`, `no_slack_cookie_row`, `cookie_decrypt_failed`, …) per profile instead of a generic error, the Safe Storage key is looked up once per run and cached (no Keychain prompt storms), and the lookup timeout is configurable via `SLACK_MCP_KEYCHAIN_TIMEOUT_MS` for slow Keychains.
 
 **Storage backend** — on macOS, `--setup` asks where credentials should live and remembers the answer; every process (server, CLI, LaunchAgent) follows the same choice. `SLACK_MCP_TOKEN_STORAGE` overrides it when set:
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -146,6 +146,21 @@ Two things to know:
 
 `SLACK_MCP_TOKEN_STORAGE=file` is the third mode: token file only, Keychain never touched (no Keychain prompts — useful on shared machines and in CI).
 
+### Optional: Multiple Workspaces (Profiles)
+
+Set `SLACK_MCP_PROFILE=<name>` (or pass `--profile <name>` to any CLI command) to give a server instance its own credential namespace — `~/.slack-mcp-tokens-<name>.json`, `~/.slack-mcp-meta-<name>.json`, and a per-profile Keychain service. Two MCP client entries with different profiles run side-by-side without sharing or overwriting each other's tokens:
+
+```json
+{
+  "mcpServers": {
+    "slack-work":     { "command": "npx", "args": ["-y", "@jtalk22/slack-mcp"], "env": { "SLACK_MCP_PROFILE": "work" } },
+    "slack-personal": { "command": "npx", "args": ["-y", "@jtalk22/slack-mcp"], "env": { "SLACK_MCP_PROFILE": "personal" } }
+  }
+}
+```
+
+Run `--setup --profile work` once per profile. If each workspace lives in a different Chrome profile, also set `SLACK_MCP_CHROME_PROFILE` per entry so extraction reads the right browser profile. Profile names are 1-32 characters (letters, digits, `-`, `_`); anything else fails at startup rather than silently writing to the default namespace.
+
 ### 6. Restart Claude
 
 The Slack tools will now be available in both Claude Desktop and Claude Code.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -254,6 +254,19 @@ tail -50 ~/Library/Logs/Claude/mcp-server-slack.log
 **Check permissions:**
 System Preferences → Privacy & Security → Accessibility → Ensure Terminal is enabled
 
+**Read the reason code.** Extraction errors name their cause per Chrome profile — the `detail` field of the error tells you which of these you're in:
+
+| Reason | Meaning | Fix |
+|--------|---------|-----|
+| `keychain_timeout` | The Chrome Safe Storage key lookup exceeded the timeout | Unlock the Keychain; retry; raise `SLACK_MCP_KEYCHAIN_TIMEOUT_MS` (default 15000) |
+| `keychain_lookup_failed` | Keychain refused the Safe Storage key | Unlock the Keychain; allow this terminal Keychain access |
+| `no_cookie_db` | Profile has no Cookies database | Point `SLACK_MCP_CHROME_USER_DATA_DIR` / `SLACK_MCP_CHROME_PROFILE` at the right Chrome |
+| `no_slack_cookie_row` | No Slack `d` cookie in that profile | Log into app.slack.com in that Chrome profile |
+| `cookie_decrypt_failed` | Cookie wouldn't decrypt with the Safe Storage key | Chrome may have re-keyed — restart Chrome, sign into Slack again, retry |
+| `cookie ok, no cached xoxc token in LevelDB` | Cookie found but no cached token on disk | Open Slack in Chrome once so the token gets cached, or use AppleScript mode |
+
+The Safe Storage key is looked up once per run and cached, so a failing Keychain produces one clear error — not a password prompt per profile.
+
 ---
 
 ## Why Browser Tokens Instead of Slack App?

--- a/glama.json
+++ b/glama.json
@@ -4,7 +4,7 @@
   "description": "Slack MCP without OAuth \u2014 21 tools, session-based, local-first. Free OSS + hosted tier from $19/mo.",
   "repository": "https://github.com/jtalk22/slack-mcp-server",
   "homepage": "https://mcp.revasserlabs.com",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "license": "MIT",
   "maintainers": [
     "jtalk22"

--- a/lib/token-store.js
+++ b/lib/token-store.js
@@ -25,9 +25,35 @@ import { join } from "path";
 import { execFileSync } from "child_process";
 import { pbkdf2Sync, createDecipheriv } from "crypto";
 
-const TOKEN_FILE = join(homedir(), ".slack-mcp-tokens.json");
-const META_FILE = join(homedir(), ".slack-mcp-meta.json");
-const KEYCHAIN_SERVICE = "slack-mcp-server";
+/**
+ * Optional workspace/profile namespace (#164): SLACK_MCP_PROFILE=work (or
+ * `--profile work` on the CLI) gives every storage surface — token file,
+ * metadata sidecar, write lock, Keychain service — its own namespace, so
+ * multiple server instances (work + personal) run side-by-side without
+ * sharing or overwriting each other's credentials. Fail-closed like the
+ * storage mode: an invalid profile name dies at startup rather than silently
+ * writing to the default namespace.
+ */
+function resolveProfile() {
+  const raw = (process.env.SLACK_MCP_PROFILE || "").trim().toLowerCase();
+  if (!raw) return "";
+  if (!/^[a-z0-9][a-z0-9_-]{0,31}$/.test(raw)) {
+    const err = new Error(
+      `Invalid SLACK_MCP_PROFILE "${raw}". Use 1-32 characters: letters, digits, "-", "_" (must start alphanumeric). ` +
+      "Refusing to guess for a credential-storage namespace."
+    );
+    err.code = "invalid_profile";
+    throw err;
+  }
+  return raw;
+}
+
+const ACTIVE_PROFILE = resolveProfile();
+const PROFILE_SUFFIX = ACTIVE_PROFILE ? `-${ACTIVE_PROFILE}` : "";
+
+const TOKEN_FILE = join(homedir(), `.slack-mcp-tokens${PROFILE_SUFFIX}.json`);
+const META_FILE = join(homedir(), `.slack-mcp-meta${PROFILE_SUFFIX}.json`);
+const KEYCHAIN_SERVICE = `slack-mcp-server${PROFILE_SUFFIX}`;
 
 // Platform detection
 const IS_MACOS = platform() === 'darwin';
@@ -249,7 +275,7 @@ function saveMeta(patch) {
 
 // ============ Cross-process write lock ============
 
-const WRITE_LOCK_FILE = join(homedir(), ".slack-mcp-write.lock");
+const WRITE_LOCK_FILE = join(homedir(), `.slack-mcp-write${PROFILE_SUFFIX}.lock`);
 const WRITE_LOCK_STALE_MS = 10_000;
 const WRITE_LOCK_WAIT_MS = 2_000;
 
@@ -489,16 +515,59 @@ function normalizeExtractionError(error) {
   };
 }
 
+// ============ Chrome Safe Storage key (#168) ============
+
+/**
+ * The Chrome Safe Storage password is per-MACHINE, not per-profile, and the
+ * Keychain lookup for it can be slow (observed 4.9s against a 5s timeout) and
+ * can prompt. It is therefore looked up at most once per process and cached —
+ * one extraction run does one lookup total instead of one per profile per
+ * path. The cache is refreshed once if a decrypt fails (Chrome re-keyed).
+ */
+const systemSafeStorageAdapter = {
+  getKey(timeoutMs) {
+    return execFileSync('security', [
+      'find-generic-password', '-s', 'Chrome Safe Storage', '-w'
+    ], { encoding: 'utf-8', timeout: timeoutMs }).trim();
+  }
+};
+
+let safeStorageAdapter = systemSafeStorageAdapter;
+let safeStorageKeyCache = null;
+
+/** Test seam: swap the Safe Storage lookup; pass null to restore. */
+export function _setSafeStorageAdapterForTests(adapter) {
+  safeStorageAdapter = adapter || systemSafeStorageAdapter;
+  safeStorageKeyCache = null;
+}
+
+function safeStorageTimeoutMs() {
+  const raw = Number(process.env.SLACK_MCP_KEYCHAIN_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 15000;
+}
+
+function getSafeStorageKey({ forceRefresh = false } = {}) {
+  if (!forceRefresh && safeStorageKeyCache) return safeStorageKeyCache.password;
+  const password = safeStorageAdapter.getKey(safeStorageTimeoutMs());
+  safeStorageKeyCache = { password };
+  return password;
+}
+
+function isTimeoutError(e) {
+  return Boolean(e?.killed) || /ETIMEDOUT|timed? ?out/i.test(String(e?.message || e));
+}
+
 /**
  * Extract the Slack `d` cookie from a specific Chrome profile's cookie DB.
- * Returns the decrypted xoxd- cookie string or null if this profile has no
- * Slack session or decryption fails.
+ * Returns { cookie, reason }: the decrypted xoxd- string, or a machine-usable
+ * failure reason — every failure path names its cause instead of collapsing
+ * to null, so extraction errors can finally say WHY (#168).
  *
  * Chrome holds a WAL lock on the live DB; we copy-then-query for safety.
  */
 function extractCookieForProfile(profileDir) {
   const cookiesPath = join(profileDir, 'Cookies');
-  if (!existsSync(cookiesPath)) return null;
+  if (!existsSync(cookiesPath)) return { cookie: null, reason: 'no_cookie_db' };
 
   const tmpDir = mkdtempSync(join(tmpdir(), 'slack-mcp-'));
   const tmpDb = join(tmpDir, 'Cookies');
@@ -514,58 +583,101 @@ function extractCookieForProfile(profileDir) {
       }
     }
 
-    const queryResult = execFileSync('sqlite3', [
-      tmpDb,
-      "SELECT hex(encrypted_value) FROM cookies WHERE host_key LIKE '%.slack.com%' AND name = 'd' LIMIT 1;"
-    ], { encoding: 'utf-8', timeout: 5000 }).trim();
+    let queryResult;
+    try {
+      queryResult = execFileSync('sqlite3', [
+        tmpDb,
+        "SELECT hex(encrypted_value) FROM cookies WHERE host_key LIKE '%.slack.com%' AND name = 'd' LIMIT 1;"
+      ], { encoding: 'utf-8', timeout: 5000 }).trim();
+    } catch (e) {
+      return { cookie: null, reason: isTimeoutError(e) ? 'cookie_query_timeout' : 'cookie_query_failed' };
+    }
 
-    try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
-
-    if (!queryResult) return null;
+    if (!queryResult) return { cookie: null, reason: 'no_slack_cookie_row' };
 
     const encrypted = Buffer.from(queryResult, 'hex');
-    if (encrypted.length < 4) return null;
+    if (encrypted.length < 4) return { cookie: null, reason: 'cookie_value_malformed' };
 
-    // Chrome Safe Storage password (per-machine, stored in macOS Keychain)
-    const safeStoragePassword = execFileSync('security', [
-      'find-generic-password', '-s', 'Chrome Safe Storage', '-w'
-    ], { encoding: 'utf-8', timeout: 5000 }).trim();
+    let safeStoragePassword;
+    try {
+      safeStoragePassword = getSafeStorageKey();
+    } catch (e) {
+      return { cookie: null, reason: isTimeoutError(e) ? 'keychain_timeout' : 'keychain_lookup_failed' };
+    }
 
     // macOS Chrome cookies: v10 prefix + AES-128-CBC
     const prefix = encrypted.subarray(0, 3).toString('utf-8');
-    if (prefix !== 'v10') return null;
+    if (prefix !== 'v10') return { cookie: null, reason: 'unsupported_cookie_format' };
 
     const ciphertext = encrypted.subarray(3);
-    const key = pbkdf2Sync(safeStoragePassword, 'saltysalt', 1003, 16, 'sha1');
-    const iv = Buffer.alloc(16, ' ');
+    const decryptWith = (password) => {
+      try {
+        const key = pbkdf2Sync(password, 'saltysalt', 1003, 16, 'sha1');
+        const decipher = createDecipheriv('aes-128-cbc', key, Buffer.alloc(16, ' '));
+        return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf-8');
+      } catch {
+        return null;
+      }
+    };
 
-    const decipher = createDecipheriv('aes-128-cbc', key, iv);
-    let decrypted;
-    try {
-      decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
-    } catch {
-      return null;
+    let text = decryptWith(safeStoragePassword);
+    if (text === null) {
+      // Chrome may have re-keyed since the password was cached — refetch once.
+      try {
+        text = decryptWith(getSafeStorageKey({ forceRefresh: true }));
+      } catch {
+        text = null;
+      }
+      if (text === null) return { cookie: null, reason: 'cookie_decrypt_failed' };
     }
 
-    const text = decrypted.toString('utf-8');
     const xoxdIndex = text.indexOf('xoxd-');
-    if (xoxdIndex < 0) return null;
-    return text.substring(xoxdIndex);
-  } catch {
+    if (xoxdIndex < 0) return { cookie: null, reason: 'no_xoxd_in_cookie' };
+    return { cookie: text.substring(xoxdIndex), reason: null };
+  } catch (e) {
+    return { cookie: null, reason: 'cookie_extraction_failed' };
+  } finally {
     try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
-    return null;
   }
 }
 
 /**
- * Legacy helper: walk CHROME_PROFILES and return the first cookie found.
+ * Test seam: the profile-level extractor has no platform gate (unlike the
+ * full pipeline), so its failure taxonomy and Safe Storage caching are
+ * testable on any OS with sqlite3 present.
+ */
+export function _extractCookieForProfileForTests(profileDir) {
+  return extractCookieForProfile(profileDir);
+}
+
+// A dead Keychain affects every profile identically — stop the run instead of
+// hammering the (possibly prompting) lookup once per profile per path.
+const FATAL_COOKIE_REASONS = new Set(['keychain_timeout', 'keychain_lookup_failed']);
+
+function fatalKeychainError(reason) {
+  return reason === 'keychain_timeout'
+    ? {
+        code: 'keychain_timeout',
+        message: 'The Chrome Safe Storage key lookup timed out.',
+        detail: `The macOS Keychain took longer than ${safeStorageTimeoutMs()}ms to return Chrome's encryption key. Retry, unlock the Keychain, or raise SLACK_MCP_KEYCHAIN_TIMEOUT_MS.`
+      }
+    : {
+        code: 'keychain_lookup_failed',
+        message: "Could not read Chrome's Safe Storage key from the Keychain.",
+        detail: 'Unlock the macOS Keychain and allow this terminal Keychain access (System Settings > Privacy & Security), then retry.'
+      };
+}
+
+/**
+ * Legacy helper: walk profiles and return the first cookie found.
  * Retained so existing callers that only want a cookie string keep working.
  */
 function extractCookieFromChromeDB() {
   const base = getChromeBase();
   for (const profile of enumerateChromeProfiles()) {
-    const cookie = extractCookieForProfile(join(base, profile));
+    const { cookie, reason } = extractCookieForProfile(join(base, profile));
     if (cookie) return cookie;
+    if (FATAL_COOKIE_REASONS.has(reason)) return null;
   }
   return null;
 }
@@ -708,14 +820,28 @@ function extractFromChromeInternal() {
     return null;
   }
 
+  // Per-profile failure reasons, so the final error can say WHY instead of
+  // collapsing everything into a generic all-paths failure (#168).
+  const profileReasons = [];
+
   // --- Path 1: LevelDB (no AppleScript, no live tab needed) ---
   if (mode === 'leveldb' || mode === 'auto') {
     for (const profileName of profiles) {
       const profileDir = join(base, profileName);
-      const cookie = extractCookieForProfile(profileDir);
-      if (!cookie) continue;
+      const { cookie, reason } = extractCookieForProfile(profileDir);
+      if (!cookie) {
+        if (FATAL_COOKIE_REASONS.has(reason)) {
+          lastExtractionError = fatalKeychainError(reason);
+          return null;
+        }
+        profileReasons.push(`${profileName}: ${reason}`);
+        continue;
+      }
       const token = extractTokenFromLevelDB(profileDir);
-      if (!token) continue;
+      if (!token) {
+        profileReasons.push(`${profileName}: cookie ok, no cached xoxc token in LevelDB`);
+        continue;
+      }
       return { token, cookie, profile: profileName, extraction_mode: 'leveldb' };
     }
 
@@ -723,7 +849,7 @@ function extractFromChromeInternal() {
       lastExtractionError = {
         code: "leveldb_no_matching_profile",
         message: "No Chrome profile had both a Slack cookie and a cached xoxc- token on disk.",
-        detail: `Profiles checked: ${profiles.join(', ')}. Open Slack in Chrome and sign in once, then retry. SLACK_MCP_CHROME_PROFILE can pin a specific profile.`
+        detail: `Per-profile: ${profileReasons.join('; ') || 'none checked'}. Open Slack in Chrome and sign in once, then retry. SLACK_MCP_CHROME_PROFILE can pin a specific profile.`
       };
       return null;
     }
@@ -732,31 +858,42 @@ function extractFromChromeInternal() {
 
   // --- Path 2: AppleScript + SQLite (legacy, requires live tab + dev flag) ---
   if (mode === 'applescript' || mode === 'auto') {
+    // The AppleScript token read talks to the running Chrome app, not to a
+    // profile directory — one attempt covers every profile. Find the first
+    // profile with a cookie, then run the (slow, possibly prompting)
+    // AppleScript exactly once instead of once per profile (#168).
     let cookieSeen = null;
     for (const profileName of profiles) {
       const profileDir = join(base, profileName);
-      const cookie = extractCookieForProfile(profileDir);
-      if (!cookie) continue;
-      cookieSeen = cookie;
+      const { cookie, reason } = extractCookieForProfile(profileDir);
+      if (cookie) {
+        cookieSeen = { cookie, profileName };
+        break;
+      }
+      if (FATAL_COOKIE_REASONS.has(reason)) {
+        lastExtractionError = fatalKeychainError(reason);
+        return null;
+      }
+      if (mode === 'applescript') profileReasons.push(`${profileName}: ${reason}`);
+    }
 
-      let token;
+    if (cookieSeen) {
+      let token = null;
       try {
         token = extractTokenFromChrome();
       } catch (e) {
         lastExtractionError = normalizeExtractionError(e);
-        continue;
       }
       if (token) {
-        return { token, cookie, profile: profileName, extraction_mode: 'applescript' };
+        return { token, cookie: cookieSeen.cookie, profile: cookieSeen.profileName, extraction_mode: 'applescript' };
       }
-    }
-
-    if (cookieSeen && !lastExtractionError) {
-      lastExtractionError = {
-        code: "apple_events_javascript_disabled",
-        message: "Cookie extracted, but AppleScript could not read the Slack token from localStorage.",
-        detail: "Enable Chrome > View > Developer > Allow JavaScript from Apple Events, then retry. Or set SLACK_MCP_EXTRACTION_MODE=leveldb to skip AppleScript entirely."
-      };
+      if (!lastExtractionError) {
+        lastExtractionError = {
+          code: "apple_events_javascript_disabled",
+          message: "Cookie extracted, but AppleScript could not read the Slack token from localStorage.",
+          detail: "Enable Chrome > View > Developer > Allow JavaScript from Apple Events, then retry. Or set SLACK_MCP_EXTRACTION_MODE=leveldb to skip AppleScript entirely."
+        };
+      }
       return null;
     }
   }
@@ -765,7 +902,7 @@ function extractFromChromeInternal() {
     lastExtractionError = {
       code: "extraction_failed_all_paths",
       message: "Could not extract Slack credentials via LevelDB or AppleScript.",
-      detail: `Profiles checked: ${profiles.join(', ')}. Ensure you are logged into Slack at app.slack.com in Chrome at least once.`
+      detail: `Per-profile: ${profileReasons.join('; ') || `profiles checked: ${profiles.join(', ')}`}. Ensure you are logged into Slack at app.slack.com in Chrome at least once.`
     };
   }
   return null;
@@ -896,6 +1033,8 @@ export function getStorageInfo() {
   return {
     mode,
     mode_source: source,
+    // Workspace/profile namespace (#164); null = the default namespace.
+    profile: ACTIVE_PROFILE || null,
     keychain_available: keychain.available(),
     plaintext_file_present: existsSync(TOKEN_FILE),
     // True while this process is serving freshly extracted tokens that could
@@ -1060,4 +1199,4 @@ export function saveTokens(token, cookie) {
   }
 }
 
-export { TOKEN_FILE, META_FILE, KEYCHAIN_SERVICE };
+export { TOKEN_FILE, META_FILE, KEYCHAIN_SERVICE, ACTIVE_PROFILE };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jtalk22/slack-mcp",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jtalk22/slack-mcp",
-      "version": "4.5.0",
+      "version": "4.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jtalk22/slack-mcp",
   "mcpName": "io.github.jtalk22/slack-mcp-server",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "description": "Slack MCP without OAuth \u2014 21 tools, session-based, local-first. Free OSS + hosted tier from $19/mo.",
   "type": "module",
   "main": "src/server.js",

--- a/scripts/setup-wizard.js
+++ b/scripts/setup-wizard.js
@@ -23,6 +23,7 @@ import {
   getStorageMode,
   getStorageModeDetail,
   setPersistedStorageMode,
+  ACTIVE_PROFILE,
 } from "../lib/token-store.js";
 import { RELEASE_VERSION } from "../lib/public-metadata.js";
 
@@ -548,6 +549,9 @@ async function runDoctor() {
       ? 'chosen during setup'
       : 'default';
   print(`Storage mode: ${storageDetail.mode} (${sourceLabel})`);
+  if (ACTIVE_PROFILE) {
+    print(`Profile: ${ACTIVE_PROFILE}`);
+  }
   if (isKeychainOnly() && creds.pendingMigration) {
     warn(`Plaintext token file still present at ${TOKEN_FILE} — it will be migrated into the Keychain and removed on the next server start or token refresh.`);
   }
@@ -593,6 +597,11 @@ async function showHelp() {
   print("  npx -y @jtalk22/slack-mcp --doctor    Run runtime and auth diagnostics");
   print("  npx -y @jtalk22/slack-mcp --version   Print version");
   print("  npx -y @jtalk22/slack-mcp --help      Show this help");
+  print();
+  print(`${colors.bold}Multiple workspaces:${colors.reset}`);
+  print("  Add --profile <name> to any command (or set SLACK_MCP_PROFILE) to");
+  print("  keep credentials in a separate namespace per workspace — e.g.");
+  print("  --setup --profile work, then a second server with --profile personal.");
   print();
   print(`${colors.bold}npm scripts:${colors.reset}`);
   print("  npm start              Start MCP server");

--- a/scripts/token-cli.js
+++ b/scripts/token-cli.js
@@ -41,7 +41,8 @@ function storageModeLine() {
     : storage.mode_source === "persisted"
       ? "chosen during setup"
       : "default";
-  return { storage, line: `${storage.mode} (${sourceLabel})` };
+  const profileSuffix = storage.profile ? ` · profile: ${storage.profile}` : "";
+  return { storage, line: `${storage.mode} (${sourceLabel})${profileSuffix}` };
 }
 
 async function showStatus() {

--- a/server.json
+++ b/server.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/jtalk22/slack-mcp-server",
     "source": "github"
   },
-  "version": "4.5.0",
+  "version": "4.6.0",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
     {
       "registryType": "npm",
       "identifier": "@jtalk22/slack-mcp",
-      "version": "4.5.0",
+      "version": "4.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/cli.js
+++ b/src/cli.js
@@ -14,7 +14,27 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const args = process.argv.slice(2);
+const rawArgs = process.argv.slice(2);
+
+// `--profile <name>` / `--profile=<name>` anywhere on the command line maps
+// to SLACK_MCP_PROFILE for the child (#164), so every mode — server, wizard,
+// web, http, token refresh — honors the same workspace namespace.
+const args = [];
+let cliProfile = null;
+for (let i = 0; i < rawArgs.length; i++) {
+  const arg = rawArgs[i];
+  if (arg === "--profile") {
+    cliProfile = rawArgs[++i] ?? "";
+  } else if (arg.startsWith("--profile=")) {
+    cliProfile = arg.slice("--profile=".length);
+  } else {
+    args.push(arg);
+  }
+}
+const childEnv = cliProfile !== null
+  ? { ...process.env, SLACK_MCP_PROFILE: cliProfile }
+  : process.env;
+
 const firstArg = args[0];
 
 const WIZARD_ARGS = new Set([
@@ -47,7 +67,7 @@ if (firstArg === "web") {
 
 const child = spawn(process.execPath, [scriptPath, ...scriptArgs], {
   stdio: "inherit",
-  env: process.env,
+  env: childEnv,
 });
 
 child.on("error", (error) => {

--- a/test/chrome-extraction.test.js
+++ b/test/chrome-extraction.test.js
@@ -1,0 +1,190 @@
+import { test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir, platform } from "node:os";
+import { join } from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { pbkdf2Sync, createCipheriv } from "node:crypto";
+
+// Chrome credential extraction was untestable before #168: every failure
+// collapsed to null and the pipeline needed a real Chrome install. This rig
+// builds a synthetic Chrome estate — a REAL SQLite cookie DB holding a
+// genuine v10 AES-128-CBC-encrypted cookie, and a REAL LevelDB-style log with
+// a cached xoxc token — and drives the actual extraction code with only the
+// Safe Storage Keychain lookup faked. It proves the #168 fixes: one Keychain
+// lookup per run (not per profile), fatal Keychain failures abort instead of
+// prompt-storming, and every failure names its cause.
+
+const SANDBOX = mkdtempSync(join(tmpdir(), "slack-mcp-chrome-test-"));
+process.env.HOME = SANDBOX;
+process.env.USERPROFILE = SANDBOX;
+delete process.env.SLACK_TOKEN;
+delete process.env.SLACK_COOKIE;
+
+const {
+  extractFromChrome,
+  getLastExtractionError,
+  _setSafeStorageAdapterForTests,
+  _extractCookieForProfileForTests,
+} = await import("../lib/token-store.js");
+
+const PASSWORD = "test-safe-storage-password";
+const COOKIE_VALUE = "xoxd-e2e-extraction-cookie";
+const CACHED_TOKEN = "xoxc-1111-2222-3333-" + "a".repeat(40);
+
+const HAS_SQLITE = spawnSync("sqlite3", ["--version"], { stdio: "ignore" }).status === 0;
+const IS_MACOS = platform() === "darwin";
+
+function encryptV10(value, password) {
+  const key = pbkdf2Sync(password, "saltysalt", 1003, 16, "sha1");
+  const cipher = createCipheriv("aes-128-cbc", key, Buffer.alloc(16, " "));
+  const ciphertext = Buffer.concat([cipher.update(value, "utf-8"), cipher.final()]);
+  return Buffer.concat([Buffer.from("v10"), ciphertext]);
+}
+
+/** Build a profile dir with a real cookie DB; optionally a LevelDB token log. */
+function buildProfile(base, name, { cookie = true, token = false, password = PASSWORD } = {}) {
+  const dir = join(base, name);
+  mkdirSync(dir, { recursive: true });
+  if (cookie) {
+    const blob = encryptV10(COOKIE_VALUE, password).toString("hex");
+    execFileSync("sqlite3", [join(dir, "Cookies"),
+      "CREATE TABLE cookies (host_key TEXT, name TEXT, encrypted_value BLOB);" +
+      `INSERT INTO cookies VALUES ('.slack.com', 'd', X'${blob}');`
+    ]);
+  }
+  if (token) {
+    const ldb = join(dir, "Local Storage", "leveldb");
+    mkdirSync(ldb, { recursive: true });
+    writeFileSync(join(ldb, "000003.log"), Buffer.from(`junk-prefix ${CACHED_TOKEN} junk-suffix`, "binary"));
+  }
+  return dir;
+}
+
+function fakeSafeStorage({ password = PASSWORD, fail = null } = {}) {
+  return {
+    calls: 0,
+    getKey() {
+      this.calls++;
+      if (fail === "timeout") throw Object.assign(new Error("spawnSync security ETIMEDOUT"), { killed: true });
+      if (fail === "denied") throw new Error("security: SecKeychainSearchCopyNext");
+      return password;
+    },
+  };
+}
+
+function chromeBase() {
+  const base = mkdtempSync(join(tmpdir(), "slack-mcp-chrome-base-"));
+  process.env.SLACK_MCP_CHROME_USER_DATA_DIR = base;
+  return base;
+}
+
+beforeEach(() => {
+  _setSafeStorageAdapterForTests(null);
+  delete process.env.SLACK_MCP_CHROME_USER_DATA_DIR;
+  delete process.env.SLACK_MCP_CHROME_PROFILE;
+  delete process.env.SLACK_MCP_EXTRACTION_MODE;
+  delete process.env.SLACK_MCP_KEYCHAIN_TIMEOUT_MS;
+});
+
+// ---------- profile-level taxonomy (any OS with sqlite3) ----------
+
+test("cookie extraction decrypts a real v10 blob and names every failure cause", { skip: !HAS_SQLITE }, () => {
+  const base = chromeBase();
+  const adapter = fakeSafeStorage();
+  _setSafeStorageAdapterForTests(adapter);
+
+  // Success: real SQLite DB, real AES round-trip.
+  const good = buildProfile(base, "Good");
+  assert.deepEqual(_extractCookieForProfileForTests(good), { cookie: COOKIE_VALUE, reason: null });
+
+  // Missing DB and empty DB name their causes instead of returning bare null.
+  assert.equal(_extractCookieForProfileForTests(join(base, "Missing")).reason, "no_cookie_db");
+  const empty = join(base, "Empty");
+  mkdirSync(empty, { recursive: true });
+  execFileSync("sqlite3", [join(empty, "Cookies"), "CREATE TABLE cookies (host_key TEXT, name TEXT, encrypted_value BLOB);"]);
+  assert.equal(_extractCookieForProfileForTests(empty).reason, "no_slack_cookie_row");
+});
+
+test("the Safe Storage key is looked up once and cached across profiles", { skip: !HAS_SQLITE }, () => {
+  const base = chromeBase();
+  const adapter = fakeSafeStorage();
+  _setSafeStorageAdapterForTests(adapter);
+
+  const a = buildProfile(base, "ProfileA");
+  const b = buildProfile(base, "ProfileB");
+
+  assert.equal(_extractCookieForProfileForTests(a).cookie, COOKIE_VALUE);
+  assert.equal(_extractCookieForProfileForTests(b).cookie, COOKIE_VALUE);
+  assert.equal(adapter.calls, 1, "second profile must reuse the cached key — one Keychain hit per run");
+});
+
+test("a decrypt failure refetches the key once, then reports cookie_decrypt_failed", { skip: !HAS_SQLITE }, () => {
+  const base = chromeBase();
+  const adapter = fakeSafeStorage({ password: "wrong-password" });
+  _setSafeStorageAdapterForTests(adapter);
+
+  const dir = buildProfile(base, "ReKeyed"); // encrypted with PASSWORD, adapter serves wrong-password
+  const result = _extractCookieForProfileForTests(dir);
+  assert.equal(result.reason, "cookie_decrypt_failed");
+  assert.equal(adapter.calls, 2, "exactly one forced refresh after a decrypt failure — no retry storm");
+});
+
+test("a Keychain lookup failure is classified, not swallowed", { skip: !HAS_SQLITE }, () => {
+  const base = chromeBase();
+  _setSafeStorageAdapterForTests(fakeSafeStorage({ fail: "timeout" }));
+  assert.equal(_extractCookieForProfileForTests(buildProfile(base, "T")).reason, "keychain_timeout");
+
+  _setSafeStorageAdapterForTests(fakeSafeStorage({ fail: "denied" }));
+  assert.equal(_extractCookieForProfileForTests(buildProfile(base, "D")).reason, "keychain_lookup_failed");
+});
+
+// ---------- full pipeline (macOS only: the pipeline is platform-gated) ----------
+
+test("full extraction succeeds end-to-end from a synthetic Chrome estate", { skip: !IS_MACOS || !HAS_SQLITE }, () => {
+  const base = chromeBase();
+  process.env.SLACK_MCP_EXTRACTION_MODE = "leveldb";
+  writeFileSync(join(base, "Local State"), JSON.stringify({ profile: { info_cache: { NoToken: {}, Full: {} } } }));
+  const adapter = fakeSafeStorage();
+  _setSafeStorageAdapterForTests(adapter);
+
+  buildProfile(base, "NoToken", { cookie: true, token: false });
+  buildProfile(base, "Full", { cookie: true, token: true });
+
+  const result = extractFromChrome();
+  assert.ok(result, `extraction failed: ${JSON.stringify(getLastExtractionError())}`);
+  assert.equal(result.token, CACHED_TOKEN);
+  assert.equal(result.cookie, COOKIE_VALUE);
+  assert.equal(result.extraction_mode, "leveldb");
+  assert.equal(adapter.calls, 1, "one Keychain lookup even when multiple profiles decrypt");
+});
+
+test("a fatal Keychain failure aborts the run — no per-profile prompt storm", { skip: !IS_MACOS || !HAS_SQLITE }, () => {
+  const base = chromeBase();
+  process.env.SLACK_MCP_EXTRACTION_MODE = "leveldb";
+  writeFileSync(join(base, "Local State"), JSON.stringify({ profile: { info_cache: { A: {}, B: {}, C: {} } } }));
+  const adapter = fakeSafeStorage({ fail: "timeout" });
+  _setSafeStorageAdapterForTests(adapter);
+
+  for (const name of ["A", "B", "C"]) buildProfile(base, name);
+
+  const result = extractFromChrome();
+  assert.equal(result, null);
+  assert.equal(getLastExtractionError().code, "keychain_timeout");
+  assert.match(getLastExtractionError().detail, /SLACK_MCP_KEYCHAIN_TIMEOUT_MS/);
+  assert.equal(adapter.calls, 1, "three profiles must not mean three slow Keychain attempts");
+});
+
+test("per-profile failure reasons surface in the final extraction error", { skip: !IS_MACOS || !HAS_SQLITE }, () => {
+  const base = chromeBase();
+  process.env.SLACK_MCP_EXTRACTION_MODE = "leveldb";
+  writeFileSync(join(base, "Local State"), JSON.stringify({ profile: { info_cache: { OnlyCookie: {} } } }));
+  _setSafeStorageAdapterForTests(fakeSafeStorage());
+
+  buildProfile(base, "OnlyCookie", { cookie: true, token: false });
+
+  assert.equal(extractFromChrome(), null);
+  const err = getLastExtractionError();
+  assert.equal(err.code, "leveldb_no_matching_profile");
+  assert.match(err.detail, /OnlyCookie: cookie ok, no cached xoxc token/);
+});

--- a/test/e2e-storage-modes.test.js
+++ b/test/e2e-storage-modes.test.js
@@ -35,9 +35,10 @@ function spawnServer(home, extraEnv = {}) {
       USERPROFILE: home,
       SLACK_TOKEN: "",
       SLACK_COOKIE: "",
-      // The child must not inherit a storage mode from the environment
-      // running the tests; each test opts in via extraEnv.
+      // The child must not inherit a storage mode or profile from the
+      // environment running the tests; each test opts in via extraEnv.
       SLACK_MCP_TOKEN_STORAGE: "",
+      SLACK_MCP_PROFILE: "",
       ...extraEnv,
     },
     stdio: ["pipe", "pipe", "pipe"],
@@ -186,3 +187,23 @@ test(
     assert.equal(existsSync(tokenPath), true, "a failed migration must not delete the plaintext file");
   }
 );
+
+test("e2e: a profile serves tokens from its own namespace and reports it", async () => {
+  const home = sandboxHome();
+  writeFileSync(join(home, ".slack-mcp-tokens-work.json"), JSON.stringify({
+    SLACK_TOKEN: "xoxc-1111-2222-3333-aaaaaaaaaaaaaaaaaaaaaaaa",
+    SLACK_COOKIE: "xoxd-e2e-work-cookie",
+    updated_at: new Date().toISOString(),
+  }));
+
+  const payload = await callTool(home, { SLACK_MCP_TOKEN_STORAGE: "file", SLACK_MCP_PROFILE: "work" }, "slack_token_status");
+  assert.equal(payload.status, "healthy");
+  assert.equal(payload.token.source, "file");
+  assert.equal(payload.storage.profile, "work");
+});
+
+test("e2e: an invalid profile kills the server at startup with a clear error", async () => {
+  const { code, stderr } = await expectStartupFailure(sandboxHome(), { SLACK_MCP_PROFILE: "Bad Name!" });
+  assert.equal(code, 1);
+  assert.match(stderr, /Invalid SLACK_MCP_PROFILE/);
+});

--- a/test/profile-namespace.test.js
+++ b/test/profile-namespace.test.js
@@ -1,0 +1,92 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+// SLACK_MCP_PROFILE (#164) namespaces every storage surface so multiple
+// server instances (work + personal) run side-by-side without sharing or
+// overwriting each other's credentials. Paths are computed at module load,
+// so the profile is set before the import and this file owns that setup.
+
+const SANDBOX = mkdtempSync(join(tmpdir(), "slack-mcp-profile-test-"));
+process.env.HOME = SANDBOX;
+process.env.USERPROFILE = SANDBOX;
+process.env.SLACK_MCP_PROFILE = "work";
+delete process.env.SLACK_TOKEN;
+delete process.env.SLACK_COOKIE;
+delete process.env.SLACK_MCP_TOKEN_STORAGE;
+
+const {
+  saveTokens,
+  loadTokensReadOnly,
+  getStorageInfo,
+  TOKEN_FILE,
+  META_FILE,
+  KEYCHAIN_SERVICE,
+  ACTIVE_PROFILE,
+} = await import("../lib/token-store.js");
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const TOKEN = "xoxc-1111-2222-3333-" + "a".repeat(24);
+const COOKIE = "xoxd-profile-test-cookie";
+
+test("a profile namespaces the token file, sidecar, and Keychain service", () => {
+  assert.equal(ACTIVE_PROFILE, "work");
+  assert.ok(TOKEN_FILE.endsWith(".slack-mcp-tokens-work.json"), TOKEN_FILE);
+  assert.ok(META_FILE.endsWith(".slack-mcp-meta-work.json"), META_FILE);
+  assert.equal(KEYCHAIN_SERVICE, "slack-mcp-server-work");
+  assert.equal(getStorageInfo().profile, "work");
+});
+
+test("saves land in the profile's namespace, not the default one", () => {
+  process.env.SLACK_MCP_TOKEN_STORAGE = "file";
+  try {
+    saveTokens(TOKEN, COOKIE);
+  } finally {
+    delete process.env.SLACK_MCP_TOKEN_STORAGE;
+  }
+
+  assert.equal(existsSync(join(SANDBOX, ".slack-mcp-tokens-work.json")), true);
+  assert.equal(existsSync(join(SANDBOX, ".slack-mcp-tokens.json")), false,
+    "the default namespace must stay untouched");
+  const data = JSON.parse(readFileSync(TOKEN_FILE, "utf-8"));
+  assert.equal(data.SLACK_TOKEN, TOKEN);
+  assert.equal(loadTokensReadOnly().token, TOKEN);
+});
+
+test("an invalid profile name fails closed at load, naming the rule", () => {
+  const probe = spawnSync(process.execPath, [
+    "--input-type=module",
+    "-e",
+    `await import(${JSON.stringify(join(REPO_ROOT, "lib", "token-store.js"))});`,
+  ], {
+    env: { ...process.env, HOME: SANDBOX, SLACK_MCP_PROFILE: "Bad Name!" },
+    encoding: "utf-8",
+  });
+  assert.notEqual(probe.status, 0);
+  assert.match(probe.stderr, /Invalid SLACK_MCP_PROFILE/);
+});
+
+test("the CLI dispatcher maps --profile to SLACK_MCP_PROFILE for the child", () => {
+  // An invalid profile through the flag must reach the child and kill it —
+  // proving the flag is parsed, stripped, and exported as env.
+  const bad = spawnSync(process.execPath, [join(REPO_ROOT, "src", "cli.js"), "--version", "--profile", "bad name!"], {
+    env: { ...process.env, HOME: SANDBOX },
+    encoding: "utf-8",
+    timeout: 30000,
+  });
+  assert.match(bad.stderr + bad.stdout, /Invalid SLACK_MCP_PROFILE/);
+
+  // A valid profile passes through cleanly and the flag is not forwarded as
+  // a positional command.
+  const good = spawnSync(process.execPath, [join(REPO_ROOT, "src", "cli.js"), "--version", "--profile=work"], {
+    env: { ...process.env, HOME: SANDBOX },
+    encoding: "utf-8",
+    timeout: 30000,
+  });
+  assert.equal(good.status, 0, good.stderr);
+  assert.match(good.stdout, /slack-mcp-server v\d+\.\d+\.\d+/);
+});

--- a/test/token-store.test.js
+++ b/test/token-store.test.js
@@ -323,6 +323,7 @@ test("getStorageInfo reports the mode and whether a plaintext file is present", 
   assert.deepEqual(getStorageInfo(), {
     mode: "keychain-only",
     mode_source: "env",
+    profile: null,
     keychain_available: true,
     plaintext_file_present: true,
     unpersisted_fresh_tokens: false,


### PR DESCRIPTION
Closes #164. Closes #168.

## Workspace profiles (#164 — requested by @iloveitaly)
`SLACK_MCP_PROFILE=work` (or `--profile work` on any CLI command) namespaces every storage surface — token file, metadata sidecar, write lock, Keychain service — so multiple MCP server instances (work + personal) run side-by-side without sharing or overwriting each other's credentials. Pair with `SLACK_MCP_CHROME_PROFILE` to point each profile's extraction at the matching Chrome profile. Invalid names fail closed at startup, same discipline as the storage mode. Reported via `storage.profile` in `slack_token_status`, `--doctor`, and `tokens:status`.

## Chrome extraction overhaul (#168)
- Safe Storage key looked up **once per process** and cached (it's per-machine, not per-profile); refetched exactly once if a decrypt fails in case Chrome re-keyed. Ends the password-prompt storm.
- Fatal Keychain failures (`keychain_timeout`, `keychain_lookup_failed`) abort the run with an actionable error instead of retrying per profile per path.
- `SLACK_MCP_KEYCHAIN_TIMEOUT_MS` (default 15000) replaces the hard 5000ms a real Keychain was observed to exceed at 4.9s.
- Every cookie-extraction failure names its cause (`no_cookie_db`, `no_slack_cookie_row`, `cookie_decrypt_failed`, …) and the final error lists per-profile reasons — no more bare `extraction_failed_all_paths`.
- AppleScript token read runs once per extraction (it talks to the Chrome app, not a profile dir).

## Tests — 57 total
- `test/chrome-extraction.test.js`: synthetic Chrome estate (real SQLite cookie DB with a genuine v10 AES-128-CBC-encrypted cookie + LevelDB-style token log) driving the real pipeline with only the Keychain lookup faked — proves single-lookup caching, fatal-abort, decrypt-retry, and the reason taxonomy. Extraction was previously untestable without live Chrome.
- `test/profile-namespace.test.js`: namespace isolation, fail-closed names, CLI `--profile` → env plumbing.
- e2e: profile served from its own namespace end-to-end; invalid profile kills startup.

## Verification
- `npm test` → 57 tests, 0 failures (2 platform skips)
- All public-surface verifiers pass; version parity green for the pre-publish window (`--allow-propagation`)
- Version bumped across all four parity files; CHANGELOG entry included — tag + release follow the merge