### PR TITLE
feat(pages): demo-video chapters + client canon + share masthead broadening

### DIFF
--- a/lib/public-pages.js
+++ b/lib/public-pages.js
@@ -63,7 +63,7 @@ function shareLinks() {
 }
 
 function shareNote() {
-  return `<strong>Verify in 30 seconds:</strong> <code>--version</code>, <code>--doctor</code>, <code>--status</code>. Self-host gives ${PUBLIC_METADATA.selfHostedToolCount} tools with session-based auth. Works with any MCP client — Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf. Hosted free tier (no card) live at <a href="${PUBLIC_METADATA.canonicalSiteUrl}">mcp.revasserlabs.com</a> — Pro $19/mo unlocks unlimited AI tools and permanent OAuth.`;
+  return `<strong>Verify in 30 seconds:</strong> <code>--version</code>, <code>--doctor</code>, <code>--status</code>. Self-host gives ${PUBLIC_METADATA.selfHostedToolCount} tools with session-based auth. Works with Claude, Cursor, Copilot, Windsurf, Gemini CLI, Codex CLI — and any other MCP client. Hosted free tier (no card) live at <a href="${PUBLIC_METADATA.canonicalSiteUrl}">mcp.revasserlabs.com</a> — Pro $19/mo unlocks unlimited AI tools and permanent OAuth.`;
 }
 
 function demoLinks() {
@@ -75,7 +75,7 @@ function demoLinks() {
 }
 
 function demoNote() {
-  return `Self-host free for ${PUBLIC_METADATA.selfHostedToolCount} tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="${PUBLIC_METADATA.canonicalSiteUrl}" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $19/mo unlocks unlimited AI tools and permanent OAuth.`;
+  return `Self-host free for ${PUBLIC_METADATA.selfHostedToolCount} tools with session-based auth. Works with Claude, Cursor, Copilot, Windsurf, Gemini CLI, Codex CLI — and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="${PUBLIC_METADATA.canonicalSiteUrl}" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $19/mo unlocks unlimited AI tools and permanent OAuth.`;
 }
 
 function demoFooterLinks() {

--- a/public/demo-slack-mcp.html
+++ b/public/demo-slack-mcp.html
@@ -1313,7 +1313,7 @@
       <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md" target="_blank" rel="noopener noreferrer">Setup Guide</a>
     </div>
     <div class="note">
-      Self-host free for 21 tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $19/mo unlocks unlimited AI tools and permanent OAuth.
+      Self-host free for 21 tools with session-based auth. Works with Claude, Cursor, Copilot, Windsurf, Gemini CLI, Codex CLI — and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $19/mo unlocks unlimited AI tools and permanent OAuth.
     </div>
   </div>
   <header class="page-header">

--- a/public/demo-video.html
+++ b/public/demo-video.html
@@ -141,6 +141,32 @@
       display: block;
       border-radius: 12px;
     }
+    .chapters {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 8px;
+      margin-top: 1rem;
+    }
+    .chapter {
+      font-family: var(--font-body);
+      font-size: 0.8125rem;
+      color: #d8efff;
+      background: transparent;
+      border: 1px solid rgba(255, 255, 255, 0.24);
+      border-radius: 999px;
+      padding: 5px 12px;
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s, color 0.15s;
+    }
+    .chapter:hover {
+      background: rgba(255, 255, 255, 0.08);
+    }
+    .chapter.active {
+      background: rgba(78, 205, 196, 0.16);
+      border-color: #4ecdc4;
+      color: #4ecdc4;
+    }
     .controls {
       display: flex;
       justify-content: center;
@@ -217,7 +243,7 @@
       <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md" target="_blank" rel="noopener noreferrer">Setup Guide</a>
       </div>
       <div class="note">
-        Self-host free for 21 tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $19/mo unlocks unlimited AI tools and permanent OAuth.
+        Self-host free for 21 tools with session-based auth. Works with Claude, Cursor, Copilot, Windsurf, Gemini CLI, Codex CLI — and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $19/mo unlocks unlimited AI tools and permanent OAuth.
       </div>
     </div>
 
@@ -228,6 +254,15 @@
         <track kind="captions" src="../docs/videos/demo-slack-mcp.vtt" srclang="en" label="English captions" default>
         Your browser does not support the video tag.
       </video>
+    </div>
+
+    <div class="chapters" id="chapters" aria-label="Video chapters">
+      <button type="button" class="chapter" data-t="0">0:00 What it is</button>
+      <button type="button" class="chapter" data-t="12">0:12 Morning triage</button>
+      <button type="button" class="chapter" data-t="35">0:35 Search &amp; threads</button>
+      <button type="button" class="chapter" data-t="70">1:10 Replies &amp; reactions</button>
+      <button type="button" class="chapter" data-t="115">1:55 Workflow profiles</button>
+      <button type="button" class="chapter" data-t="165">2:45 Self-host vs hosted</button>
     </div>
 
     <div class="controls">
@@ -276,6 +311,28 @@
     video.addEventListener('ended', () => {
       video.currentTime = HIGHLIGHT_START_SECONDS;
       video.play();
+    });
+
+    // Chapters: one delegated click listener seeks + plays
+    const chapters = document.getElementById('chapters');
+    const chapterButtons = Array.from(chapters.querySelectorAll('.chapter'));
+
+    chapters.addEventListener('click', (event) => {
+      const button = event.target.closest('.chapter');
+      if (!button) return;
+      video.currentTime = Number(button.dataset.t);
+      video.play();
+    });
+
+    // Active-state tracking follows playback position
+    video.addEventListener('timeupdate', () => {
+      let active = chapterButtons[0];
+      for (const button of chapterButtons) {
+        if (video.currentTime >= Number(button.dataset.t)) active = button;
+      }
+      for (const button of chapterButtons) {
+        button.classList.toggle('active', button === active);
+      }
     });
   </script>
 </body>

--- a/public/demo.html
+++ b/public/demo.html
@@ -753,7 +753,7 @@
       <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md" target="_blank" rel="noopener noreferrer">Setup Guide</a>
     </div>
     <div class="cta-note">
-      Self-host free for 21 tools with session-based auth. Works with Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf, and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $19/mo unlocks unlimited AI tools and permanent OAuth.
+      Self-host free for 21 tools with session-based auth. Works with Claude, Cursor, Copilot, Windsurf, Gemini CLI, Codex CLI — and any other MCP client. No OAuth app, no admin approval. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">mcp.revasserlabs.com</a> — Pro $19/mo unlocks unlimited AI tools and permanent OAuth.
     </div>
   </div>
 

--- a/public/share.html
+++ b/public/share.html
@@ -108,7 +108,7 @@
 <body>
   <main class="wrap">
     <h1>Slack MCP Server</h1>
-    <p class="sub">Give Claude full access to your Slack. Self-host 21 tools for free (16 read/write + 2 workflow profile primitives + 3 paid stubs that point at hosted). Hosted free tier — workflow continuity + AI catch-up. Sign up no card at <a href="https://mcp.revasserlabs.com">mcp.revasserlabs.com</a>.</p>
+    <p class="sub">Slack for your AI agent — no OAuth, no admin, no app to register. Self-host 21 tools for free: 12 read, 4 write, 2 workflow-profile primitives, 3 hosted-brain stubs. Hosted free tier — workflow continuity + AI catch-up. Sign up no card at <a href="https://mcp.revasserlabs.com">mcp.revasserlabs.com</a>.</p>
 
     <a class="preview" href="https://github.com/jtalk22/slack-mcp-server" rel="noopener">
       <img src="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png" alt="Slack MCP Server social preview card">
@@ -124,7 +124,7 @@
       <a href="https://mcp.revasserlabs.com" rel="noopener" style="background:rgba(240,194,70,0.18);border-color:rgba(240,194,70,0.45);color:#f0c246">Hosted</a>
     </div>
 
-    <p class="note"><strong>Verify in 30 seconds:</strong> <code>--version</code>, <code>--doctor</code>, <code>--status</code>. Self-host gives 21 tools with session-based auth. Works with any MCP client — Claude, ChatGPT, Cursor, Copilot, Gemini, Windsurf. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com">mcp.revasserlabs.com</a> — Pro $19/mo unlocks unlimited AI tools and permanent OAuth.</p>
+    <p class="note"><strong>Verify in 30 seconds:</strong> <code>--version</code>, <code>--doctor</code>, <code>--status</code>. Self-host gives 21 tools with session-based auth. Works with Claude, Cursor, Copilot, Windsurf, Gemini CLI, Codex CLI — and any other MCP client. Hosted free tier (no card) live at <a href="https://mcp.revasserlabs.com">mcp.revasserlabs.com</a> — Pro $19/mo unlocks unlimited AI tools and permanent OAuth.</p>
   </main>
 </body>
 </html>

--- a/templates/public-pages/demo-video.html.tpl
+++ b/templates/public-pages/demo-video.html.tpl
@@ -141,6 +141,32 @@
       display: block;
       border-radius: 12px;
     }
+    .chapters {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 8px;
+      margin-top: 1rem;
+    }
+    .chapter {
+      font-family: var(--font-body);
+      font-size: 0.8125rem;
+      color: #d8efff;
+      background: transparent;
+      border: 1px solid rgba(255, 255, 255, 0.24);
+      border-radius: 999px;
+      padding: 5px 12px;
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s, color 0.15s;
+    }
+    .chapter:hover {
+      background: rgba(255, 255, 255, 0.08);
+    }
+    .chapter.active {
+      background: rgba(78, 205, 196, 0.16);
+      border-color: #4ecdc4;
+      color: #4ecdc4;
+    }
     .controls {
       display: flex;
       justify-content: center;
@@ -228,6 +254,15 @@
       </video>
     </div>
 
+    <div class="chapters" id="chapters" aria-label="Video chapters">
+      <button type="button" class="chapter" data-t="0">0:00 What it is</button>
+      <button type="button" class="chapter" data-t="12">0:12 Morning triage</button>
+      <button type="button" class="chapter" data-t="35">0:35 Search &amp; threads</button>
+      <button type="button" class="chapter" data-t="70">1:10 Replies &amp; reactions</button>
+      <button type="button" class="chapter" data-t="115">1:55 Workflow profiles</button>
+      <button type="button" class="chapter" data-t="165">2:45 Self-host vs hosted</button>
+    </div>
+
     <div class="controls">
       <button class="btn btn-primary" onclick="togglePlay()" aria-label="Play or pause the full Slack MCP demo video">Play / Pause</button>
       <button class="btn btn-secondary" onclick="restart()" aria-label="Restart the full Slack MCP demo video">Restart</button>
@@ -274,6 +309,28 @@
     video.addEventListener('ended', () => {
       video.currentTime = HIGHLIGHT_START_SECONDS;
       video.play();
+    });
+
+    // Chapters: one delegated click listener seeks + plays
+    const chapters = document.getElementById('chapters');
+    const chapterButtons = Array.from(chapters.querySelectorAll('.chapter'));
+
+    chapters.addEventListener('click', (event) => {
+      const button = event.target.closest('.chapter');
+      if (!button) return;
+      video.currentTime = Number(button.dataset.t);
+      video.play();
+    });
+
+    // Active-state tracking follows playback position
+    video.addEventListener('timeupdate', () => {
+      let active = chapterButtons[0];
+      for (const button of chapterButtons) {
+        if (video.currentTime >= Number(button.dataset.t)) active = button;
+      }
+      for (const button of chapterButtons) {
+        button.classList.toggle('active', button === active);
+      }
     });
   </script>
 </body>

--- a/templates/public-pages/share.html.tpl
+++ b/templates/public-pages/share.html.tpl
@@ -108,7 +108,7 @@
 <body>
   <main class="wrap">
     <h1>Slack MCP Server</h1>
-    <p class="sub">Give Claude full access to your Slack. Self-host {{SELF_HOSTED_TOOL_COUNT}} tools for free (16 read/write + 2 workflow profile primitives + 3 paid stubs that point at hosted). Hosted free tier — workflow continuity + AI catch-up. Sign up no card at <a href="{{CANONICAL_SITE_URL}}">mcp.revasserlabs.com</a>.</p>
+    <p class="sub">Slack for your AI agent — no OAuth, no admin, no app to register. Self-host {{SELF_HOSTED_TOOL_COUNT}} tools for free: 12 read, 4 write, 2 workflow-profile primitives, 3 hosted-brain stubs. Hosted free tier — workflow continuity + AI catch-up. Sign up no card at <a href="{{CANONICAL_SITE_URL}}">mcp.revasserlabs.com</a>.</p>
 
     <a class="preview" href="{{GITHUB_REPO_URL}}" rel="noopener">
       <img src="{{SOCIAL_IMAGE_URL}}" alt="Slack MCP Server social preview card">


### PR DESCRIPTION
## What

**Chapters on the demo-video page** — 6 pill buttons (`data-t` seek+play via one delegated listener, `timeupdate` active-state, teal active) matching the .vtt cue boundaries (0:00 / 0:12 / 0:35 / 1:10 / 1:55 / 2:45). This makes the README's forthcoming "full 3:31 demo with chapters" claim true — it merges first by design.

**Client canon** (`lib/public-pages.js` shareNote/demoNote) — drops ChatGPT (claimed nowhere else on the estate), adds Gemini CLI + Codex CLI so the shared strings match the README's six-client table: *Works with Claude, Cursor, Copilot, Windsurf, Gemini CLI, Codex CLI — and any other MCP client.*

**share.html masthead** — "Give Claude full access…" → "Slack for your AI agent — no OAuth, no admin, no app to register."; tool phrasing aligned to 12/4/2/3.

## Verification

- `generate-public-pages.js` → `verify-generated-public-pages.js` clean (no drift; regenerated outputs committed with templates + lib)
- `check-public-language.sh` pass
- `check-public-surface-integrity.js` pass
- Root `index.html` untouched (its panel string didn't change)

Part 1 of the README/landing UX recovery series (PR A of A/B/C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added interactive video chapters, allowing viewers to jump to sections and see the currently active chapter while watching.
- **Content Updates**
  - Updated compatibility messaging across demo, sharing, and note pages to include Windsurf, Gemini CLI, and Codex CLI.
  - Revised sharing-page copy to emphasize “Slack for your AI agent” and updated tool capability descriptions.
  - Preserved existing hosted free-tier links and Pro plan messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->