### PR TITLE
feat(readme): half the visible length, none of the story — registry-metadata unification

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,5 @@ node_modules
 !README.md
 .env
 .DS_Store
+# Marketing video renditions are canonical on GitHub Pages; keep the image lean.
+docs/videos

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -120,6 +120,31 @@ jobs:
           echo "npm version $VERSION not visible after 10 attempts" >&2
           exit 1
 
+      - name: Verify live npm description matches package.json
+        if: steps.npm_check.outputs.already_published != 'true'
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          # npm metadata is immutable per version; a stale description on the live
+          # surface can only heal on the next publish. Catch the mismatch NOW,
+          # while this run can still be diagnosed, instead of months later.
+          EXPECTED="$(jq -r '.description' package.json)"
+          for i in $(seq 1 10); do
+            LIVE="$(npm view "@jtalk22/slack-mcp@$VERSION" description 2>/dev/null || true)"
+            if [[ "$LIVE" == "$EXPECTED" ]]; then
+              echo "Live npm description matches package.json."
+              exit 0
+            fi
+            echo "Live description not settled yet (attempt $i/10); waiting 15s..."
+            sleep 15
+          done
+          echo "Live npm description does not match package.json after 10 attempts." >&2
+          echo "expected: $EXPECTED" >&2
+          echo "live:     $LIVE" >&2
+          exit 1
+
       - name: Publish to MCP registry
         if: steps.registry_check.outputs.already_published != 'true'
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.7.0] - 2026-08-07
+
+### The OS comes back
+
+No MCP tool contracts changed. This release re-stages the public surface as
+what made it work in the first place—the fiction of a running application—and
+unifies every generated page on one design-token vocabulary.
+
+### Changed
+
+- **One token vocabulary** — `lib/public-pages.js` now emits a byte-identical
+  `:root` block (`{{DESIGN_TOKENS}}`) and parameterized `@font-face` rules
+  (`{{FONT_FACES}}`) into all six generated pages; CI asserts the canonical
+  block on every page and bans retired token names in templates.
+- **Proof reel re-shot as a screen-recording fiction** — the whole 42-second
+  reel now lives inside one persistent faux-macOS window on a midnight-blue
+  desktop: traffic lights, tools chip, fake input bar, timecode ticker. Grain
+  overlay, solid full-bleed poster scenes, and italic-serif numerals removed;
+  the system register (success green, link blue, clay assistant accent)
+  returns inside app chrome. Scene marks, still branches, and the
+  deterministic completion contract are unchanged.
+- **Walkthrough restyled onto the shared vocabulary** — sans type inside the
+  window, system-register accents, midnight desk bed; every scenario,
+  control, easter egg, and the pinned narrative clock preserved.
+- **App icon** — ink square, paper hashtag, one vermilion notification-badge
+  dot (3 colors, down from 7); favicon and inline copies regenerated.
+- **README rebuilt** — roughly half the visible length; deep material moved
+  into collapsible sections with anchored headings kept visible; badge row
+  re-inked (weekly-downloads badge, estate colors, registry badge linking to
+  the live server record); Glama rating card added to Security.
+- **Registry metadata unified** — `glama.json` pruned to the schema's minimal
+  claim contract; the Docker image OCI description label now carries the
+  canonical short description (CI-enforced); the publish workflow verifies the
+  live npm description matches `package.json` after publish.
+- **Docker build context** — marketing video renditions excluded via
+  `.dockerignore`; they remain canonical on GitHub Pages.
+
 ## [4.6.2] - 2026-08-05
 
 ### The public surface catches up to the system underneath

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM node:26-alpine
 # OCI Image Labels for registry discoverability
 LABEL maintainer="jtalk22"
 LABEL org.opencontainers.image.title="Slack MCP Server"
-LABEL org.opencontainers.image.description="Full Slack access for Claude - DMs, channels, search. No OAuth. No admin approval. Just works."
+LABEL org.opencontainers.image.description="Slack for AI agents: DMs, search, threads, triage, actions - browser-session or hosted OAuth."
 LABEL org.opencontainers.image.source="https://github.com/jtalk22/slack-mcp-server"
 LABEL org.opencontainers.image.url="https://github.com/jtalk22/slack-mcp-server"
 LABEL org.opencontainers.image.documentation="https://github.com/jtalk22/slack-mcp-server#readme"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![npm version](https://img.shields.io/npm/v/@jtalk22/slack-mcp?style=flat-square&logo=npm&logoColor=white&label=npm&color=cb3837)](https://www.npmjs.com/package/@jtalk22/slack-mcp)&nbsp;[![npm total downloads](https://img.shields.io/npm/dt/%40jtalk22%2Fslack-mcp?style=flat-square&label=total%20downloads&color=555)](https://www.npmjs.com/package/@jtalk22/slack-mcp)&nbsp;[![CI](https://img.shields.io/github/actions/workflow/status/jtalk22/slack-mcp-server/ci.yml?style=flat-square&logo=githubactions&logoColor=white&label=CI)](https://github.com/jtalk22/slack-mcp-server/actions/workflows/ci.yml)&nbsp;[![npm provenance signed](https://img.shields.io/badge/provenance-signed-4ecdc4?style=flat-square&logo=npm&logoColor=white)](#provenance-dont-take-my-word-for-it)&nbsp;[![MCP Registry](https://img.shields.io/badge/MCP_Registry-listed-3b82f6?style=flat-square)](https://registry.modelcontextprotocol.io)
+[![npm version](https://img.shields.io/npm/v/@jtalk22/slack-mcp?style=flat-square&logo=npm&logoColor=white&label=npm&labelColor=0b0b0c&color=e5482f)](https://www.npmjs.com/package/@jtalk22/slack-mcp)&nbsp;[![npm weekly downloads](https://img.shields.io/npm/dw/%40jtalk22%2Fslack-mcp?style=flat-square&label=weekly%20downloads&labelColor=0b0b0c&color=ffb224)](https://www.npmjs.com/package/@jtalk22/slack-mcp)&nbsp;[![CI](https://img.shields.io/github/actions/workflow/status/jtalk22/slack-mcp-server/ci.yml?style=flat-square&logo=githubactions&logoColor=white&label=CI&labelColor=0b0b0c)](https://github.com/jtalk22/slack-mcp-server/actions/workflows/ci.yml)&nbsp;[![npm provenance signed](https://img.shields.io/badge/provenance-signed-e5482f?style=flat-square&labelColor=0b0b0c)](#provenance-dont-take-my-word-for-it)&nbsp;[![MCP Registry](https://img.shields.io/badge/MCP_Registry-listed-ffb224?style=flat-square&labelColor=0b0b0c)](https://registry.modelcontextprotocol.io/v0/servers/io.github.jtalk22%2Fslack-mcp-server/versions/latest)
 
 <div align="center">
 
@@ -8,11 +8,7 @@
 
 <h1>Slack MCP Server</h1>
 
-<h2>Ask what happened. Get receipts. Close the loop.</h2>
-
-<p>Turn Slack from an interruption stream into searchable operating memory and approved action. The open-source local path ships <strong>21 tools today</strong> through the browser session you already have—no Slack app, scope review, or admin queue. Hosted adds permanent OAuth, indexing, scheduled intelligence, and team continuity when the workflow must run without you.</p>
-
-<p><strong>If you can read it in Slack, your agent can read it too.</strong></p>
+<p>Slack for AI agents: DMs, search, threads, triage, actions — browser-session or hosted OAuth.</p>
 
 </div>
 
@@ -45,32 +41,19 @@ npx -y @jtalk22/slack-mcp --setup
 
 ## It’s Monday, 9:07. Slack has already formed opinions.
 
-The demo starts where a real workday starts: unread DMs, an incident channel, product chatter, and engineering follow-ups competing for attention.
-
-| Signal | What the agent does | What comes back |
-|---|---|---|
-| `23 unread` in `#incidents` | Reads the relevant history and thread | The P1, owner, resolution, and remaining risk |
-| A five-month printer mystery | Searches across the workspace | The exact `#facilities` message, with channel and context |
-| A thread that needs closure | Replies, reacts, or marks it read | The loop is closed without opening Slack |
+You ask “what blew up overnight?” and the agent reads the workspace instead of you. It reconstructs the 2 AM P1 from `#incidents`—owner, resolution, and the runbook step that is still wrong. It finds the printer PIN that has been waiting in `#facilities` for five months. Then it closes the handled loops—replies, reactions, read-state changes—only where you approve.
 
 This is not screenshot automation. The agent calls Slack through a real MCP tool surface and receives typed results it can search, summarize, export, or act on.
 
 ---
 
-## From one question to recurring operations
-
-| Who | Job to be done | Best starting path |
-|---|---|---|
-| Developer or solo operator | Give an agent real Slack context and approved actions now, without waiting on app governance | **Local / MIT** |
-| Engineering or operations lead | Reconstruct incidents, recover decisions, hand off ownership, and clear the morning queue | **Local or Hosted** |
-| Support, product, or executive team | Turn channel sets into typed support, launch, incident, or executive briefs | **Hosted for schedules and indexing** |
-| Business running unattended workflows | Keep retrieval and briefs alive across token rotation, users, and workspaces | **Hosted / permanent OAuth** |
-
-The local product is complete, not a crippled trial. Hosted earns the upgrade through continuity, intelligence, and collaboration—not by holding ordinary Slack access hostage.
-
----
-
 ## Built past the demo
+
+The difficult part is not another chat tool. It is the operating layer underneath: browser-session extraction that names its failure stages, a credential lifecycle built for rotation, full-fidelity reads, guarded writes, and typed workflow output. The code is plain JavaScript in this repository—audit it before trusting it with a session.
+
+<details>
+<summary><strong>The engineering underneath — extraction, credential lifecycle, reads, guarded writes, typed output</strong></summary>
+<br>
 
 ### 1. The browser-session engine
 
@@ -82,8 +65,6 @@ The local product is complete, not a crippled trial. Hosted earns the upgrade th
 - runs Chrome-compatible PBKDF2 + AES-128-CBC decryption locally;
 - requires no DevTools, clipboard step, browser flag, or live Slack tab;
 - names the failed extraction stage—`keychain_timeout`, `no_slack_cookie_row`, `cookie_decrypt_failed`, and more—instead of returning one opaque error.
-
-The code is plain JavaScript in this repository. Audit it before trusting it with a session.
 
 ### 2. Credential lifecycle, not credential paste
 
@@ -109,15 +90,17 @@ Send a reply, add or remove a reaction, and mark a conversation read. Every work
 
 Save workflow profiles for incident rooms, executive briefs, support inboxes, launch watches, and custom operations. The OSS primitives are local JSON; the optional hosted brain renders them into contract-shaped briefs.
 
+</details>
+
 ---
 
 ## Two ways into Slack
 
-Slack already knows who you are. The question is how your agent gets there.
+Slack already knows who you are. The official path is a Slack-managed remote integration governed by workspace policy—a strong fit for organization-sanctioned deployments, documented by [Slack](https://docs.slack.dev/ai/slack-mcp-server/) with integration settings under [admin control](https://docs.slack.dev/ai/slackbot-mcp-client/admin-approval/). This project is the direct local path: session-based auth from the browser session already in Chrome, local stdio, any stdio MCP client, and no Slack app or admin request. Same Slack identity. Same underlying permissions. A radically shorter path from your workspace to your agent.
 
-<div align="center">
-  <img src="docs/images/diagram-oauth-comparison.svg" width="960" alt="Two ways into Slack: an admin-governed remote integration or the local browser-session path">
-</div>
+<details>
+<summary><strong>Side by side: the managed integration path vs. the local session path</strong></summary>
+<br>
 
 | | Slack official MCP | **Slack MCP Server — local** |
 |---|---|---|
@@ -130,9 +113,7 @@ Slack already knows who you are. The question is how your agent gets there.
 | Product surface | Broad Slack-native capabilities | **21 focused tools across read, act, and automate** |
 | Runtime | Slack-managed | **MIT code on your machine** |
 
-Same Slack identity. Same underlying permissions. A radically shorter path from your workspace to your agent.
-
-Slack's official surface has evolved and is a strong fit for organization-sanctioned deployments. Its current capabilities and supported clients are documented by [Slack](https://docs.slack.dev/ai/slack-mcp-server/); workspace integration settings remain under [admin control](https://docs.slack.dev/ai/slackbot-mcp-client/admin-approval/). This project is the direct local path when you need useful Slack access now, in the clients you already use.
+</details>
 
 <details>
 <summary><strong>Is the local path against Slack's terms?</strong></summary>
@@ -149,18 +130,11 @@ Treat browser-session automation as an acceptable-use decision for you and your 
 
 **Node 22 or 24 recommended. Node 20 remains supported for the v4 line.**
 
-Fastest path—run setup without installing a global command:
-
 ```bash
 npx -y @jtalk22/slack-mcp --setup
 ```
 
-Prefer a persistent CLI:
-
-```bash
-npm install -g @jtalk22/slack-mcp
-slack-mcp --setup
-```
+Prefer a persistent CLI: `npm install -g @jtalk22/slack-mcp` then `slack-mcp --setup`.
 
 Then:
 
@@ -169,17 +143,6 @@ Then:
 3. Fully restart the client.
 4. Ask the agent to run `slack_health_check`.
 5. A workspace name in the response means the connection is live.
-
-| Client | Configuration surface | Status |
-|---|---|---|
-| Claude Code | `claude mcp add` or `~/.claude.json` | Documented |
-| Claude Desktop | Desktop MCP configuration | Verified |
-| Cursor | `.cursor/mcp.json` | Documented |
-| GitHub Copilot | `.vscode/mcp.json` | Documented |
-| Windsurf | `~/.codeium/windsurf/mcp_config.json` | Documented |
-| Gemini CLI | `~/.gemini/settings.json` | Documented |
-| Codex CLI | `codex mcp add` or `~/.codex/config.toml` | Documented |
-| Other clients | Any stdio MCP configuration | Protocol-compatible |
 
 Use the same server command everywhere:
 
@@ -192,9 +155,32 @@ Use the same server command everywhere:
 
 On macOS, setup can extract from Chrome and persist the selected storage backend. On other platforms, provide `SLACK_TOKEN` and `SLACK_COOKIE` through the client's environment configuration. Docker, HTTP, and detailed client examples live in [docs/SETUP.md](docs/SETUP.md) and [docs/DEPLOYMENT-MODES.md](docs/DEPLOYMENT-MODES.md).
 
+<details>
+<summary><strong>Client configuration matrix</strong></summary>
+<br>
+
+| Client | Configuration surface | Status |
+|---|---|---|
+| Claude Code | `claude mcp add` or `~/.claude.json` | Documented |
+| Claude Desktop | Desktop MCP configuration | Verified |
+| Cursor | `.cursor/mcp.json` | Documented |
+| GitHub Copilot | `.vscode/mcp.json` | Documented |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` | Documented |
+| Gemini CLI | `~/.gemini/settings.json` | Documented |
+| Codex CLI | `codex mcp add` or `~/.codex/config.toml` | Documented |
+| Other clients | Any stdio MCP configuration | Protocol-compatible |
+
+</details>
+
 ---
 
 ## 21 tools: read, act, automate
+
+The local surface ships **21 tools** today: **12 read-only** Slack operations, **4 write-path** tools that each carry an MCP destructive annotation so clients can gate workspace writes, 2 local workflow primitives, and 3 hosted-intelligence stubs that return a structured upgrade payload without making a Slack call. Four read tools accept `include_rich_message_fields: true` to surface attachments, blocks, files, reactions, and metadata—complete inputs and response contracts live in [docs/API.md](docs/API.md).
+
+<details>
+<summary><strong>The full tool inventory</strong></summary>
+<br>
 
 ### 12 read-only Slack operations
 
@@ -202,7 +188,7 @@ On macOS, setup can extract from Chrome and persist the selected storage backend
 |---|---|
 | `slack_health_check` | Verify credentials and workspace identity |
 | `slack_token_status` | Inspect credential age, health, cache, profile, and storage state |
-| `slack_refresh_tokens` | Refresh local credentials from the browser session on macOS*—reads Slack, writes only local state |
+| `slack_refresh_tokens` | Refresh local credentials from the browser session on macOS—reads Slack, writes only local state |
 | `slack_list_conversations` | List channels and DMs |
 | `slack_conversations_history` | Read channel or DM history with optional rich fields |
 | `slack_get_full_conversation` | Export complete history and threads |
@@ -237,17 +223,23 @@ On macOS, setup can extract from Chrome and persist the selected storage backend
 | `slack_catch_me_up` | Structured catch-up against a saved workflow profile |
 | `slack_triage` | Prioritized action queue with routing recommendations |
 
-The OSS stubs make the hosted capability discoverable and return a structured upgrade payload; they do not make a Slack call. `slack_refresh_tokens` only writes local credential state. Complete inputs and response contracts live in [docs/API.md](docs/API.md).
+The OSS stubs make the hosted capability discoverable; they do not make a Slack call. `slack_refresh_tokens` only writes local credential state.
+
+</details>
 
 ---
 
 ## Typed workflows: Slack in, JSON out
 
-Bind a workflow kind to channels, priority people, retention, and cadence:
+Bind a workflow kind to channels, priority people, retention, and cadence. The local profile primitives are free; hosted performs the indexed retrieval and contract-validated summarization that turn profiles into durable scheduled operations.
 
 ```bash
 npx -y @jtalk22/slack-mcp --apply-template oncall-handoff --channels C012345,C067890
 ```
+
+<details>
+<summary><strong>Workflow contracts and shipped templates</strong></summary>
+<br>
 
 | Workflow kind | Contract |
 |---|---|
@@ -259,25 +251,7 @@ npx -y @jtalk22/slack-mcp --apply-template oncall-handoff --channels C012345,C06
 
 Six editable templates ship in the package: `oncall-handoff`, `support-triage`, `exec-monday`, `sprint-tracker`, `customer-feedback`, and `incident-room`.
 
-The local profile primitives remain free. Hosted performs the indexed retrieval and contract-validated summarization required to turn those profiles into durable scheduled operations.
-
----
-
-## Rich messages are not just `text`
-
-Four read tools accept `include_rich_message_fields: true`, surfacing attachments, blocks, files, reactions, metadata, subtype, bot/app markers, and workspace identity.
-
-```json
-{
-  "ts": "1767368030.607599",
-  "user": "incident-bot",
-  "text": "",
-  "subtype": "bot_message",
-  "attachments": [{ "title": "PagerDuty", "text": "P1 — API latency > 2s" }]
-}
-```
-
-This changes output shape, not permissions. Rich fields are opt-in to protect client context. Slack search results do not carry every rich field; use search to find the hit, then history or thread tools to retrieve the full payload.
+</details>
 
 ---
 
@@ -290,6 +264,12 @@ Resolution is deterministic; first hit wins:
 3. macOS Keychain
 4. Chrome extraction on macOS
 
+Session credentials commonly rotate after one or two weeks. When Slack returns `invalid_auth`, `not_authed`, `token_expired`, `token_revoked`, `account_inactive`, or HTTP 401, run `npx -y @jtalk22/slack-mcp --setup` to recover locally. On macOS, `slack_refresh_tokens` or `--refresh-tokens` refreshes without leaving the client; the optional LaunchAgent in [docs/SETUP.md](docs/SETUP.md) keeps long-idle installations healthy.
+
+<details>
+<summary><strong>Storage modes and multi-workspace profiles</strong></summary>
+<br>
+
 | Mode | Behavior |
 |---|---|
 | `auto` | Token file plus Keychain backup |
@@ -297,16 +277,6 @@ Resolution is deterministic; first hit wins:
 | `file` | Owner-only token file; Keychain is never touched |
 
 The selected backend is remembered in non-secret metadata and used by the server, CLI, and optional refresh job. An unrecognized mode fails at startup instead of silently downgrading storage.
-
-Session credentials commonly rotate after one or two weeks. When Slack returns `invalid_auth`, `not_authed`, `token_expired`, `token_revoked`, `account_inactive`, or HTTP 401, the server gives the local recovery command first:
-
-```bash
-npx -y @jtalk22/slack-mcp --setup
-```
-
-On macOS, `slack_refresh_tokens` or `npx -y @jtalk22/slack-mcp --refresh-tokens` refreshes without leaving the client. The optional LaunchAgent in [docs/SETUP.md](docs/SETUP.md) keeps long-idle installations healthy.
-
-### Multiple workspaces
 
 ```json
 {
@@ -327,13 +297,13 @@ On macOS, `slack_refresh_tokens` or `npx -y @jtalk22/slack-mcp --refresh-tokens`
 
 Each profile gets its own token file, Keychain entries, metadata, and lock. Add `SLACK_MCP_CHROME_PROFILE` when the workspaces live in different Chrome profiles.
 
+</details>
+
 ---
 
 ## Free local when you’re driving. Hosted when it must drive itself.
 
-When local control is enough, stop here. Everything above is MIT-licensed and runs on your machine.
-
-The split is operational: local is the fastest route to control; hosted is the route to unattended business workflows. Hosted exists for work that must survive a rotating browser session:
+When local control is enough, stop here—everything above is MIT-licensed and runs on your machine. The local product is complete, not a crippled trial: hosted earns the upgrade through continuity, intelligence, and collaboration, not by holding ordinary Slack access hostage. Hosted exists for work that must survive a rotating browser session:
 
 - permanent OAuth;
 - indexed semantic search;
@@ -341,26 +311,16 @@ The split is operational: local is the fastest route to control; hosted is the r
 - contract-validated workflow briefs;
 - shared profiles and managed workspace continuity.
 
-| Tier | Price | Adds |
-|---|---:|---|
-| Self-host | Free | Current local surface—21 tools today—and workflow-profile primitives |
-| Hosted Free | $0, no card | 1 workspace, 2,000 requests/month, 25 AI calls/month, 7-day index |
-| Pro | $19/month or $190/year | Unlimited requests and AI calls under fair use, permanent OAuth, 2 workspaces |
-| Team | $49/month flat or $490/year | Shared workflow profiles, 5 workspaces, 24-hour support |
-| Safeguard | $199/month, waitlist | Approval gates, scheduled catch-up DM, workspace memory—in development |
-
 [See live hosted pricing →](https://mcp.revasserlabs.com/pricing)
 
 ---
 
 ## Security and provenance
 
-- Credential files are owner-only.
-- Keychain-only mode keeps plaintext credentials off disk.
+- Credential files are owner-only; Keychain-only mode keeps plaintext credentials off disk.
 - Configuration fails closed for unknown storage modes and invalid profiles.
 - Writes are atomic and shared credential state is process-locked.
-- The local web server binds to localhost.
-- Workspace write tools carry destructive annotations.
+- The local web server binds to localhost; workspace write tools carry destructive annotations.
 - Every release publishes from CI with npm provenance.
 
 ### Provenance: don't take my word for it
@@ -369,9 +329,9 @@ The split is operational: local is the fastest route to control; hosted is the r
 npm audit signatures
 ```
 
-A clean result verifies that the package signatures and attestations trace back through the published release chain. Inspect the package before handing it a live Slack session.
+A clean result verifies that the package signatures and attestations trace back through the published release chain. Inspect the package before handing it a live Slack session. Full policy: [SECURITY.md](SECURITY.md).
 
-Full policy: [SECURITY.md](SECURITY.md).
+<a href="https://glama.ai/mcp/servers/jtalk22/slack-mcp-server"><img src="https://glama.ai/mcp/servers/jtalk22/slack-mcp-server/badge" width="380" alt="Slack MCP Server security, license, and quality rating on Glama"></a>
 
 ---
 

--- a/REPO.md
+++ b/REPO.md
@@ -2,31 +2,34 @@
 
 **Platform:** Commercial (awareness tier)
 **Status:** Active
-**Role:** Public npm [`@jtalk22/slack-mcp`](https://www.npmjs.com/package/@jtalk22/slack-mcp). Session-based Slack MCP for Claude Code and MCP clients. Free tier that drives awareness for hosted commercial tier.
+**Role:** Public npm [`@jtalk22/slack-mcp`](https://www.npmjs.com/package/@jtalk22/slack-mcp). Session-based Slack MCP for any stdio MCP client. Free tier that drives awareness for hosted commercial tier.
 
 ## Consumers (what uses this)
-- Claude Code, Cursor, any MCP client — local-first Slack MCP
+- Claude Code, Cursor, any stdio MCP client — local-first Slack MCP
 - `revereveal/slack-mcp-dev` — private dev fork upstream ref
 - `revereveal/slack-mcp-hosted` — commercial tier derives from this
-- npm users (22 stars, downloads)
+- npm users (live downloads: https://www.npmjs.com/package/@jtalk22/slack-mcp)
 
 ## Producers (what this uses)
-- Slack API — OAuth + socket mode
+- Slack API — browser-session auth (local) / OAuth (hosted)
 - Anthropic's MCP protocol spec
 
 ## Live surfaces
 | Surface | URL | What |
 |---|---|---|
-| npm package | [npmjs.com/package/@jtalk22/slack-mcp](https://www.npmjs.com/package/@jtalk22/slack-mcp) | v3.1.0 |
+| npm package | [npmjs.com/package/@jtalk22/slack-mcp](https://www.npmjs.com/package/@jtalk22/slack-mcp) | current release (see repo tags) |
+| GitHub Pages | [jtalk22.github.io/slack-mcp-server](https://jtalk22.github.io/slack-mcp-server/) | landing + proof reel + walkthrough |
 | GitHub repo | public | README + docs |
+| MCP registry | `io.github.jtalk22/slack-mcp-server` | registry listing |
+| GHCR | `ghcr.io/jtalk22/slack-mcp-server` | container image |
 
 ## Key contacts / entry points
 - README.md — public-facing docs
-- `src/` — TypeScript source
-- Release branches as cut by `release/v*.*.*` convention
+- `src/` + `lib/` — JavaScript source (ESM)
+- `templates/public-pages/` → `lib/public-pages.js` — generated public surface
+- Releases cut from tags `v*.*.*`; publish.yml handles npm + MCP registry
 
 ## Status notes
-- 235 commits, 1d since last push. 22 stars.
 - Stays in `jtalk22/` (NOT moving to revereveal) because npm package scope is `@jtalk22/*` — namespace matches repo owner.
-- Open PR #117 `release/v4.1.2` — unshipped, 4 commits. Audit flagged for ship-or-abandon decision.
+- Star/download counts: read them live; never pin them here.
 - Uses LFS? No

--- a/docs/launch-posts.md
+++ b/docs/launch-posts.md
@@ -1,4 +1,4 @@
-# Slack MCP v4.6.2 — launch and distribution kit
+# Slack MCP — launch and distribution kit
 
 This is a copy bank, not canonical product documentation. Recheck live pricing, version, and download numbers immediately before publishing.
 

--- a/glama.json
+++ b/glama.json
@@ -1,25 +1,6 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
-  "name": "slack-mcp-server",
-  "description": "Slack for AI agents: DMs, search, threads, triage, actions - browser-session or hosted OAuth.",
-  "repository": "https://github.com/jtalk22/slack-mcp-server",
-  "homepage": "https://mcp.revasserlabs.com",
-  "version": "4.7.0",
-  "license": "MIT",
   "maintainers": [
     "jtalk22"
-  ],
-  "categories": [
-    "communication",
-    "productivity"
-  ],
-  "features": {
-    "tools": 21,
-    "resources": 2,
-    "prompts": 3,
-    "transports": [
-      "stdio",
-      "streamable-http"
-    ]
-  }
+  ]
 }

--- a/scripts/check-public-surface-integrity.js
+++ b/scripts/check-public-surface-integrity.js
@@ -84,23 +84,26 @@ function main() {
   );
   check(
     results,
-    "glama version parity",
-    glamaMeta.version === RELEASE_VERSION,
-    `found ${glamaMeta.version}`
-  );
-  check(
-    results,
     "description parity",
     packageJson.description === PUBLIC_METADATA.canonicalShortDescription &&
-      serverMeta.description === PUBLIC_METADATA.canonicalShortDescription &&
-      glamaMeta.description === PUBLIC_METADATA.canonicalShortDescription,
-    `package=${packageJson.description}; server=${serverMeta.description}; glama=${glamaMeta.description}`
+      serverMeta.description === PUBLIC_METADATA.canonicalShortDescription,
+    `package=${packageJson.description}; server=${serverMeta.description}`
   );
+  // Glama's live schema defines only maintainers; everything else it reads
+  // from the repository directly, so the file stays a minimal claim contract.
   check(
     results,
-    "glama tool count",
-    glamaMeta.features?.tools === PUBLIC_METADATA.selfHostedToolCount,
-    `expected ${PUBLIC_METADATA.selfHostedToolCount}, found ${glamaMeta.features?.tools ?? "n/a"}`
+    "glama minimal contract",
+    Array.isArray(glamaMeta.maintainers) && glamaMeta.maintainers.includes("jtalk22"),
+    `maintainers=${JSON.stringify(glamaMeta.maintainers ?? null)}`
+  );
+
+  const dockerfile = read("Dockerfile");
+  check(
+    results,
+    "Dockerfile LABEL description parity",
+    dockerfile.includes(`LABEL org.opencontainers.image.description="${PUBLIC_METADATA.canonicalShortDescription}"`),
+    "OCI image description label must carry the canonical short description"
   );
 
   const cliVersionResult = runNode(["src/cli.js", "--version"]);
@@ -166,8 +169,8 @@ function main() {
   check(
     results,
     "README download proof",
-    readme.includes("img.shields.io/npm/dt/%40jtalk22%2Fslack-mcp"),
-    "README must use the dynamic cumulative npm download badge"
+    readme.includes("img.shields.io/npm/dw/%40jtalk22%2Fslack-mcp"),
+    "README must use the dynamic weekly npm download badge"
   );
 
   const cliHelpResult = runNode(["src/cli.js", "--help"]);


### PR DESCRIPTION
## What

v4.7.0 Part B — README, discoverability, registry metadata. Stacked on #214.

- **README rebuilt**: 406 → 198 visible lines. Anchored headings stay outside `<details>` (GitHub won't auto-open a closed details on anchor navigation); the three count literals live in a visible summary sentence; persona table and static pricing table deleted (live pricing page is canonical); rich-fields note absorbed into the tool section; ToS details kept verbatim.
- **Badge row**: five flat-square shields with `labelColor=0b0b0c` — npm version (vermilion) · **weekly** downloads `npm/dw` (amber) · CI (semantic) · provenance-signed (vermilion, kills the teal leftover) · MCP Registry linking to the live server-record endpoint. Glama A-grade rating card added to Security (physically incompatible with the shields row; it's a 760×400 card).
- **Gate amendments (enumerated)**: download-proof check follows the dw badge; glama version-parity + tool-count checks removed and description-parity loses its glama clause (see below); NEW minimal-contract check (`maintainers` includes `jtalk22`); NEW Dockerfile OCI-description parity check.
- **glama.json pruned** to `{$schema, maintainers}` — the live Glama schema defines only `maintainers`; the version field was frozen at 4.6.2 pretending to mean something. Reversible.
- **Dockerfile LABEL** now carries the canonical short description (was "Full Slack access for Claude").
- **publish.yml**: new post-publish step polls the live npm description until it matches `package.json` — the live-surface check that would have caught the 4.6.2 stale-description miss.
- **.dockerignore** excludes `docs/videos` (22 MB of marketing renditions, canonical on GitHub Pages) — build-context hygiene and the leading suspect for the Aug 7 Glama builder failure (local `docker build --no-cache` passes on main, so their failure is environment-side).
- REPO.md refreshed (no pinned versions/star counts, JavaScript not TypeScript, resolved PR note dropped); launch-posts title version-neutral; CHANGELOG entry for 4.7.0.

## Verification

- `check-public-surface-integrity` · `check-public-language` · `verify-generated-public-pages` · `npm test` — all pass bare.
- Live URLs verified 200: `npm/dw` badge, Glama rating card, registry `versions/latest` endpoint.
- README count literals, session-auth phrasing, category-thesis headings, and the `Provenance: don't take my word for it` anchor all preserved verbatim.
