### PR TITLE
feat(readme): surface signed provenance + funding + trust voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   <a href="https://www.npmjs.com/package/@jtalk22/slack-mcp"><img src="https://img.shields.io/npm/dw/@jtalk22/slack-mcp" alt="npm weekly downloads"></a>
   <a href="https://github.com/jtalk22/slack-mcp-server/actions/workflows/ci.yml"><img src="https://github.com/jtalk22/slack-mcp-server/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://registry.modelcontextprotocol.io"><img src="https://img.shields.io/badge/MCP_Registry-listed-blue" alt="MCP Registry"></a>
+  <a href="#provenance-dont-take-my-word-for-it"><img src="https://img.shields.io/badge/provenance-signed-4ecdc4?logo=npm&logoColor=white" alt="npm provenance signed"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-green.svg" alt="MIT"></a>
   <a href="https://github.com/jtalk22/slack-mcp-server"><img src="https://img.shields.io/github/stars/jtalk22/slack-mcp-server?style=social" alt="GitHub stars"></a>
 </p>
@@ -449,6 +450,16 @@ More in [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md).
 - Fail-closed config: an unrecognized storage mode kills the server at startup instead of guessing.
 - The web server binds to localhost only; API keys use `crypto.randomBytes`.
 - Full policy: [SECURITY.md](SECURITY.md).
+
+### Provenance: don't take my word for it
+
+You're about to hand a package your live Slack cookie. Fair to want proof of what it is. Every release publishes straight from CI with [npm provenance](https://docs.npmjs.com/generating-provenance-statements): the tarball on npm is signed and traces to this repo's exact commit and GitHub Actions run — no hand-uploaded build in the path. Verify it in one command, before you trust it with anything:
+
+```bash
+npm audit signatures
+```
+
+A green line means the code you install is the code you can read here. If it ever isn't, that command says so.
 
 ## Docs
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "mcpName": "io.github.jtalk22/slack-mcp-server",
   "version": "4.6.0",
   "description": "Slack MCP without OAuth — 21 tools, session-based, local-first. Free OSS + hosted tier from $19/mo.",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/jtalk22"
+  },
   "type": "module",
   "main": "src/server.js",
   "bin": {


### PR DESCRIPTION
Answering 'make it more verifiable + distinctive + stronger npm optics':

## The verifiable win (already earned, was invisible)
v4.6.0 ships **live SLSA provenance attestations** — signed, traceable to this repo's exact commit via CI. Confirmed on the registry. Nothing in the README pointed at it. Now:
- 'provenance signed' masthead badge
- A **'Provenance: don't take my word for it'** Security block with a runnable one-command proof: `npm audit signatures`. That's the distinctive voice AND the strongest trust move for a tool you hand a session cookie — the joke does real work.

## npm optics
- `funding` field added → npm page surfaces the Sponsors link.
- Weekly-downloads badge (prior pass) stays: **~4,710/mo, 1,193/wk** — real, earned proof.
- **Recommendation against a rename:** `slackmcp` / `slack-session-mcp` are free on npm, but renaming resets 4.7k/mo of download proof to zero and breaks every install doc across the MCP registry, Glama, and Smithery. The downloads + provenance badges are the stronger optics than a name grab.

Gates: drift, language, integrity all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an npm provenance badge and guidance for verifying release signatures.
* **Chores**
  * Added package funding information for project sponsorship.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->