### PR TITLE
docs(maintainer): stacked-PR merge trap + hosted build-panel gotchas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,3 +107,14 @@ Tokens load from `~/.slack-mcp-tokens.json` or `SLACK_TOKEN`/`SLACK_COOKIE` env 
   demo deterministically (webm master → renditions). Chapter `data-t` values in
   `demo-video.html.tpl` and `.vtt` cue times are hand-mapped to real scene
   boundaries — re-verify both against extracted frames after any re-capture.
+- **Never `gh pr merge --delete-branch` a PR whose branch is the BASE of a
+  stacked PR.** GitHub closes the child PR unrecoverably (a closed PR whose base
+  branch died cannot be retargeted or reopened). Recover with
+  `git rebase --onto origin/main <old-base> <child-branch>`, force-push-with-lease,
+  and open a replacement PR. Merge stacked chains bottom-up without `--delete-branch`,
+  or let the child auto-retarget first.
+- **Glama builds are not our Dockerfile.** The glama.ai listing generates its own
+  image (debian + Node, `git clone` + `pnpm install`) from settings in the claimed
+  admin panel — repo `.dockerignore`/Dockerfile changes don't affect it. Build
+  failures there are usually their builder's infra; re-run via admin → Dockerfile
+  → Build & Release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,9 @@ Tokens load from `~/.slack-mcp-tokens.json` or `SLACK_TOKEN`/`SLACK_COOKIE` env 
 - **Never `gh pr merge --delete-branch` a PR whose branch is the BASE of a
   stacked PR.** GitHub closes the child PR unrecoverably (a closed PR whose base
   branch died cannot be retargeted or reopened). Recover with
-  `git rebase --onto origin/main <old-base> <child-branch>`, force-push-with-lease,
+  `git rebase --onto origin/main <old-base-tip-sha> <child-branch>` (use the old
+  base's tip COMMIT SHA — the deleted branch name may no longer resolve; find it
+  via the local branch, reflog, or the merged PR's head SHA), force-push-with-lease,
   and open a replacement PR. Merge stacked chains bottom-up without `--delete-branch`,
   or let the child auto-retarget first.
 - **Glama builds are not our Dockerfile.** The glama.ai listing generates its own


### PR DESCRIPTION
Two gotchas learned during the v4.7.0 release, recorded in the maintainer guide:

- Merging a PR with branch deletion when that branch is the BASE of a stacked PR closes the child unrecoverably — recovery recipe included (rebase --onto + replacement PR).
- The glama.ai listing builds its own generated image from the claimed admin panel — repo Dockerfile/.dockerignore changes don't affect it; failures there are usually their builder infra, re-run via admin.

Docs-only change; no code paths touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance about risks when deleting branches in stacked pull requests.
  * Documented Glama’s independent Docker build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->