### PR TITLE
release: v4.6.1 prep — worker tool parity, registry copy fix, description parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.6.1] - 2026-08-04
+
+### Shelf Repair — the discovery surfaces catch up to the product
+
+No runtime changes to the stdio server. This release refreshes every surface a
+new user meets before their first `npx`: the hosted-eval worker, the MCP
+registry metadata, and the demo pages.
+
+### Changed
+- **Hosted-eval worker reaches tool parity + the upgrade path** (`workers/mcp-worker.js`) —
+  the Smithery/hosted-eval worker now exposes 19 tools: the full 16-tool Slack
+  read/write surface plus the 3 discoverable hosted upgrade stubs
+  (`slack_smart_search`, `slack_catch_me_up`, `slack_triage`) with the same
+  `tool_requires_hosted` payload the stdio server returns. Deployed to a fresh
+  script name (`slack-mcp-oss`); `compatibility_date` bumped 2024-01-01 → 2026-08-01.
+- **MCP registry description no longer reads as paid-only** (`server.json`) —
+  "Free OSS + hosted tier from $19/mo" was being mirrored by downstream
+  directories as "no free tier or trial available" for the hosted remote.
+  Now: free OSS AND a hosted free tier, stated separately.
+- **Smithery listing copy refreshed** (`smithery.yaml` + live listing) — stale
+  "$9/mo Pro" corrected to $19/mo; description leads with session-tokens-not-OAuth
+  and names the hosted tier.
+- **Interactive demo no longer opens on a secrets-mining frame**
+  (`public/demo.html`) — "Find the API Key — search DMs for sensitive
+  information" reframed as self-directed retrieval and demoted to last;
+  List Channels leads.
+- **README surfaces the hosted option at the install decision point** — one
+  compact pointer after the Install walkthrough; the candor framing stays.
+
 ## [4.6.0] - 2026-07-22
 
 ### Workspace Profiles + Chrome Extraction Overhaul

--- a/glama.json
+++ b/glama.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "name": "slack-mcp-server",
-  "description": "Slack MCP without OAuth \u2014 21 tools, session-based, local-first. Free OSS + hosted tier from $19/mo.",
+  "description": "Slack MCP without OAuth — 21 tools, session-based. Free OSS; hosted has a free tier, Pro $19/mo.",
   "repository": "https://github.com/jtalk22/slack-mcp-server",
   "homepage": "https://mcp.revasserlabs.com",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "license": "MIT",
   "maintainers": [
     "jtalk22"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jtalk22/slack-mcp",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jtalk22/slack-mcp",
-      "version": "4.6.0",
+      "version": "4.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@jtalk22/slack-mcp",
   "mcpName": "io.github.jtalk22/slack-mcp-server",
-  "version": "4.6.0",
-  "description": "Slack MCP without OAuth — 21 tools, session-based, local-first. Free OSS + hosted tier from $19/mo.",
+  "version": "4.6.1",
+  "description": "Slack MCP without OAuth — 21 tools, session-based. Free OSS; hosted has a free tier, Pro $19/mo.",
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/jtalk22"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.jtalk22/slack-mcp-server",
   "title": "Slack MCP Server",
-  "description": "Slack MCP without OAuth \u2014 21 tools, session-based, local-first. Free OSS + hosted tier from $19/mo.",
+  "description": "Slack MCP without OAuth — 21 tools, session-based. Free OSS; hosted has a free tier, Pro $19/mo.",
   "websiteUrl": "https://mcp.revasserlabs.com",
   "icons": [
     {
@@ -17,7 +17,7 @@
     "url": "https://github.com/jtalk22/slack-mcp-server",
     "source": "github"
   },
-  "version": "4.6.0",
+  "version": "4.6.1",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
     {
       "registryType": "npm",
       "identifier": "@jtalk22/slack-mcp",
-      "version": "4.6.0",
+      "version": "4.6.1",
       "transport": {
         "type": "stdio"
       },

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,7 +1,8 @@
 # Smithery configuration for slack-mcp-server
 # https://smithery.ai/docs/build/project-config/smithery-yaml
-# Slack MCP — free OSS or hosted (free tier + $9/mo Pro). 21 tools:
-# read/write Slack + workflow profile primitives + AI brain via hosted upgrade.
+# Slack MCP — session tokens, not OAuth: no app to register, no admin approval.
+# 21 tools: Slack read/write + workflow-profile primitives + discoverable AI
+# upgrade stubs (hosted tier at mcp.revasserlabs.com — free tier, $19/mo Pro).
 
 startCommand:
   type: stdio

--- a/workers/mcp-worker.js
+++ b/workers/mcp-worker.js
@@ -234,8 +234,61 @@ const TOOLS = [
       required: ["query"]
     },
     annotations: { title: "Search Users", readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true }
+  },
+  {
+    name: "slack_smart_search",
+    description: "Semantic + lexical hybrid search across your indexed Slack history. Returns ranked results with relevance scores, channel context, thread context, and matched terms. Hosted-only (requires Vectorize + Workers AI). Free tier ships 25 AI tool calls/month (shared across the hosted AI tools); upgrade to Pro $19/mo for unlimited at mcp.revasserlabs.com/pricing.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Natural language or keyword query (semantic + lexical hybrid)" },
+        channel_ids: { type: "array", items: { type: "string" }, description: "Optional — restrict search to these channel IDs" },
+        days_back: { type: "number", description: "Optional — restrict search to the last N days (max 90 on Pro+, 7 on Free)" },
+        limit: { type: "number", description: "Maximum results to return (default 10, max 50)" }
+      },
+      required: ["query"]
+    },
+    annotations: { title: "Smart Search (hosted)", readOnlyHint: true, idempotentHint: true, openWorldHint: true }
+  },
+  {
+    name: "slack_catch_me_up",
+    description: "Run a structured catch-up against a saved workflow profile. Returns structured JSON per the profile's workflow_kind: support_inbox returns {open_threads, ack_lag, owner_gaps, escalations, next_actions}; incident_room returns {incident_summary, timeline, open_risks, owner_gaps, next_actions}; exec_brief returns {summary, decisions, risks, asks, action_items}; product_launch_watch returns {launch_signals, feedback_themes, blockers, metrics, next_actions}; custom returns {summary, highlights, open_questions, next_actions}. Hosted-only. Free tier ships 25 AI tool calls/month (shared across the hosted AI tools); Pro $19/mo unlocks unlimited.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        profile_name: { type: "string", description: "Name of a workflow profile saved via slack_workflow_save" },
+        since: { type: "string", description: "Optional ISO8601 timestamp — only consider Slack messages newer than this. Default: 24 hours ago for daily-cadence profiles, 7 days for weekly." }
+      },
+      required: ["profile_name"]
+    },
+    annotations: { title: "Catch Me Up (hosted)", readOnlyHint: true, idempotentHint: false, openWorldHint: true }
+  },
+  {
+    name: "slack_triage",
+    description: "Classify and route Slack threads against a workflow profile. Returns triage decisions per thread: priority (low|medium|high|urgent), suggested owner, escalation flag, time-sensitivity, and a routing recommendation. Hosted-only. Free tier ships 25 AI tool calls/month (shared across the hosted AI tools); Pro $19/mo unlocks unlimited.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        profile_name: { type: "string", description: "Name of a workflow profile saved via slack_workflow_save" },
+        channel_ids: { type: "array", items: { type: "string" }, description: "Optional — restrict triage to these channels (defaults to profile's channels)" },
+        thread_ts: { type: "string", description: "Optional — triage a specific thread instead of the full inbox" }
+      },
+      required: ["profile_name"]
+    },
+    annotations: { title: "Triage (hosted)", readOnlyHint: true, idempotentHint: false, openWorldHint: true }
   }
 ];
+
+// Mirrors HOSTED_UPGRADE_PAYLOAD in lib/handlers.js — the worker is a
+// standalone file with no lib/ imports, so the payload is inlined.
+const HOSTED_UPGRADE_PAYLOAD = {
+  error: "tool_requires_hosted",
+  message: "This tool needs hosted mode (Vectorize + Workers AI). Get free monthly credits at mcp.revasserlabs.com — no card required.",
+  signup_url: "https://mcp.revasserlabs.com/signup",
+  upgrade_url: "https://mcp.revasserlabs.com/pricing",
+  free_tier_quota: "2,000 requests/mo + 25 AI tool calls/mo (no card)",
+  pro_value_prop: "Pro $19/mo unlocks unlimited requests and AI tool calls, permanent OAuth (no token rotation).",
+};
 
 // Slack API methods that require form-encoded params instead of JSON.
 const FORM_ENCODED_METHODS = new Set([
@@ -551,6 +604,19 @@ async function handleToolCall(name, args, env, queryParams) {
           users: matches.slice(0, limit)
         }, null, 2) }] };
       }
+      case "slack_smart_search":
+      case "slack_catch_me_up":
+      case "slack_triage":
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              ...HOSTED_UPGRADE_PAYLOAD,
+              requested: { tool: name, args: args || {} }
+            }, null, 2)
+          }],
+          isError: true
+        };
       default:
         return {
           content: [{

--- a/workers/wrangler.toml
+++ b/workers/wrangler.toml
@@ -1,6 +1,6 @@
 name = "slack-mcp-server"
 main = "mcp-worker.js"
-compatibility_date = "2024-01-01"
+compatibility_date = "2026-08-01"
 
 # Secrets (set via `wrangler secret put SLACK_TOKEN`)
 # SLACK_TOKEN = xoxc-...


### PR DESCRIPTION
- workers/mcp-worker.js: 16 -> 19 tools (adds the 3 hosted upgrade stubs
  with the stdio server's tool_requires_hosted payload); compat date bump.
  Deployed live as slack-mcp-oss (the old slack-mcp-server script name is
  occupied by a MatterCoordinator Durable Object and must not be overwritten).
- server.json / package.json / glama.json: description no longer reads as
  paid-only — downstream directories were mirroring 'no free tier or trial'
  for the hosted remote. Three-way parity enforced by the integrity gate.
- smithery.yaml: stale $9/mo corrected to $19/mo; description leads with
  session-tokens-not-OAuth and names the hosted tier.
- CHANGELOG 4.6.1 entry; versions bumped in all parity surfaces.

Gates: integrity + language + version-parity + full test suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hosted-only tools for smart search, catch-up summaries, and Slack triage.
  * Added clear upgrade guidance when hosted-only tools are requested from unsupported environments.

* **Documentation**
  * Updated setup and service descriptions to clarify hosted availability, pricing, authentication, and tool coverage.
  * Refreshed demo content and ordering, and added a README pointer to the hosted option.

* **Chores**
  * Updated the release version to 4.6.1 and refreshed platform compatibility metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->