### PR TITLE
README: address the incumbent + surface the Chrome-extraction internals

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ What it does <i>not</i> do: it does not evade compliance exports, DLP, or retent
 If your workspace's acceptable-use policy forbids unofficial clients, respect it — the OAuth-based <a href="https://mcp.revasserlabs.com">hosted version</a> exists for exactly that case.
 </details>
 
+<details>
+<summary><b>How is this different from korotovsky/slack-mcp-server?</b></summary>
+<br>
+
+Fair question, and worth answering plainly — the session-token trick isn't unique to this project. <a href="https://github.com/korotovsky/slack-mcp-server">korotovsky/slack-mcp-server</a> is the established one: written in Go, larger, with a broader surface (Apps, GovSlack, Group DMs, smart history fetch). If maximum feature coverage is what you want, it's a genuinely good tool — use it.
+
+This project makes a different bet — <b>zero-friction setup and a managed escape hatch</b>:
+
+<ul>
+<li><b>Tokens extract themselves.</b> korotovsky has you obtain the <code>xoxc-</code> / <code>xoxd-</code> pair by hand and paste them into env vars. On macOS, this server reads the token from Chrome's on-disk LevelDB and decrypts the cookie straight out of Chrome's own cookie store — <a href="#how-the-chrome-extraction-works">how it works</a>. Point it at your browser; there's no cookie to copy.</li>
+<li><b>A managed OAuth option.</b> Both servers use tokens locally; only this one has a hosted counterpart at <a href="https://mcp.revasserlabs.com">mcp.revasserlabs.com</a> that runs the same tools OAuth-backed — for workspaces where an unofficial client is off the table, or when you're done re-pasting tokens every two weeks.</li>
+<li><b>Credential hygiene as a mode.</b> <code>keychain-only</code> keeps zero plaintext on disk, verified by read-back, with loud structured failures instead of a silent fallback.</li>
+</ul>
+
+Same core idea, optimized for the first five minutes and the long-run upkeep rather than raw surface area.
+</details>
+
 ---
 
 ## Watch it run
@@ -343,6 +360,15 @@ Session tokens (`xoxc-` + `xoxd-`) come from your browser. The server resolves t
 Tokens expire; the server notices before you do — proactive health monitoring, automatic refresh on macOS, warnings as tokens age out. File writes are atomic (temp → `chmod` → rename) and concurrent refreshes are mutex-locked, so nothing corrupts and no two writers clobber each other.
 
 Chrome extraction diagnoses itself: every failure names its cause — `keychain_timeout`, `no_slack_cookie_row`, `cookie_decrypt_failed`, and more, per profile — instead of one opaque error. The full failure-code table (and the Keychain timeout tunable) is in [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md).
+
+### How the Chrome extraction works
+
+No DevTools, no "paste this cookie" step — on macOS the server reads what Chrome already has on disk and decrypts it the way Chrome itself does:
+
+- **The token** (`xoxc-`) is matched out of Chrome's on-disk LevelDB (`Local Storage/leveldb`), newest record first. No live Slack tab, no AppleScript, no dev flags — it works even with Chrome closed.
+- **The cookie** (`xoxd-`) is decrypted with Chrome's own scheme. The server copies the cookie SQLite DB (WAL sidecars included, since Chrome holds a lock on the live file), reads the machine's `Chrome Safe Storage` key from the Keychain, then runs `PBKDF2(key, "saltysalt", 1003, sha1) → AES-128-CBC` to turn the `v10` blob back into your session cookie.
+
+Same decryption Chrome runs on every launch — the server just does it once, in about a second, so no cookie ever passes through your clipboard. It's [readable JavaScript](lib/token-store.js) you can audit before trusting it with anything.
 
 ### Storage backends
 


### PR DESCRIPTION
Two positioning gaps a Show HN thread raises in its first ten comments — closed as one PR.

## 1. Name the incumbent (honestly)
`korotovsky/slack-mcp-server` — the established Go server using the same session-token approach — appeared nowhere in the README. A new candor `<details>` under *The trick* now answers the exact question HN will ask: it credits korotovsky's breadth (Apps, GovSlack, Group DMs, smart history), then states this project's distinct bet plainly — **automatic Chrome extraction + a managed hosted OAuth option** vs. its manual token paste and self-host-only model.

Verified live against korotovsky's 2026-07-16 push before writing: still manual-token env vars, no managed service — so the differentiation is accurate today. (Re-verify at launch: if they ship auto-extraction, move 1's novelty claim weakens.)

## 2. Surface the engineering
The strongest, genuinely-novel detail — decrypting Chrome's own cookie store — was invisible. New **How the Chrome extraction works** subsection under token storage: `xoxc-` token from on-disk LevelDB (no live tab, no AppleScript, works with Chrome closed), `xoxd-` cookie via Chrome's exact `PBKDF2(…, "saltysalt", 1003, sha1) → AES-128-CBC` `v10` scheme, linking the readable `lib/token-store.js`. This is the launch's lead engineering story.

## Verification
- Banned-language, public-surface-integrity, and generated-page drift gates all exit 0.
- Anchor `#how-the-chrome-extraction-works` matches the new heading; incumbent block links to it.
- +26 lines, README only, no tool/count changes.

## One strategic call for review
Naming a larger competitor in your own README is a real positioning decision (it sends some traffic their way). The frontier-advisor read: HN makes the comparison regardless, so framing it first beats being framed. Easy to revert if you'd rather not — the engineering section stands on its own either way.