### PR TITLE
fix(ci): harden Dependabot and refresh audit lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x, 26.x]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -38,7 +38,7 @@ jobs:
         run: npm test
 
       - name: Verify npm install flow
-        if: matrix.node-version == '20.x'
+        if: matrix.node-version == '24.x'
         run: node scripts/verify-install-flow.js
 
   lint:
@@ -50,7 +50,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'npm'
 
       - name: Install dependencies
@@ -74,6 +74,9 @@ jobs:
       - name: Check attribution guardrail regression
         run: node scripts/verify-attribution-guardrail.js
 
+      - name: Check Dependabot auto-merge guardrail
+        run: node scripts/verify-dependabot-auto-merge.js
+
       - name: Check public surface integrity
         run: node scripts/check-public-surface-integrity.js
 
@@ -86,7 +89,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
-          node-version: "20.x"
+          node-version: "24.x"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,7 +12,12 @@ jobs:
   auto-merge:
     name: Auto-Merge Safe Updates
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    # The PR author stays dependabot[bot] after a maintainer pushes to its branch.
+    # Require the event actor too so unsigned maintainer commits skip this job
+    # instead of failing Dependabot's intentionally strict signature check.
+    if: |
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.actor == 'dependabot[bot]'
     steps:
       - name: Dependabot metadata
         id: metadata
@@ -22,18 +27,14 @@ jobs:
 
       - name: Auto-merge patch updates
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: |
-          gh pr review --approve "$PR_URL" --body "Auto-approved: patch dependency update" || echo "::notice::Approval skipped"
-          gh pr merge --auto --squash "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ github.token }}
 
       - name: Auto-merge GitHub Actions updates
         if: steps.metadata.outputs.package-ecosystem == 'github-actions'
-        run: |
-          gh pr review --approve "$PR_URL" --body "Auto-approved: GitHub Actions update" || echo "::notice::Approval skipped"
-          gh pr merge --auto --squash "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ github.token }}
@@ -42,20 +43,20 @@ jobs:
         if: |
           steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
           steps.metadata.outputs.dependency-type == 'direct:development'
-        run: |
-          gh pr review --approve "$PR_URL" --body "Auto-approved: minor development dependency update" || echo "::notice::Approval skipped"
-          gh pr merge --auto --squash "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ github.token }}
 
       - name: Summary
         run: |
-          echo "## Dependabot Auto-Merge" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Package | ${{ steps.metadata.outputs.dependency-names }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Update type | ${{ steps.metadata.outputs.update-type }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Ecosystem | ${{ steps.metadata.outputs.package-ecosystem }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Dependency type | ${{ steps.metadata.outputs.dependency-type }} |" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Dependabot Auto-Merge"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Package | ${{ steps.metadata.outputs.dependency-names }} |"
+            echo "| Update type | ${{ steps.metadata.outputs.update-type }} |"
+            echo "| Ecosystem | ${{ steps.metadata.outputs.package-ecosystem }} |"
+            echo "| Dependency type | ${{ steps.metadata.outputs.dependency-type }} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,12 +31,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "bookmarklet": "node scripts/generate-bookmarklet.js",
     "cf:browser": "node scripts/cloudflare-browser-tool.js",
     "verify:attribution-guardrail": "node scripts/verify-attribution-guardrail.js",
+    "verify:dependabot-auto-merge": "node scripts/verify-dependabot-auto-merge.js",
     "verify:public-pages": "node scripts/verify-generated-public-pages.js",
     "verify:version-parity": "node scripts/check-version-parity.js",
     "verify:public-surface": "node scripts/check-public-surface-integrity.js",

--- a/scripts/verify-dependabot-auto-merge.js
+++ b/scripts/verify-dependabot-auto-merge.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const WORKFLOW_PATH = resolve(ROOT, ".github", "workflows", "dependabot-auto-merge.yml");
+const workflow = readFileSync(WORKFLOW_PATH, "utf8");
+
+const checks = [
+  {
+    label: "PR author must be Dependabot",
+    ok: workflow.includes("github.event.pull_request.user.login == 'dependabot[bot]'"),
+  },
+  {
+    label: "workflow actor must be Dependabot",
+    ok: workflow.includes("github.actor == 'dependabot[bot]'"),
+  },
+  {
+    label: "both identities must be required by the same job condition",
+    ok: /if:\s*\|[\s\S]*?pull_request\.user\.login == 'dependabot\[bot\]'\s*&&[\s\S]*?github\.actor == 'dependabot\[bot\]'/m.test(workflow),
+  },
+  {
+    label: "Dependabot metadata verification must remain enabled",
+    ok: workflow.includes("dependabot/fetch-metadata@") && !workflow.includes("skip-commit-verification"),
+  },
+  {
+    label: "Actions must not attempt to approve their own PR",
+    ok: !workflow.includes("gh pr review"),
+  },
+  {
+    label: "eligible updates must use auto-merge",
+    ok: workflow.includes('gh pr merge --auto --squash "$PR_URL"'),
+  },
+];
+
+let failed = false;
+for (const check of checks) {
+  const status = check.ok ? "PASS" : "FAIL";
+  console.log(`${status} ${check.label}`);
+  failed ||= !check.ok;
+}
+
+if (failed) {
+  process.exitCode = 1;
+} else {
+  console.log("Dependabot auto-merge guardrail verified.");
+}


### PR DESCRIPTION
## What changed

- resolve the root `@hono/node-server` advisory through the supported MCP SDK dependency range
- require both the Dependabot PR author and Dependabot workflow actor before auto-merge metadata runs
- preserve strict Dependabot commit verification while skipping maintainer-authored branch synchronizations
- remove the ineffective Actions self-approval step
- add a regression guard for the workflow policy
- expand CI coverage to Node 20, 22, 24, and 26; run browser/install proof on Node 24

## Verification

- `npm test` — 55 pass, 2 intentionally skipped
- `npm audit --audit-level=moderate` — 0 vulnerabilities
- `npm --prefix workers/browser-ops audit --audit-level=moderate` — 0 vulnerabilities
- `npm run verify:dependabot-auto-merge` — pass
- `npm run verify:public-pages` — pass
- `npm run verify:public-surface` — pass
- `actionlint .github/workflows/ci.yml .github/workflows/dependabot-auto-merge.yml` — pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration coverage for Node.js 20, 22, 24, and 26.
  * Standardized linting and browser checks on Node.js 24.
  * Added safeguards for automated dependency update merges.

* **Tests**
  * Added verification checks for automated merge workflow permissions, identity, and guardrails.
  * Added an npm command to run these checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->