### PR TITLE
fix(readme): hosted pointer at the install decision point

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ docker pull ghcr.io/jtalk22/slack-mcp-server:latest
 
 Full walkthrough — including the optional keep-tokens-fresh LaunchAgent — in **[docs/SETUP.md](docs/SETUP.md)**.
 
+Rather skip local token setup entirely? The optional **[hosted tier](https://mcp.revasserlabs.com)** runs the same tool surface with permanent OAuth — no token rotation — and a free tier with no card. Details in [Hosted](#hosted-optional--the-oss-package-is-complete-without-it) below; the OSS package stays complete without it.
+
 ---
 
 ## The 21 tools


### PR DESCRIPTION
The hosted tier sat at 95.6% of README depth as plain inline text — a
reader at peak intent (just installed, or just balked at token setup)
never saw it. One compact line after the Install walkthrough, keeping
the candor framing: same tool surface, permanent OAuth, free tier, and
the OSS package stays complete without it. The full Hosted section and
its pricing table stay where they are.
