### PR TITLE
fix(registry): server.json description within the 100-char MCP registry cap

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "name": "slack-mcp-server",
-  "description": "Slack’s operating layer for AI agents: DMs, search, full threads, unread triage, actions, and workflows—local browser-session auth or hosted permanent OAuth.",
+  "description": "Slack for AI agents: DMs, search, threads, triage, actions - browser-session or hosted OAuth.",
   "repository": "https://github.com/jtalk22/slack-mcp-server",
   "homepage": "https://mcp.revasserlabs.com",
   "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@jtalk22/slack-mcp",
   "mcpName": "io.github.jtalk22/slack-mcp-server",
   "version": "4.6.2",
-  "description": "Slack’s operating layer for AI agents: DMs, search, full threads, unread triage, actions, and workflows—local browser-session auth or hosted permanent OAuth.",
+  "description": "Slack for AI agents: DMs, search, threads, triage, actions - browser-session or hosted OAuth.",
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/jtalk22"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.jtalk22/slack-mcp-server",
   "title": "Slack MCP Server",
-  "description": "Slack’s operating layer for AI agents: DMs, search, full threads, unread triage, actions, and workflows—local browser-session auth or hosted permanent OAuth.",
+  "description": "Slack for AI agents: DMs, search, threads, triage, actions - browser-session or hosted OAuth.",
   "websiteUrl": "https://mcp.revasserlabs.com",
   "icons": [
     {


### PR DESCRIPTION
MCP registry rejected v4.6.2 with 422: description length 149 > 100. Shortened to 93 chars. npm publish itself succeeded; after merge the release re-run publishes the registry entry (npm step skips via the already-published guard).