### PR TITLE
README: name the hosted brain's fourth inference tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ Set each one up once: `npx -y @jtalk22/slack-mcp --setup --profile work`. When t
 
 ## Hosted (optional — the OSS package is complete without it)
 
-Everything above is free, MIT-licensed, and runs entirely on your machine. The hosted brain at [mcp.revasserlabs.com](https://mcp.revasserlabs.com) exists for exactly two things the OSS package deliberately doesn't do: **AI summarization** (`smart_search`, `catch_me_up`, `triage`) and **permanent OAuth** (no 2-week token rotation). If you don't want either, you never need it. The OSS server is complete; hosted earns its keep when the workflow has to run tomorrow — on a schedule, without a token to babysit.
+Everything above is free, MIT-licensed, and runs entirely on your machine. The hosted brain at [mcp.revasserlabs.com](https://mcp.revasserlabs.com) exists for exactly two things the OSS package deliberately doesn't do: **AI summarization** (`smart_search`, `catch_me_up`, `triage`, plus a hosted-native fourth tool `slack_workflow_brief` that renders a saved profile into a contract-validated brief) and **permanent OAuth** (no 2-week token rotation). If you don't want either, you never need it. The OSS server is complete; hosted earns its keep when the workflow has to run tomorrow — on a schedule, without a token to babysit.
 
 | Tier | Price | What it adds |
 | ---- | ----- | ------------ |


### PR DESCRIPTION
The Hosted section listed three inference tools (`smart_search`, `catch_me_up`, `triage`) — the three that ship in this package as discoverable upgrade stubs. The hosted brain actually runs a **fourth**, `slack_workflow_brief`, which renders a saved workflow profile into a contract-validated brief and has no OSS stub.

Naming it keeps the OSS and hosted surfaces telling the same story — the hosted site now says the same thing.

**The tool table is unchanged** — this package still ships exactly 21 tools. One-sentence clarification, prose only.

Language, integrity, and drift gates all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated hosted-service documentation to include the new `slack_workflow_brief` tool.
  * Clarified that hosted workflows can generate contract-validated briefs from saved workflow profiles, alongside AI summarization and permanent OAuth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->