### PR TITLE
fix(demo): lead with List Channels; reframe the key scenario as self-directed retrieval

### DIFF
--- a/public/demo.html
+++ b/public/demo.html
@@ -785,13 +785,6 @@
       <div class="try-buttons">
         <h4>Try a Scenario</h4>
         <div class="scenarios">
-          <button class="scenario-btn" onclick="runScenario('findKey')" id="btn-findKey">
-            <span class="icon">🔑</span>
-            <div class="text">
-              <div class="title">Find the API Key</div>
-              <div class="desc">Search DMs for sensitive information</div>
-            </div>
-          </button>
           <button class="scenario-btn" onclick="runScenario('listChannels')" id="btn-listChannels">
             <span class="icon">📋</span>
             <div class="text">
@@ -804,6 +797,13 @@
             <div class="text">
               <div class="title">Who is Alex?</div>
               <div class="desc">Look up user profile and activity</div>
+            </div>
+          </button>
+          <button class="scenario-btn" onclick="runScenario('findKey')" id="btn-findKey">
+            <span class="icon">🔑</span>
+            <div class="text">
+              <div class="title">Find That Key You Sent</div>
+              <div class="desc">Search your own DMs for something you shared</div>
             </div>
           </button>
         </div>

--- a/templates/public-pages/demo.html.tpl
+++ b/templates/public-pages/demo.html.tpl
@@ -783,13 +783,6 @@
       <div class="try-buttons">
         <h4>Try a Scenario</h4>
         <div class="scenarios">
-          <button class="scenario-btn" onclick="runScenario('findKey')" id="btn-findKey">
-            <span class="icon">🔑</span>
-            <div class="text">
-              <div class="title">Find the API Key</div>
-              <div class="desc">Search DMs for sensitive information</div>
-            </div>
-          </button>
           <button class="scenario-btn" onclick="runScenario('listChannels')" id="btn-listChannels">
             <span class="icon">📋</span>
             <div class="text">
@@ -802,6 +795,13 @@
             <div class="text">
               <div class="title">Who is Alex?</div>
               <div class="desc">Look up user profile and activity</div>
+            </div>
+          </button>
+          <button class="scenario-btn" onclick="runScenario('findKey')" id="btn-findKey">
+            <span class="icon">🔑</span>
+            <div class="text">
+              <div class="title">Find That Key You Sent</div>
+              <div class="desc">Search your own DMs for something you shared</div>
             </div>
           </button>
         </div>


### PR DESCRIPTION
The unlinked-but-reachable public/demo.html opened with 'Find the API Key —
Search DMs for sensitive information', which hands a Show HN audience the
shadow-IT headline the README's session-scope framing carefully avoids.
The mock transcript already shows the operator retrieving a key THEY sent,
so the scenario is honestly self-directed — now titled that way ('Find That
Key You Sent — search your own DMs for something you shared') and demoted
to last; List Channels leads.

Template + generated output committed together; integrity gate green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Renamed the API key demo scenario to “Find That Key You Sent.”
  * Updated its description to clarify that it searches the user’s own direct messages for previously shared information.
  * Repositioned the scenario after the channel and user scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->