### PR TITLE
Brand-align demo wrapper pages to poster canon

### DIFF
--- a/lib/public-pages.js
+++ b/lib/public-pages.js
@@ -68,7 +68,7 @@ function shareNote() {
 
 function demoLinks() {
   return `
-      <a href="${PUBLIC_METADATA.canonicalSiteUrl}" target="_blank" rel="noopener noreferrer" style="background:rgba(240,194,70,0.18);border-color:rgba(240,194,70,0.45);color:#f0c246">Hosted</a>
+      <a href="${PUBLIC_METADATA.canonicalSiteUrl}" target="_blank" rel="noopener noreferrer" style="background:rgba(255,107,107,0.18);border-color:rgba(255,107,107,0.45);color:#ff6b6b">Hosted</a>
       <a href="${NPM_URL}" target="_blank" rel="noopener noreferrer">npm Install</a>
       <a href="${SETUP_URL}" target="_blank" rel="noopener noreferrer">Setup Guide</a>
     `.trim();
@@ -79,7 +79,7 @@ function demoNote() {
 }
 
 function demoFooterLinks() {
-  return `<a href="${PUBLIC_METADATA.canonicalRepoUrl}">GitHub</a> · <a href="${NPM_URL}" style="color:#94a3b8;text-decoration:none;font-size:0.875rem">npm</a> · <a href="${PUBLIC_METADATA.canonicalSiteUrl}" style="color:#f0c246;text-decoration:none;font-size:0.875rem">Hosted</a>`;
+  return `<a href="${PUBLIC_METADATA.canonicalRepoUrl}">GitHub</a> · <a href="${NPM_URL}" style="color:#8d99a9;text-decoration:none;font-size:0.875rem">npm</a> · <a href="${PUBLIC_METADATA.canonicalSiteUrl}" style="color:#ff6b6b;text-decoration:none;font-size:0.875rem">Hosted</a>`;
 }
 
 function commonTokens() {

--- a/public/demo-slack-mcp.html
+++ b/public/demo-slack-mcp.html
@@ -1378,7 +1378,7 @@
 <body>
   <div class="cta-strip">
     <div class="links">
-<a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer" style="background:rgba(240,194,70,0.18);border-color:rgba(240,194,70,0.45);color:#f0c246">Hosted</a>
+<a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer" style="background:rgba(255,107,107,0.18);border-color:rgba(255,107,107,0.45);color:#ff6b6b">Hosted</a>
       <a href="https://www.npmjs.com/package/@jtalk22/slack-mcp" target="_blank" rel="noopener noreferrer">npm Install</a>
       <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md" target="_blank" rel="noopener noreferrer">Setup Guide</a>
     </div>

--- a/public/demo-video.html
+++ b/public/demo-video.html
@@ -67,7 +67,12 @@
     }
     body {
       font-family: var(--font-body);
-      background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+      /* Poster ground — near-black with faint coral (left) + teal (right) corner glows */
+      background:
+        radial-gradient(58% 46% at 14% 0%, rgba(255, 107, 107, 0.07), transparent 62%),
+        radial-gradient(58% 46% at 86% 0%, rgba(78, 205, 196, 0.07), transparent 62%),
+        linear-gradient(180deg, #0e1119 0%, #0b0e14 58%, #07090e 100%);
+      background-attachment: fixed;
       min-height: 100vh;
       display: flex;
       flex-direction: column;
@@ -80,7 +85,7 @@
       width: 100%;
     }
     h1 {
-      color: #ffffff;
+      color: #f0f3f7;
       font-size: 1.75rem;
       font-weight: 600;
       text-align: center;
@@ -89,15 +94,15 @@
       letter-spacing: -0.02em;
     }
     .subtitle {
-      color: #94a3b8;
+      color: #8d99a9;
       text-align: center;
       margin-bottom: 1.5rem;
       font-size: 1rem;
     }
     .cta-strip {
       margin: 0 auto 1rem;
-      background: rgba(15, 52, 96, 0.72);
-      border: 1px solid rgba(255, 255, 255, 0.16);
+      background: rgba(18, 22, 31, 0.82);
+      border: 1px solid rgba(255, 255, 255, 0.14);
       border-radius: 12px;
       padding: 10px 14px;
       display: flex;
@@ -113,9 +118,9 @@
       flex-wrap: wrap;
     }
     .cta-strip .links a {
-      color: #d8efff;
+      color: #dfe6ee;
       text-decoration: none;
-      border: 1px solid rgba(255, 255, 255, 0.24);
+      border: 1px solid rgba(255, 255, 255, 0.25);
       border-radius: 999px;
       padding: 4px 8px;
     }
@@ -123,10 +128,10 @@
       background: rgba(255, 255, 255, 0.08);
     }
     .cta-strip .note {
-      color: rgba(255, 255, 255, 0.82);
+      color: rgba(255, 255, 255, 0.78);
     }
     .cta-strip .note a {
-      color: #9ee7ff;
+      color: #7fe0d6;
       text-decoration: underline;
     }
     .video-wrapper {
@@ -134,12 +139,21 @@
       border-radius: 12px;
       overflow: hidden;
       box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
-      background: #0f0f1a;
+      background: #0b0e14;
     }
     video {
       width: 100%;
       display: block;
       border-radius: 12px;
+    }
+    /* Captions — tasteful lower subtitle, not a wall. Semi-opaque near-black box,
+       reduced size so an active cue never covers the demo's own input bar. */
+    video::cue {
+      font-size: 62%;
+      line-height: 1.35;
+      background-color: rgba(11, 14, 20, 0.82);
+      color: #f0f3f7;
+      font-family: "IBM Plex Sans", "Inter", "Segoe UI", sans-serif;
     }
     .chapters {
       display: flex;
@@ -151,9 +165,9 @@
     .chapter {
       font-family: var(--font-body);
       font-size: 0.8125rem;
-      color: #d8efff;
+      color: #dfe6ee;
       background: transparent;
-      border: 1px solid rgba(255, 255, 255, 0.24);
+      border: 1px solid rgba(255, 255, 255, 0.25);
       border-radius: 999px;
       padding: 5px 12px;
       cursor: pointer;
@@ -184,7 +198,7 @@
     }
     .btn-primary {
       background: #4ecdc4;
-      color: #1a1a2e;
+      color: #07090e;
     }
     .btn-primary:hover {
       background: #5eead4;
@@ -192,7 +206,7 @@
     }
     .btn-secondary {
       background: rgba(255, 255, 255, 0.1);
-      color: #ffffff;
+      color: #f0f3f7;
       border: 1px solid rgba(255, 255, 255, 0.2);
     }
     .btn-secondary:hover {
@@ -203,12 +217,12 @@
       text-align: center;
     }
     .back-link a {
-      color: #94a3b8;
+      color: #8d99a9;
       text-decoration: none;
       font-size: 0.875rem;
     }
     .back-link a:hover {
-      color: #ffffff;
+      color: #f0f3f7;
     }
 
     @media (max-width: 640px) {
@@ -238,7 +252,7 @@
     <p class="subtitle">No OAuth. No admin approval. 21 tools for Claude, Cursor, Copilot, Gemini, and any MCP client. <code style="background:rgba(255,255,255,0.1);padding:2px 6px;border-radius:4px;font-size:0.875rem">npx -y @jtalk22/slack-mcp --setup</code></p>
     <div class="cta-strip">
       <div class="links">
-<a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer" style="background:rgba(240,194,70,0.18);border-color:rgba(240,194,70,0.45);color:#f0c246">Hosted</a>
+<a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer" style="background:rgba(255,107,107,0.18);border-color:rgba(255,107,107,0.45);color:#ff6b6b">Hosted</a>
       <a href="https://www.npmjs.com/package/@jtalk22/slack-mcp" target="_blank" rel="noopener noreferrer">npm Install</a>
       <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md" target="_blank" rel="noopener noreferrer">Setup Guide</a>
       </div>
@@ -272,7 +286,7 @@
     </div>
 
     <div class="back-link">
-      <a href="https://github.com/jtalk22/slack-mcp-server">GitHub</a> · <a href="https://www.npmjs.com/package/@jtalk22/slack-mcp" style="color:#94a3b8;text-decoration:none;font-size:0.875rem">npm</a> · <a href="https://mcp.revasserlabs.com" style="color:#f0c246;text-decoration:none;font-size:0.875rem">Hosted</a>
+      <a href="https://github.com/jtalk22/slack-mcp-server">GitHub</a> · <a href="https://www.npmjs.com/package/@jtalk22/slack-mcp" style="color:#8d99a9;text-decoration:none;font-size:0.875rem">npm</a> · <a href="https://mcp.revasserlabs.com" style="color:#ff6b6b;text-decoration:none;font-size:0.875rem">Hosted</a>
     </div>
   </div>
 

--- a/public/demo.html
+++ b/public/demo.html
@@ -29,19 +29,20 @@
     :root {
       --font-heading: "Space Grotesk", "Avenir Next", "Segoe UI", sans-serif;
       --font-body: "IBM Plex Sans", "Inter", "Segoe UI", sans-serif;
-      --bg-primary: #0f0f1a;
-      --bg-secondary: #1a1a2e;
-      --bg-tertiary: #16213e;
-      --bg-input: #0f3460;
+      /* Poster canon — near-black grounds, coral emphasis, teal system/tool */
+      --bg-primary: #0b0e14;
+      --bg-secondary: #12161f;
+      --bg-tertiary: #0e121a;
+      --bg-input: #1a2130;
       --accent: #4ecdc4;
       --accent-hover: #45b7aa;
       --accent-glow: rgba(78, 205, 196, 0.3);
-      --danger: #e94560;
-      --claude-orange: #da7756;
-      --claude-bg: #2d2a24;
-      --text-primary: #ffffff;
-      --text-secondary: rgba(255, 255, 255, 0.7);
-      --text-muted: rgba(255, 255, 255, 0.5);
+      --danger: #ff6b6b;
+      --claude-orange: #ff6b6b;
+      --claude-bg: #12161f;
+      --text-primary: #f0f3f7;
+      --text-secondary: rgba(240, 243, 247, 0.7);
+      --text-muted: rgba(240, 243, 247, 0.5);
       --border-radius: 12px;
       --transition: all 0.2s ease;
     }
@@ -56,10 +57,12 @@
       line-height: 1.5;
     }
 
-    /* Preview Banner */
+    /* Preview Banner — flat brand near-black bar with the poster's coral→teal top rule */
     .preview-banner {
-      background: linear-gradient(135deg, var(--danger), #ff8c00);
-      color: white;
+      background: #12161f;
+      border-top: 3px solid transparent;
+      border-image: linear-gradient(90deg, #ff6b6b 0%, #ff6b6b 34%, #4ecdc4 66%, #4ecdc4 100%) 1;
+      color: #f0f3f7;
       padding: 12px 20px;
       text-align: center;
       font-size: 14px;
@@ -69,7 +72,7 @@
       z-index: 100;
     }
     .preview-banner code {
-      background: rgba(0,0,0,0.2);
+      background: rgba(255,255,255,0.1);
       padding: 2px 8px;
       border-radius: 4px;
       font-family: monospace;
@@ -79,8 +82,8 @@
       text-decoration: underline;
     }
     .cta-strip {
-      background: rgba(15, 52, 96, 0.9);
-      border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+      background: rgba(18, 22, 31, 0.92);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
       padding: 10px 16px;
       display: flex;
       justify-content: space-between;
@@ -95,7 +98,7 @@
       flex-wrap: wrap;
     }
     .cta-links a {
-      color: #d8efff;
+      color: #dfe6ee;
       text-decoration: none;
       padding: 4px 8px;
       border: 1px solid rgba(255, 255, 255, 0.25);
@@ -108,7 +111,7 @@
       color: rgba(255, 255, 255, 0.75);
     }
     .cta-note a {
-      color: #9ee7ff;
+      color: #7fe0d6;
       text-decoration: underline;
     }
 
@@ -140,7 +143,7 @@
     .claude-logo {
       width: 36px;
       height: 36px;
-      background: linear-gradient(135deg, var(--claude-orange), #c4694a);
+      background: linear-gradient(135deg, var(--claude-orange), #e85555);
       border-radius: 10px;
       display: flex;
       align-items: center;
@@ -174,7 +177,7 @@
       transition: var(--transition);
     }
     .reset-btn:hover {
-      background: rgba(233, 69, 96, 0.2);
+      background: rgba(255, 107, 107, 0.2);
       border-color: var(--danger);
       color: var(--danger);
     }
@@ -422,7 +425,7 @@
     }
 
     .conversation-item.active {
-      background: linear-gradient(135deg, var(--accent), #3b82f6);
+      background: linear-gradient(135deg, var(--accent), #2f9d94);
     }
 
     .conversation-item.active .conv-name,
@@ -453,8 +456,8 @@
       flex-shrink: 0;
     }
 
-    .avatar.dm { background: linear-gradient(135deg, #8b5cf6, #ec4899); }
-    .avatar.channel { background: linear-gradient(135deg, #3b82f6, #06b6d4); }
+    .avatar.dm { background: rgba(255, 107, 107, 0.16); color: #ff6b6b; }
+    .avatar.channel { background: rgba(78, 205, 196, 0.16); color: #4ecdc4; }
 
     .conv-info { flex: 1; min-width: 0; }
     .conv-name { font-weight: 500; font-size: 14px; }
@@ -501,7 +504,7 @@
     .mobile-scenario-rail {
       display: none;
       padding: 14px 16px;
-      background: rgba(15, 52, 96, 0.55);
+      background: rgba(18, 22, 31, 0.6);
       border-bottom: 1px solid rgba(255, 255, 255, 0.08);
     }
 
@@ -606,7 +609,7 @@
       background: rgba(0,0,0,0.3);
       padding: 2px 6px;
       border-radius: 4px;
-      color: #f472b6;
+      color: #7fe0d6;
       font-family: monospace;
     }
 
@@ -637,7 +640,7 @@
       justify-content: center;
       font-size: 32px;
       font-weight: 700;
-      background: linear-gradient(135deg, #8b5cf6, #ec4899);
+      background: linear-gradient(135deg, #ff6b6b, #e85555);
     }
 
     .user-card h4 {
@@ -744,11 +747,11 @@
 <body>
   <!-- Preview Banner -->
   <div class="preview-banner">
-    INTERACTIVE DEMO — simulated data. Run <code>npm run web</code> for your live workspace, or try <a href="https://mcp.revasserlabs.com" style="color:#f0c246;font-weight:600">Hosted</a> — free tier (no card) live; Pro $19/mo unlocks unlimited AI tools and permanent OAuth.
+    INTERACTIVE DEMO — simulated data. Run <code>npm run web</code> for your live workspace, or try <a href="https://mcp.revasserlabs.com" style="color:#7fe0d6;font-weight:600">Hosted</a> — free tier (no card) live; Pro $19/mo unlocks unlimited AI tools and permanent OAuth.
   </div>
   <div class="cta-strip">
     <div class="cta-links">
-<a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer" style="background:rgba(240,194,70,0.18);border-color:rgba(240,194,70,0.45);color:#f0c246">Hosted</a>
+<a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer" style="background:rgba(255,107,107,0.18);border-color:rgba(255,107,107,0.45);color:#ff6b6b">Hosted</a>
       <a href="https://www.npmjs.com/package/@jtalk22/slack-mcp" target="_blank" rel="noopener noreferrer">npm Install</a>
       <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md" target="_blank" rel="noopener noreferrer">Setup Guide</a>
     </div>
@@ -970,11 +973,12 @@
     }
 
     function getColor(initials) {
+      // Brand tints only — coral / teal alternation (poster canon)
       const colors = [
-        '#8b5cf6, #ec4899',
-        '#3b82f6, #06b6d4',
-        '#f59e0b, #ef4444',
-        '#10b981, #3b82f6'
+        '#ff6b6b, #e85555',
+        '#4ecdc4, #3aa89f',
+        '#ff8a8a, #ff6b6b',
+        '#4ecdc4, #2f9d94'
       ];
       return colors[initials.charCodeAt(0) % colors.length];
     }

--- a/templates/public-pages/demo-video.html.tpl
+++ b/templates/public-pages/demo-video.html.tpl
@@ -67,7 +67,12 @@
     }
     body {
       font-family: var(--font-body);
-      background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+      /* Poster ground — near-black with faint coral (left) + teal (right) corner glows */
+      background:
+        radial-gradient(58% 46% at 14% 0%, rgba(255, 107, 107, 0.07), transparent 62%),
+        radial-gradient(58% 46% at 86% 0%, rgba(78, 205, 196, 0.07), transparent 62%),
+        linear-gradient(180deg, #0e1119 0%, #0b0e14 58%, #07090e 100%);
+      background-attachment: fixed;
       min-height: 100vh;
       display: flex;
       flex-direction: column;
@@ -80,7 +85,7 @@
       width: 100%;
     }
     h1 {
-      color: #ffffff;
+      color: #f0f3f7;
       font-size: 1.75rem;
       font-weight: 600;
       text-align: center;
@@ -89,15 +94,15 @@
       letter-spacing: -0.02em;
     }
     .subtitle {
-      color: #94a3b8;
+      color: #8d99a9;
       text-align: center;
       margin-bottom: 1.5rem;
       font-size: 1rem;
     }
     .cta-strip {
       margin: 0 auto 1rem;
-      background: rgba(15, 52, 96, 0.72);
-      border: 1px solid rgba(255, 255, 255, 0.16);
+      background: rgba(18, 22, 31, 0.82);
+      border: 1px solid rgba(255, 255, 255, 0.14);
       border-radius: 12px;
       padding: 10px 14px;
       display: flex;
@@ -113,9 +118,9 @@
       flex-wrap: wrap;
     }
     .cta-strip .links a {
-      color: #d8efff;
+      color: #dfe6ee;
       text-decoration: none;
-      border: 1px solid rgba(255, 255, 255, 0.24);
+      border: 1px solid rgba(255, 255, 255, 0.25);
       border-radius: 999px;
       padding: 4px 8px;
     }
@@ -123,10 +128,10 @@
       background: rgba(255, 255, 255, 0.08);
     }
     .cta-strip .note {
-      color: rgba(255, 255, 255, 0.82);
+      color: rgba(255, 255, 255, 0.78);
     }
     .cta-strip .note a {
-      color: #9ee7ff;
+      color: #7fe0d6;
       text-decoration: underline;
     }
     .video-wrapper {
@@ -134,12 +139,21 @@
       border-radius: 12px;
       overflow: hidden;
       box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
-      background: #0f0f1a;
+      background: #0b0e14;
     }
     video {
       width: 100%;
       display: block;
       border-radius: 12px;
+    }
+    /* Captions — tasteful lower subtitle, not a wall. Semi-opaque near-black box,
+       reduced size so an active cue never covers the demo's own input bar. */
+    video::cue {
+      font-size: 62%;
+      line-height: 1.35;
+      background-color: rgba(11, 14, 20, 0.82);
+      color: #f0f3f7;
+      font-family: "IBM Plex Sans", "Inter", "Segoe UI", sans-serif;
     }
     .chapters {
       display: flex;
@@ -151,9 +165,9 @@
     .chapter {
       font-family: var(--font-body);
       font-size: 0.8125rem;
-      color: #d8efff;
+      color: #dfe6ee;
       background: transparent;
-      border: 1px solid rgba(255, 255, 255, 0.24);
+      border: 1px solid rgba(255, 255, 255, 0.25);
       border-radius: 999px;
       padding: 5px 12px;
       cursor: pointer;
@@ -184,7 +198,7 @@
     }
     .btn-primary {
       background: #4ecdc4;
-      color: #1a1a2e;
+      color: #07090e;
     }
     .btn-primary:hover {
       background: #5eead4;
@@ -192,7 +206,7 @@
     }
     .btn-secondary {
       background: rgba(255, 255, 255, 0.1);
-      color: #ffffff;
+      color: #f0f3f7;
       border: 1px solid rgba(255, 255, 255, 0.2);
     }
     .btn-secondary:hover {
@@ -203,12 +217,12 @@
       text-align: center;
     }
     .back-link a {
-      color: #94a3b8;
+      color: #8d99a9;
       text-decoration: none;
       font-size: 0.875rem;
     }
     .back-link a:hover {
-      color: #ffffff;
+      color: #f0f3f7;
     }
 
     @media (max-width: 640px) {

--- a/templates/public-pages/demo.html.tpl
+++ b/templates/public-pages/demo.html.tpl
@@ -29,19 +29,20 @@
     :root {
       --font-heading: "Space Grotesk", "Avenir Next", "Segoe UI", sans-serif;
       --font-body: "IBM Plex Sans", "Inter", "Segoe UI", sans-serif;
-      --bg-primary: #0f0f1a;
-      --bg-secondary: #1a1a2e;
-      --bg-tertiary: #16213e;
-      --bg-input: #0f3460;
+      /* Poster canon — near-black grounds, coral emphasis, teal system/tool */
+      --bg-primary: #0b0e14;
+      --bg-secondary: #12161f;
+      --bg-tertiary: #0e121a;
+      --bg-input: #1a2130;
       --accent: #4ecdc4;
       --accent-hover: #45b7aa;
       --accent-glow: rgba(78, 205, 196, 0.3);
-      --danger: #e94560;
-      --claude-orange: #da7756;
-      --claude-bg: #2d2a24;
-      --text-primary: #ffffff;
-      --text-secondary: rgba(255, 255, 255, 0.7);
-      --text-muted: rgba(255, 255, 255, 0.5);
+      --danger: #ff6b6b;
+      --claude-orange: #ff6b6b;
+      --claude-bg: #12161f;
+      --text-primary: #f0f3f7;
+      --text-secondary: rgba(240, 243, 247, 0.7);
+      --text-muted: rgba(240, 243, 247, 0.5);
       --border-radius: 12px;
       --transition: all 0.2s ease;
     }
@@ -56,10 +57,12 @@
       line-height: 1.5;
     }
 
-    /* Preview Banner */
+    /* Preview Banner — flat brand near-black bar with the poster's coral→teal top rule */
     .preview-banner {
-      background: linear-gradient(135deg, var(--danger), #ff8c00);
-      color: white;
+      background: #12161f;
+      border-top: 3px solid transparent;
+      border-image: linear-gradient(90deg, #ff6b6b 0%, #ff6b6b 34%, #4ecdc4 66%, #4ecdc4 100%) 1;
+      color: #f0f3f7;
       padding: 12px 20px;
       text-align: center;
       font-size: 14px;
@@ -69,7 +72,7 @@
       z-index: 100;
     }
     .preview-banner code {
-      background: rgba(0,0,0,0.2);
+      background: rgba(255,255,255,0.1);
       padding: 2px 8px;
       border-radius: 4px;
       font-family: monospace;
@@ -79,8 +82,8 @@
       text-decoration: underline;
     }
     .cta-strip {
-      background: rgba(15, 52, 96, 0.9);
-      border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+      background: rgba(18, 22, 31, 0.92);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
       padding: 10px 16px;
       display: flex;
       justify-content: space-between;
@@ -95,7 +98,7 @@
       flex-wrap: wrap;
     }
     .cta-links a {
-      color: #d8efff;
+      color: #dfe6ee;
       text-decoration: none;
       padding: 4px 8px;
       border: 1px solid rgba(255, 255, 255, 0.25);
@@ -108,7 +111,7 @@
       color: rgba(255, 255, 255, 0.75);
     }
     .cta-note a {
-      color: #9ee7ff;
+      color: #7fe0d6;
       text-decoration: underline;
     }
 
@@ -140,7 +143,7 @@
     .claude-logo {
       width: 36px;
       height: 36px;
-      background: linear-gradient(135deg, var(--claude-orange), #c4694a);
+      background: linear-gradient(135deg, var(--claude-orange), #e85555);
       border-radius: 10px;
       display: flex;
       align-items: center;
@@ -174,7 +177,7 @@
       transition: var(--transition);
     }
     .reset-btn:hover {
-      background: rgba(233, 69, 96, 0.2);
+      background: rgba(255, 107, 107, 0.2);
       border-color: var(--danger);
       color: var(--danger);
     }
@@ -422,7 +425,7 @@
     }
 
     .conversation-item.active {
-      background: linear-gradient(135deg, var(--accent), #3b82f6);
+      background: linear-gradient(135deg, var(--accent), #2f9d94);
     }
 
     .conversation-item.active .conv-name,
@@ -453,8 +456,8 @@
       flex-shrink: 0;
     }
 
-    .avatar.dm { background: linear-gradient(135deg, #8b5cf6, #ec4899); }
-    .avatar.channel { background: linear-gradient(135deg, #3b82f6, #06b6d4); }
+    .avatar.dm { background: rgba(255, 107, 107, 0.16); color: #ff6b6b; }
+    .avatar.channel { background: rgba(78, 205, 196, 0.16); color: #4ecdc4; }
 
     .conv-info { flex: 1; min-width: 0; }
     .conv-name { font-weight: 500; font-size: 14px; }
@@ -501,7 +504,7 @@
     .mobile-scenario-rail {
       display: none;
       padding: 14px 16px;
-      background: rgba(15, 52, 96, 0.55);
+      background: rgba(18, 22, 31, 0.6);
       border-bottom: 1px solid rgba(255, 255, 255, 0.08);
     }
 
@@ -606,7 +609,7 @@
       background: rgba(0,0,0,0.3);
       padding: 2px 6px;
       border-radius: 4px;
-      color: #f472b6;
+      color: #7fe0d6;
       font-family: monospace;
     }
 
@@ -637,7 +640,7 @@
       justify-content: center;
       font-size: 32px;
       font-weight: 700;
-      background: linear-gradient(135deg, #8b5cf6, #ec4899);
+      background: linear-gradient(135deg, #ff6b6b, #e85555);
     }
 
     .user-card h4 {
@@ -744,7 +747,7 @@
 <body>
   <!-- Preview Banner -->
   <div class="preview-banner">
-    INTERACTIVE DEMO — simulated data. Run <code>npm run web</code> for your live workspace, or try <a href="{{CANONICAL_SITE_URL}}" style="color:#f0c246;font-weight:600">Hosted</a> — free tier (no card) live; Pro $19/mo unlocks unlimited AI tools and permanent OAuth.
+    INTERACTIVE DEMO — simulated data. Run <code>npm run web</code> for your live workspace, or try <a href="{{CANONICAL_SITE_URL}}" style="color:#7fe0d6;font-weight:600">Hosted</a> — free tier (no card) live; Pro $19/mo unlocks unlimited AI tools and permanent OAuth.
   </div>
   <div class="cta-strip">
     <div class="cta-links">
@@ -968,11 +971,12 @@
     }
 
     function getColor(initials) {
+      // Brand tints only — coral / teal alternation (poster canon)
       const colors = [
-        '#8b5cf6, #ec4899',
-        '#3b82f6, #06b6d4',
-        '#f59e0b, #ef4444',
-        '#10b981, #3b82f6'
+        '#ff6b6b, #e85555',
+        '#4ecdc4, #3aa89f',
+        '#ff8a8a, #ff6b6b',
+        '#4ecdc4, #2f9d94'
       ];
       return colors[initials.charCodeAt(0) % colors.length];
     }


### PR DESCRIPTION
Both demo wrapper pages (`demo-video.html`, `demo.html`) still carried the old navy palette while the poster, README hero, and recorded demo set had already moved to the near-black / coral / teal triad. This closes that gap so the whole public surface reads as one brand.

## What changed
- **demo-video.html** — near-black poster ground with faint coral (left) + teal (right) corner glows; `video::cue` captions now styled (near-black 82%-opacity box, 62% size so an active cue never covers the demo's own input bar); heading/subtitle/back-link on off-white + muted tokens.
- **demo.html** — root palette to poster canon; preview banner is now a flat near-black bar carrying the poster's coral→teal top rule (was a red→orange gradient); conversation + user-card avatars and the `getColor()` JS palette drop purple/pink for coral/teal alternation.
- **lib/public-pages.js** — Hosted pill/link amber → coral; npm muted grey normalized to the brand muted token.

## Verification
- `node scripts/generate-public-pages.js` re-run — no additional drift.
- Drift, banned-language, and public-surface-integrity gates all exit 0.
- Renders eyeballed at desktop 1440 and mobile 390 for both pages — zero purple/pink, captions legible, chapters intact, clean mobile wrap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refreshed demo pages with a cohesive coral, teal, and near-black visual theme.
  * Updated Hosted call-to-action links, banners, buttons, gradients, avatars, and interactive states.
  * Improved video presentation with refined backgrounds, chapter controls, and caption styling.
  * Synchronized generated and template-based public pages for consistent branding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->