### PR TITLE
v4.8.0 — tool profiles and request pacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.8.0] - 2026-08-07
 
-### Earn the launch: tool profiles + conservative request pacing
+### Tool profiles and request pacing
 
-No MCP tool contracts changed. This release answers the two questions a
-technical audience asks first about a browser-session Slack server — per-turn
-schema cost and account safety — with shipped features instead of disclaimers.
+No MCP tool contracts changed. This release addresses the two running costs of
+a browser-session Slack server: the tool schema a client carries on every turn,
+and the request velocity that Slack's session-anomaly detection watches.
 
 ### Added
 
@@ -35,14 +35,15 @@ schema cost and account safety — with shipped features instead of disclaimers.
 
 ### Changed
 
-- **README** — new "Run it with eyes open" section states the Enterprise Grid
-  session-flagging caution (with the pacing answer), names the local threat
-  model (Chrome LevelDB token, cookie SQLite database, Keychain Safe Storage,
-  local PBKDF2 + AES-128-CBC decryption, local-only writes, and the infostealer
-  resemblance stated plainly), and describes the minimal user-name cache in
-  Slack-TOS terms. The local/hosted split now states the boundary explicitly:
-  local never transmits anything to us; hosted never sees a browser cookie.
-  Tool-profile and pacing configuration documented in the README and CLI help.
+- **README** — new "Grid, credentials, and caching" section documents the
+  Enterprise Grid session-anomaly risk and the pacing that mitigates it, the
+  credential extraction path (Chrome LevelDB token, cookie SQLite database,
+  Keychain Safe Storage, local PBKDF2 + AES-128-CBC decryption, local-only
+  writes), its similarity to the access pattern credential stealers use, and
+  the contents of the one user-name cache. The local/hosted split now states
+  the boundary: local never contacts us, hosted never receives a browser
+  cookie. Tool-profile and pacing configuration documented in README and CLI
+  help.
 
 ## [4.7.0] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.8.0] - 2026-08-07
+
+### Earn the launch: tool profiles + conservative request pacing
+
+No MCP tool contracts changed. This release answers the two questions a
+technical audience asks first about a browser-session Slack server — per-turn
+schema cost and account safety — with shipped features instead of disclaimers.
+
+### Added
+
+- **Tool profiles (`SLACK_MCP_TOOLS` / `--tools`)** — advertise a smaller slice
+  of the surface to cut per-turn tool-schema cost. `essentials` ships the six
+  core tools (unread, history, search, thread, user lookup, send) at roughly
+  985 estimated tokens of schema, down from about 3,600 for all 21; `read`
+  advertises the read-only tools (~2,559); `all` remains the default, so
+  existing installs are unchanged. A custom comma-separated allow-list is also
+  accepted. Filtering narrows only the advertised `tools/list` — every handler
+  stays callable. `scripts/measure-tool-schema.js` (`npm run measure:tools`)
+  reproduces the numbers (a ~4-chars/token estimate, labelled as one). Files:
+  `lib/tools.js`, `src/server.js`, `src/server-http.js`, `src/cli.js`,
+  `scripts/setup-wizard.js`, `scripts/measure-tool-schema.js`.
+- **Conservative request pacing, on by default** — outbound Slack calls are
+  spaced by a minimum inter-request-start interval and capped in concurrency to
+  stay under session-anomaly burst thresholds (most relevant on Enterprise
+  Grid). Tunable via `SLACK_MCP_MIN_REQUEST_INTERVAL_MS` (default 350; 0
+  disables) and `SLACK_MCP_MAX_CONCURRENCY` (default 3). No tool-contract
+  change. Files: `lib/slack-client.js`.
+
+### Changed
+
+- **README** — new "Run it with eyes open" section states the Enterprise Grid
+  session-flagging caution (with the pacing answer), names the local threat
+  model (Chrome LevelDB token, cookie SQLite database, Keychain Safe Storage,
+  local PBKDF2 + AES-128-CBC decryption, local-only writes, and the infostealer
+  resemblance stated plainly), and describes the minimal user-name cache in
+  Slack-TOS terms. The local/hosted split now states the boundary explicitly:
+  local never transmits anything to us; hosted never sees a browser cookie.
+  Tool-profile and pacing configuration documented in the README and CLI help.
+
 ## [4.7.0] - 2026-08-07
 
 ### The OS comes back

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npx -y @jtalk22/slack-mcp --setup
 <p align="center">
   <a href="#built-past-the-demo">The moat</a> ·
   <a href="#two-ways-into-slack">Why session auth</a> ·
-  <a href="#run-it-with-eyes-open">Grid & threat model</a> ·
+  <a href="#grid-credentials-and-caching">Grid & credentials</a> ·
   <a href="#install">Install</a> ·
   <a href="#21-tools-read-act-automate">21 tools</a> ·
   <a href="#typed-workflows-slack-in-json-out">Workflows</a> ·
@@ -127,17 +127,15 @@ Treat browser-session automation as an acceptable-use decision for you and your 
 
 ---
 
-## Run it with eyes open
+## Grid, credentials, and caching
 
-Grid, the threat model, and cache posture — stated up front, not found later.
+**Enterprise Grid.** Grid runs aggressive session-anomaly detection. Browser-session automation can trip it, which flags the session and kills it, regardless of which tool drives the traffic. Outbound calls are paced by default to stay under burst thresholds (`SLACK_MCP_MIN_REQUEST_INTERVAL_MS`, default 350; `SLACK_MCP_MAX_CONCURRENCY`, default 3). Pacing lowers that risk; it does not remove it. On Grid, use the [hosted OAuth tier](https://mcp.revasserlabs.com) or Slack's official MCP instead.
 
-**Enterprise Grid.** Grid runs aggressive session-anomaly detection, and browser-session automation can trip it — flagging the session and getting it killed — independent of which tool drives it. Outbound Slack calls are paced by default to stay well under burst thresholds (`SLACK_MCP_MIN_REQUEST_INTERVAL_MS`, default 350; `SLACK_MCP_MAX_CONCURRENCY`, default 3). Even so, if your workspace runs on Grid, the session-safe path is the [hosted OAuth tier](https://mcp.revasserlabs.com) or the official Slack MCP — not this local one.
+**Credential extraction.** `--setup` reads the newest `xoxc-` token from Chrome's on-disk LevelDB, snapshots the cookie SQLite database, retrieves Chrome Safe Storage from the macOS Keychain, and runs PBKDF2 + AES-128-CBC decryption locally. It writes the token file, Keychain entries, and non-secret metadata. It transmits nothing — the server talks to Slack and nowhere else.
 
-**What it touches on your machine.** `--setup` reads the newest `xoxc-` token from Chrome's on-disk LevelDB, snapshots the cookie SQLite database, retrieves Chrome Safe Storage from the macOS Keychain, and runs Chrome-compatible PBKDF2 + AES-128-CBC decryption locally. It writes only local credential state — the token file, Keychain entries, and non-secret metadata. Nothing is transmitted anywhere: the local server speaks only to Slack, as you.
+**This is the same access pattern credential stealers use.** Chrome App-Bound Encryption exists to make this class of read harder, and infostealer families (Lumma, Vidar, Meduza) bypass it to lift live sessions. The mechanism here is comparable. What differs is that you run it, on your own machine, against your own session, and nothing leaves the host. The source is plain JavaScript in this repository; audit it before handing it a live session.
 
-Name it plainly: this is the same class of local access that Chrome App-Bound Encryption exists to make harder, and that infostealer families (Lumma, Vidar, Meduza) bypass to lift live sessions. The code path is behaviorally similar; the difference is intent and locality — you run it, on your own machine, as yourself, and it exfiltrates nothing. The source is plain JavaScript in this repository. Read it before you trust it with a session.
-
-**Cache posture.** The only cache is a small user-name lookup: lazy, 500 entries maximum, one-hour TTL, minimised and dropped promptly. Reads happen on demand; the server keeps no persistent copy of your workspace.
+**User cache.** One cache exists: user-name lookups, populated on demand, 500 entries maximum, one-hour TTL. No message content, no channel history, and no persistent copy of the workspace is stored.
 
 ---
 
@@ -193,7 +191,7 @@ On macOS, setup can extract from Chrome and persist the selected storage backend
 
 The local surface ships **21 tools** today: **12 read-only** Slack operations, **4 write-path** tools that each carry an MCP destructive annotation so clients can gate workspace writes, 2 local workflow primitives, and 3 hosted-intelligence stubs that return a structured upgrade payload without making a Slack call. Four read tools accept `include_rich_message_fields: true` to surface attachments, blocks, files, reactions, and metadata—complete inputs and response contracts live in [docs/API.md](docs/API.md).
 
-**Advertise fewer tools if the schema tax matters.** A client pays for the tool schema on every turn that carries it. `SLACK_MCP_TOOLS=essentials` advertises the six core tools — unread, history, search, thread, user lookup, send — at roughly **985 estimated tokens** of schema per turn, down from about **3,600** for all 21 (`read` sits near 2,559). `--tools=slack_x,slack_y` takes an explicit set; the default stays all 21. Filtering narrows only what's advertised — every handler stays callable — and you can reproduce the numbers with `node scripts/measure-tool-schema.js` (a ~4-chars/token estimate, stated as one).
+**Advertising fewer tools.** A client pays for the tool schema on every turn that carries it. `SLACK_MCP_TOOLS=essentials` advertises six tools — unread, history, search, thread, user lookup, send — costing roughly **985 estimated tokens** of schema per turn against about **3,600** for all 21; `read` sits near 2,559. `--tools=slack_x,slack_y` takes an explicit set. The default stays all 21. Filtering changes what is advertised, not what is callable. Reproduce the numbers with `node scripts/measure-tool-schema.js` (a ~4-chars-per-token estimate).
 
 <details>
 <summary><strong>The full tool inventory</strong></summary>
@@ -328,7 +326,7 @@ When local control is enough, stop here—everything above is MIT-licensed and r
 - contract-validated workflow briefs;
 - shared profiles and managed workspace continuity.
 
-The boundary is clean. **Local mode never talks to us** — it runs on your machine and speaks only to Slack. **Hosted never sees a browser cookie** — it runs on permanent OAuth for work that must survive a rotating session (unattended schedules, Enterprise Grid). Everything above the fold is MIT-licensed and complete on its own; hosted is the paid path for continuity, not a tax on ordinary Slack access.
+Local mode never contacts us; it runs on your machine and talks only to Slack. Hosted never receives a browser cookie; it runs on permanent OAuth, for work that has to survive a rotating session — unattended schedules, Enterprise Grid. Everything above is MIT-licensed and complete on its own.
 
 [See live hosted pricing →](https://mcp.revasserlabs.com/pricing)
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ npx -y @jtalk22/slack-mcp --setup
 <p align="center">
   <a href="#built-past-the-demo">The moat</a> ·
   <a href="#two-ways-into-slack">Why session auth</a> ·
+  <a href="#run-it-with-eyes-open">Grid & threat model</a> ·
   <a href="#install">Install</a> ·
   <a href="#21-tools-read-act-automate">21 tools</a> ·
   <a href="#typed-workflows-slack-in-json-out">Workflows</a> ·
@@ -126,6 +127,20 @@ Treat browser-session automation as an acceptable-use decision for you and your 
 
 ---
 
+## Run it with eyes open
+
+Grid, the threat model, and cache posture — stated up front, not found later.
+
+**Enterprise Grid.** Grid runs aggressive session-anomaly detection, and browser-session automation can trip it — flagging the session and getting it killed — independent of which tool drives it. Outbound Slack calls are paced by default to stay well under burst thresholds (`SLACK_MCP_MIN_REQUEST_INTERVAL_MS`, default 350; `SLACK_MCP_MAX_CONCURRENCY`, default 3). Even so, if your workspace runs on Grid, the session-safe path is the [hosted OAuth tier](https://mcp.revasserlabs.com) or the official Slack MCP — not this local one.
+
+**What it touches on your machine.** `--setup` reads the newest `xoxc-` token from Chrome's on-disk LevelDB, snapshots the cookie SQLite database, retrieves Chrome Safe Storage from the macOS Keychain, and runs Chrome-compatible PBKDF2 + AES-128-CBC decryption locally. It writes only local credential state — the token file, Keychain entries, and non-secret metadata. Nothing is transmitted anywhere: the local server speaks only to Slack, as you.
+
+Name it plainly: this is the same class of local access that Chrome App-Bound Encryption exists to make harder, and that infostealer families (Lumma, Vidar, Meduza) bypass to lift live sessions. The code path is behaviorally similar; the difference is intent and locality — you run it, on your own machine, as yourself, and it exfiltrates nothing. The source is plain JavaScript in this repository. Read it before you trust it with a session.
+
+**Cache posture.** The only cache is a small user-name lookup: lazy, 500 entries maximum, one-hour TTL, minimised and dropped promptly. Reads happen on demand; the server keeps no persistent copy of your workspace.
+
+---
+
 ## Install
 
 **Node 22 or 24 recommended. Node 20 remains supported for the v4 line.**
@@ -177,6 +192,8 @@ On macOS, setup can extract from Chrome and persist the selected storage backend
 ## 21 tools: read, act, automate
 
 The local surface ships **21 tools** today: **12 read-only** Slack operations, **4 write-path** tools that each carry an MCP destructive annotation so clients can gate workspace writes, 2 local workflow primitives, and 3 hosted-intelligence stubs that return a structured upgrade payload without making a Slack call. Four read tools accept `include_rich_message_fields: true` to surface attachments, blocks, files, reactions, and metadata—complete inputs and response contracts live in [docs/API.md](docs/API.md).
+
+**Advertise fewer tools if the schema tax matters.** A client pays for the tool schema on every turn that carries it. `SLACK_MCP_TOOLS=essentials` advertises the six core tools — unread, history, search, thread, user lookup, send — at roughly **985 estimated tokens** of schema per turn, down from about **3,600** for all 21 (`read` sits near 2,559). `--tools=slack_x,slack_y` takes an explicit set; the default stays all 21. Filtering narrows only what's advertised — every handler stays callable — and you can reproduce the numbers with `node scripts/measure-tool-schema.js` (a ~4-chars/token estimate, stated as one).
 
 <details>
 <summary><strong>The full tool inventory</strong></summary>
@@ -310,6 +327,8 @@ When local control is enough, stop here—everything above is MIT-licensed and r
 - scheduled catch-up and triage;
 - contract-validated workflow briefs;
 - shared profiles and managed workspace continuity.
+
+The boundary is clean. **Local mode never talks to us** — it runs on your machine and speaks only to Slack. **Hosted never sees a browser cookie** — it runs on permanent OAuth for work that must survive a rotating session (unattended schedules, Enterprise Grid). Everything above the fold is MIT-licensed and complete on its own; hosted is the paid path for continuity, not a tax on ordinary Slack access.
 
 [See live hosted pricing →](https://mcp.revasserlabs.com/pricing)
 

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -42,6 +42,84 @@ const FORM_ENCODED_METHODS = new Set([
 
 let lastRefreshAttempt = 0;
 
+// ============ Conservative request pacing ============
+// Slack's session-anomaly detection — most aggressively on Enterprise Grid —
+// reacts to burst velocity, not only to the documented per-method rate limits.
+// An engineering answer beats a disclaimer: by default we space outbound
+// request STARTS by a minimum interval and cap concurrent in-flight requests.
+// Both are configurable; set the interval to 0 to disable spacing entirely.
+
+function readIntEnv(name, fallback) {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export const REQUEST_PACING = Object.freeze({
+  minIntervalMs: Math.max(0, readIntEnv("SLACK_MCP_MIN_REQUEST_INTERVAL_MS", 350)),
+  maxConcurrency: Math.max(1, readIntEnv("SLACK_MCP_MAX_CONCURRENCY", 3)),
+});
+
+/**
+ * Build a request pacer: a scheduler that caps concurrency and spaces request
+ * starts by a minimum interval. Injectable clock/sleep make it deterministically
+ * testable. Returns a `schedule(fn)` that resolves with fn()'s result once a
+ * slot is free and the interval has elapsed.
+ */
+export function createRequestPacer({
+  minIntervalMs = 0,
+  maxConcurrency = Infinity,
+  sleepFn = sleep,
+  now = () => Date.now(),
+} = {}) {
+  const cap = maxConcurrency > 0 ? maxConcurrency : Infinity;
+  let active = 0;
+  let nextAllowedStart = 0;
+  const waiters = [];
+
+  function acquire() {
+    if (active < cap) {
+      active += 1;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => waiters.push(resolve));
+  }
+
+  function release() {
+    active -= 1;
+    const next = waiters.shift();
+    if (next) {
+      active += 1;
+      next();
+    }
+  }
+
+  async function schedule(fn) {
+    await acquire();
+    try {
+      if (minIntervalMs > 0) {
+        // Reserve a distinct start slot synchronously (no await before the
+        // assignment) so concurrent callers are spaced, not bunched.
+        const t = now();
+        const start = Math.max(t, nextAllowedStart);
+        nextAllowedStart = start + minIntervalMs;
+        const wait = start - t;
+        if (wait > 0) await sleepFn(wait);
+      }
+      return await fn();
+    } finally {
+      release();
+    }
+  }
+
+  schedule.stats = () => ({ active, cap, minIntervalMs, queued: waiters.length });
+  return schedule;
+}
+
+// Process-wide pacer applied to every outbound Slack HTTP request.
+const requestPacer = createRequestPacer(REQUEST_PACING);
+
 // ============ LRU Cache with TTL ============
 
 class LRUCache {
@@ -263,11 +341,14 @@ export async function slackAPI(method, params = {}, options = {}) {
       body = JSON.stringify(params);
     }
 
-    response = await fetch(`https://slack.com/api/${method}`, {
+    // Route through the pacer: caps concurrency and spaces request starts so a
+    // burst of tool calls doesn't read as anomalous session velocity. Retries
+    // recurse back through slackAPI and are paced again.
+    response = await requestPacer(() => fetch(`https://slack.com/api/${method}`, {
       method: "POST",
       headers,
       body,
-    });
+    }));
   } catch (networkError) {
     // Retry on network errors with exponential backoff + jitter
     if (retryCount < maxRetries) {

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -45,9 +45,9 @@ let lastRefreshAttempt = 0;
 // ============ Conservative request pacing ============
 // Slack's session-anomaly detection — most aggressively on Enterprise Grid —
 // reacts to burst velocity, not only to the documented per-method rate limits.
-// An engineering answer beats a disclaimer: by default we space outbound
-// request STARTS by a minimum interval and cap concurrent in-flight requests.
-// Both are configurable; set the interval to 0 to disable spacing entirely.
+// By default we space outbound request STARTS by a minimum interval and cap
+// concurrent in-flight requests. Both are configurable; set the interval to 0
+// to disable spacing entirely.
 
 function readIntEnv(name, fallback) {
   const raw = process.env[name];

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -691,7 +691,11 @@ export function getActiveToolProfile(argv = process.argv, env = process.env) {
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === "--tools") {
-      cliValue = argv[i + 1] ?? "";
+      // A following option is a missing operand, not the value — never consume
+      // `--setup` or `--profile=work` as a tool profile. cli.js rejects this at
+      // launch; here we fall through to the environment.
+      const next = argv[i + 1];
+      cliValue = next === undefined || next.startsWith("--") ? null : next;
     } else if (arg.startsWith("--tools=")) {
       cliValue = arg.slice("--tools=".length);
     }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -600,8 +600,8 @@ export const TOOLS = [
 // narrows the ADVERTISED list — every handler stays wired, so a client that
 // calls a non-advertised tool by name still works.
 
-// The tight job-to-be-done: see what's unread, read a conversation, search the
-// workspace, read a thread, resolve a person, and reply. Six tools.
+// The six tools covering the common case: see what's unread, read a
+// conversation, search the workspace, read a thread, resolve a person, reply.
 export const ESSENTIALS_TOOLS = [
   "slack_conversations_unreads",
   "slack_conversations_history",

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -589,3 +589,119 @@ export const TOOLS = [
     }
   }
 ];
+
+// ============ Tool Profiles (schema-cost control) ============
+// The TOOLS array above is the canonical surface — drift-guarded byte-for-byte
+// against TOOL_HANDLERS. A client pays for the full tool schema on every turn
+// that carries it, so a client that only needs the core job can advertise a
+// smaller slice and cut that per-turn cost. Selection is opt-in via
+// SLACK_MCP_TOOLS=essentials|read|all (or --tools=<comma,list,of,names>);
+// the default stays "all" so existing installs are unchanged. Filtering only
+// narrows the ADVERTISED list — every handler stays wired, so a client that
+// calls a non-advertised tool by name still works.
+
+// The tight job-to-be-done: see what's unread, read a conversation, search the
+// workspace, read a thread, resolve a person, and reply. Six tools.
+export const ESSENTIALS_TOOLS = [
+  "slack_conversations_unreads",
+  "slack_conversations_history",
+  "slack_search_messages",
+  "slack_get_thread",
+  "slack_users_search",
+  "slack_send_message",
+];
+
+const TOOLS_BY_NAME = new Map(TOOLS.map((tool) => [tool.name, tool]));
+
+/** Names of every tool annotated readOnlyHint: true, in canonical order. */
+export function readOnlyToolNames() {
+  return TOOLS.filter((tool) => tool.annotations?.readOnlyHint === true).map((tool) => tool.name);
+}
+
+/**
+ * Resolve a raw profile string into the tools to advertise.
+ *
+ * Accepts "all" (default), "read", "essentials", or a comma-separated custom
+ * allow-list of exact tool names. Unknown names in a custom list are dropped
+ * with a warning; a value that matches nothing at all falls back to "all"
+ * rather than crashing — a mis-set filter must never silently strip Slack
+ * access to zero tools. Returns { profile, tools, dropped, warning }.
+ */
+export function resolveToolProfile(rawValue) {
+  const raw = (rawValue == null ? "" : String(rawValue)).trim();
+  const lowered = raw.toLowerCase();
+
+  if (!raw || lowered === "all") {
+    return { profile: "all", tools: TOOLS, dropped: [], warning: null };
+  }
+  if (lowered === "essentials" || lowered === "essential") {
+    return {
+      profile: "essentials",
+      tools: TOOLS.filter((tool) => ESSENTIALS_TOOLS.includes(tool.name)),
+      dropped: [],
+      warning: null,
+    };
+  }
+  if (lowered === "read" || lowered === "read-only" || lowered === "readonly") {
+    const readNames = new Set(readOnlyToolNames());
+    return {
+      profile: "read",
+      tools: TOOLS.filter((tool) => readNames.has(tool.name)),
+      dropped: [],
+      warning: null,
+    };
+  }
+
+  // Custom comma-separated allow-list of exact tool names.
+  const requested = raw.split(",").map((name) => name.trim()).filter(Boolean);
+  const keptNames = new Set();
+  const dropped = [];
+  for (const name of requested) {
+    if (TOOLS_BY_NAME.has(name)) {
+      keptNames.add(name);
+    } else {
+      dropped.push(name);
+    }
+  }
+  if (keptNames.size === 0) {
+    return {
+      profile: "all",
+      tools: TOOLS,
+      dropped,
+      warning: `SLACK_MCP_TOOLS="${raw}" matched no known tools (unknown: ${dropped.join(", ") || "none"}); advertising all ${TOOLS.length}.`,
+    };
+  }
+  return {
+    profile: "custom",
+    tools: TOOLS.filter((tool) => keptNames.has(tool.name)), // canonical order
+    dropped,
+    warning: dropped.length
+      ? `SLACK_MCP_TOOLS custom list dropped unknown tool(s): ${dropped.join(", ")}.`
+      : null,
+  };
+}
+
+/**
+ * Read the active tool profile from CLI argv (--tools=… / --tools …) and the
+ * SLACK_MCP_TOOLS environment variable, argv taking precedence. Adds a `source`
+ * field ("cli" | "env" | "default") to the resolveToolProfile result.
+ */
+export function getActiveToolProfile(argv = process.argv, env = process.env) {
+  let cliValue = null;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--tools") {
+      cliValue = argv[i + 1] ?? "";
+    } else if (arg.startsWith("--tools=")) {
+      cliValue = arg.slice("--tools=".length);
+    }
+  }
+  const raw = cliValue !== null ? cliValue : (env.SLACK_MCP_TOOLS ?? "");
+  const source = cliValue !== null ? "cli" : (env.SLACK_MCP_TOOLS ? "env" : "default");
+  return { ...resolveToolProfile(raw), source };
+}
+
+/** Convenience: just the resolved tool array for the current process. */
+export function getActiveTools(argv, env) {
+  return getActiveToolProfile(argv, env).tools;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jtalk22/slack-mcp",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jtalk22/slack-mcp",
-      "version": "4.7.0",
+      "version": "4.8.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jtalk22/slack-mcp",
   "mcpName": "io.github.jtalk22/slack-mcp-server",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "description": "Slack for AI agents: DMs, search, threads, triage, actions - browser-session or hosted OAuth.",
   "funding": {
     "type": "github",
@@ -44,6 +44,7 @@
     "verify:public-pages": "node scripts/verify-generated-public-pages.js",
     "verify:version-parity": "node scripts/check-version-parity.js",
     "verify:public-surface": "node scripts/check-public-surface-integrity.js",
+    "measure:tools": "node scripts/measure-tool-schema.js",
     "verify:media-manifest": "node scripts/media-manifest.js --check",
     "verify:release-dry-run": "node scripts/release-preflight.js",
     "smoke:browser": "node scripts/browser-smoke.js",

--- a/scripts/measure-tool-schema.js
+++ b/scripts/measure-tool-schema.js
@@ -72,7 +72,7 @@ function main() {
       `  ${r.profile.padEnd(10)}  ${String(r.tools).padStart(5)}   ${String(r.chars).padStart(5)}   ${String(r.est_tokens).padStart(10)}   ${delta.padStart(5)}`
     );
   }
-  console.log("\n  Estimate only (~4 chars/token). Publish it as an estimate.");
+  console.log("\n  Token counts are estimates (~4 chars per token), not tokenizer-exact.");
 }
 
 main();

--- a/scripts/measure-tool-schema.js
+++ b/scripts/measure-tool-schema.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * Measure the tool-schema cost of each SLACK_MCP_TOOLS profile.
+ *
+ * An MCP client pays for the tools/list schema on every turn that carries it,
+ * so a smaller advertised surface is a smaller per-turn tax. This prints the
+ * exact serialized size of the advertised payload for each profile and a token
+ * estimate using the widely-used ~4-characters-per-token heuristic.
+ *
+ * The heuristic is an ESTIMATE, not a tokenizer-exact count, and is labelled as
+ * such wherever the number is published. It is stable and reproducible, which is
+ * what a before/after comparison needs.
+ *
+ *   node scripts/measure-tool-schema.js          # human-readable table
+ *   node scripts/measure-tool-schema.js --json    # machine-readable
+ */
+
+import { resolveToolProfile } from "../lib/tools.js";
+
+const PROFILES = ["all", "read", "essentials"];
+
+// The tools/list payload each client receives: name, description, inputSchema,
+// and annotations — the full advertised object, as it goes on the wire.
+function advertisedPayload(tools) {
+  return JSON.stringify(
+    tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      inputSchema: t.inputSchema,
+      annotations: t.annotations,
+    }))
+  );
+}
+
+function estimateTokens(str) {
+  return Math.round(str.length / 4);
+}
+
+function measure(profile) {
+  const { tools } = resolveToolProfile(profile);
+  const payload = advertisedPayload(tools);
+  return {
+    profile,
+    tools: tools.length,
+    chars: payload.length,
+    est_tokens: estimateTokens(payload),
+  };
+}
+
+function main() {
+  const rows = PROFILES.map(measure);
+  const asJson = process.argv.includes("--json");
+
+  if (asJson) {
+    const baseline = rows.find((r) => r.profile === "all")?.est_tokens ?? 0;
+    const out = {
+      method: "~4 chars/token estimate over the advertised tools/list payload (name+description+inputSchema+annotations)",
+      baseline_tokens: baseline,
+      profiles: rows,
+    };
+    console.log(JSON.stringify(out, null, 2));
+    return;
+  }
+
+  const baseline = rows.find((r) => r.profile === "all")?.est_tokens ?? 0;
+  console.log("Tool-schema cost per profile (est. tokens ≈ chars / 4):\n");
+  console.log("  profile     tools   chars   est_tokens   vs all");
+  console.log("  " + "-".repeat(52));
+  for (const r of rows) {
+    const delta = baseline ? `${Math.round((r.est_tokens / baseline) * 100)}%` : "n/a";
+    console.log(
+      `  ${r.profile.padEnd(10)}  ${String(r.tools).padStart(5)}   ${String(r.chars).padStart(5)}   ${String(r.est_tokens).padStart(10)}   ${delta.padStart(5)}`
+    );
+  }
+  console.log("\n  Estimate only (~4 chars/token). Publish it as an estimate.");
+}
+
+main();

--- a/scripts/setup-wizard.js
+++ b/scripts/setup-wizard.js
@@ -603,7 +603,7 @@ async function showHelp() {
   print("  keep credentials in a separate namespace per workspace — e.g.");
   print("  --setup --profile work, then a second server with --profile personal.");
   print();
-  print(`${colors.bold}Trim the surface:${colors.reset}`);
+  print(`${colors.bold}Tool selection:${colors.reset}`);
   print("  --tools essentials (or SLACK_MCP_TOOLS=essentials) advertises the six");
   print("  core tools to cut per-turn schema cost; 'read' advertises read-only");
   print("  tools; 'all' is the default. Every handler stays callable either way.");

--- a/scripts/setup-wizard.js
+++ b/scripts/setup-wizard.js
@@ -603,6 +603,16 @@ async function showHelp() {
   print("  keep credentials in a separate namespace per workspace — e.g.");
   print("  --setup --profile work, then a second server with --profile personal.");
   print();
+  print(`${colors.bold}Trim the surface:${colors.reset}`);
+  print("  --tools essentials (or SLACK_MCP_TOOLS=essentials) advertises the six");
+  print("  core tools to cut per-turn schema cost; 'read' advertises read-only");
+  print("  tools; 'all' is the default. Every handler stays callable either way.");
+  print();
+  print(`${colors.bold}Request pacing:${colors.reset}`);
+  print("  Outbound Slack calls are paced by default. Tune with");
+  print("  SLACK_MCP_MIN_REQUEST_INTERVAL_MS (default 350, 0 disables) and");
+  print("  SLACK_MCP_MAX_CONCURRENCY (default 3).");
+  print();
   print(`${colors.bold}npm scripts:${colors.reset}`);
   print("  npm start              Start MCP server");
   print("  npm run web            Start REST API + Web UI (port 3000)");

--- a/server.json
+++ b/server.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/jtalk22/slack-mcp-server",
     "source": "github"
   },
-  "version": "4.7.0",
+  "version": "4.8.0",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
     {
       "registryType": "npm",
       "identifier": "@jtalk22/slack-mcp",
-      "version": "4.7.0",
+      "version": "4.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/cli.js
+++ b/src/cli.js
@@ -21,17 +21,36 @@ const rawArgs = process.argv.slice(2);
 // web, http, token refresh — honors the same workspace namespace.
 // `--tools <profile>` / `--tools=<profile>` maps to SLACK_MCP_TOOLS the same
 // way, so the advertised tool surface can be narrowed from the launch command.
+// A separated operand (`--flag value`) must not swallow the following option:
+// `--tools --setup` used to consume `--setup` as the value AND drop it from
+// args, so the wizard silently never ran. Reject the missing value instead.
+function takeOperand(flag, rawArgs, index) {
+  const next = rawArgs[index + 1];
+  if (next === undefined || next.startsWith("--")) {
+    console.error(`${flag} requires a value.`);
+    if (flag === "--tools") {
+      console.error("  Use: --tools essentials | read | all | <comma-separated tool names>");
+    } else {
+      console.error("  Use: --profile <workspace-namespace-name>");
+    }
+    process.exit(1);
+  }
+  return next;
+}
+
 const args = [];
 let cliProfile = null;
 let cliTools = null;
 for (let i = 0; i < rawArgs.length; i++) {
   const arg = rawArgs[i];
   if (arg === "--profile") {
-    cliProfile = rawArgs[++i] ?? "";
+    cliProfile = takeOperand("--profile", rawArgs, i);
+    i++;
   } else if (arg.startsWith("--profile=")) {
     cliProfile = arg.slice("--profile=".length);
   } else if (arg === "--tools") {
-    cliTools = rawArgs[++i] ?? "";
+    cliTools = takeOperand("--tools", rawArgs, i);
+    i++;
   } else if (arg.startsWith("--tools=")) {
     cliTools = arg.slice("--tools=".length);
   } else {

--- a/src/cli.js
+++ b/src/cli.js
@@ -19,21 +19,30 @@ const rawArgs = process.argv.slice(2);
 // `--profile <name>` / `--profile=<name>` anywhere on the command line maps
 // to SLACK_MCP_PROFILE for the child (#164), so every mode — server, wizard,
 // web, http, token refresh — honors the same workspace namespace.
+// `--tools <profile>` / `--tools=<profile>` maps to SLACK_MCP_TOOLS the same
+// way, so the advertised tool surface can be narrowed from the launch command.
 const args = [];
 let cliProfile = null;
+let cliTools = null;
 for (let i = 0; i < rawArgs.length; i++) {
   const arg = rawArgs[i];
   if (arg === "--profile") {
     cliProfile = rawArgs[++i] ?? "";
   } else if (arg.startsWith("--profile=")) {
     cliProfile = arg.slice("--profile=".length);
+  } else if (arg === "--tools") {
+    cliTools = rawArgs[++i] ?? "";
+  } else if (arg.startsWith("--tools=")) {
+    cliTools = arg.slice("--tools=".length);
   } else {
     args.push(arg);
   }
 }
-const childEnv = cliProfile !== null
-  ? { ...process.env, SLACK_MCP_PROFILE: cliProfile }
-  : process.env;
+const childEnv = {
+  ...process.env,
+  ...(cliProfile !== null ? { SLACK_MCP_PROFILE: cliProfile } : {}),
+  ...(cliTools !== null ? { SLACK_MCP_TOOLS: cliTools } : {}),
+};
 
 const firstArg = args[0];
 

--- a/src/server-http.js
+++ b/src/server-http.js
@@ -14,7 +14,7 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 
-import { TOOLS } from "../lib/tools.js";
+import { getActiveToolProfile } from "../lib/tools.js";
 import { TOOL_HANDLERS } from "../lib/handlers.js";
 import { RELEASE_VERSION } from "../lib/public-metadata.js";
 import { isAuthDeath, lifeboatResponse } from "../lib/lifeboat.js";
@@ -66,6 +66,11 @@ function applyCors(req, res) {
   return allowOrigin;
 }
 
+// Resolve the advertised tool surface once (SLACK_MCP_TOOLS narrows it; default
+// is the full surface). Handlers stay fully wired regardless.
+const ACTIVE_TOOLS = getActiveToolProfile();
+if (ACTIVE_TOOLS.warning) console.warn(`Tool profile: ${ACTIVE_TOOLS.warning}`);
+
 // Create MCP server
 const server = new Server(
   { name: SERVER_NAME, version: SERVER_VERSION },
@@ -74,7 +79,7 @@ const server = new Server(
 
 // Register tool list handler
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: TOOLS
+  tools: ACTIVE_TOOLS.tools
 }));
 
 // Register tool call handler
@@ -202,6 +207,7 @@ const httpServer = http.createServer(async (req, res) => {
 httpServer.listen(PORT, () => {
   console.log(`${SERVER_NAME} v${SERVER_VERSION} HTTP server running on port ${PORT}`);
   console.log(`MCP endpoint: http://localhost:${PORT}/mcp`);
+  console.log(`Tool profile: ${ACTIVE_TOOLS.profile} (${ACTIVE_TOOLS.tools.length} tools, source: ${ACTIVE_TOOLS.source})`);
   if (HTTP_INSECURE) {
     console.warn("WARNING: SLACK_MCP_HTTP_INSECURE=1 enabled. /mcp is unauthenticated and CORS is wildcard.");
   } else {

--- a/src/server.js
+++ b/src/server.js
@@ -28,7 +28,7 @@ import {
 import { loadTokensReadOnly } from "../lib/token-store.js";
 import { RELEASE_VERSION } from "../lib/public-metadata.js";
 import { checkTokenHealth } from "../lib/slack-client.js";
-import { TOOLS } from "../lib/tools.js";
+import { getActiveToolProfile } from "../lib/tools.js";
 import {
   TOOL_HANDLERS,
   handleHealthCheck,
@@ -101,6 +101,11 @@ const RESOURCES = [
   }
 ];
 
+// Resolve the advertised tool surface once per process. SLACK_MCP_TOOLS (or
+// --tools=…) can narrow it to cut per-turn schema cost; the default is the full
+// surface. Handlers stay fully wired regardless of what is advertised.
+const ACTIVE_TOOLS = getActiveToolProfile();
+
 // Initialize server
 const server = new Server(
   { name: SERVER_NAME, version: SERVER_VERSION },
@@ -109,7 +114,7 @@ const server = new Server(
 
 // Register tool list handler
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: TOOLS
+  tools: ACTIVE_TOOLS.tools
 }));
 
 // Register prompts handlers
@@ -303,6 +308,13 @@ async function main() {
   process.on("SIGHUP", () => shutdown("SIGHUP"));
   process.stdin.on("end", () => shutdown("stdin end (MCP client disconnected)"));
   process.stdin.on("error", (err) => shutdown(`stdin error: ${err?.message || err}`));
+
+  // Surface which tool profile is active so a narrowed surface is never a
+  // silent surprise (and a mistyped SLACK_MCP_TOOLS says so out loud).
+  if (ACTIVE_TOOLS.warning) console.error(`Tool profile: ${ACTIVE_TOOLS.warning}`);
+  console.error(
+    `Tool profile: ${ACTIVE_TOOLS.profile} (${ACTIVE_TOOLS.tools.length} tools, source: ${ACTIVE_TOOLS.source})`
+  );
 
   // Start server
   const transport = new StdioServerTransport();

--- a/test/request-pacing.test.js
+++ b/test/request-pacing.test.js
@@ -49,7 +49,16 @@ test("a rejecting task releases its slot (no deadlock)", async () => {
   assert.equal(result, "ok");
 });
 
-test("default pacing is conservative and on by default", () => {
+test("default pacing is conservative and on by default", (t) => {
+  // REQUEST_PACING reads the environment at module load, and disabling pacing
+  // is a supported configuration — so only assert the defaults when neither
+  // override is set.
+  const overridden = ["SLACK_MCP_MIN_REQUEST_INTERVAL_MS", "SLACK_MCP_MAX_CONCURRENCY"]
+    .some((name) => process.env[name] !== undefined && process.env[name] !== "");
+  if (overridden) {
+    t.skip("pacing overridden in this environment");
+    return;
+  }
   assert.ok(REQUEST_PACING.minIntervalMs > 0, "spacing is on by default");
   assert.ok(REQUEST_PACING.maxConcurrency >= 1, "concurrency cap is set");
 });

--- a/test/request-pacing.test.js
+++ b/test/request-pacing.test.js
@@ -1,0 +1,55 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createRequestPacer, REQUEST_PACING } from "../lib/slack-client.js";
+
+test("caps concurrent in-flight tasks at maxConcurrency", async () => {
+  const pacer = createRequestPacer({ minIntervalMs: 0, maxConcurrency: 2 });
+  let active = 0;
+  let peak = 0;
+  const run = () =>
+    pacer(async () => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise((r) => setTimeout(r, 25));
+      active -= 1;
+    });
+  await Promise.all(Array.from({ length: 8 }, run));
+  assert.ok(peak <= 2, `peak concurrency ${peak} must be <= 2`);
+  assert.equal(active, 0, "all slots released");
+});
+
+test("spaces request starts by at least minIntervalMs even under concurrency", async () => {
+  const interval = 40;
+  const pacer = createRequestPacer({ minIntervalMs: interval, maxConcurrency: Infinity });
+  const starts = [];
+  await Promise.all(
+    Array.from({ length: 5 }, () => pacer(async () => { starts.push(Date.now()); }))
+  );
+  starts.sort((a, b) => a - b);
+  for (let i = 1; i < starts.length; i++) {
+    const gap = starts[i] - starts[i - 1];
+    // Small tolerance for timer/Date.now coarseness; starts are reserved
+    // monotonically so the true gap is >= interval.
+    assert.ok(gap >= interval - 8, `gap ${gap}ms (index ${i}) must be ~>= ${interval}ms`);
+  }
+});
+
+test("interval of 0 disables spacing (near-instant)", async () => {
+  const pacer = createRequestPacer({ minIntervalMs: 0, maxConcurrency: Infinity });
+  const t0 = Date.now();
+  await Promise.all(Array.from({ length: 20 }, () => pacer(async () => {})));
+  assert.ok(Date.now() - t0 < 100, "no interval → no meaningful delay");
+});
+
+test("a rejecting task releases its slot (no deadlock)", async () => {
+  const pacer = createRequestPacer({ minIntervalMs: 0, maxConcurrency: 1 });
+  await assert.rejects(pacer(async () => { throw new Error("boom"); }), /boom/);
+  // If the slot leaked, this second call would hang forever.
+  const result = await pacer(async () => "ok");
+  assert.equal(result, "ok");
+});
+
+test("default pacing is conservative and on by default", () => {
+  assert.ok(REQUEST_PACING.minIntervalMs > 0, "spacing is on by default");
+  assert.ok(REQUEST_PACING.maxConcurrency >= 1, "concurrency cap is set");
+});

--- a/test/tool-profiles.test.js
+++ b/test/tool-profiles.test.js
@@ -17,7 +17,7 @@ test("default (empty / 'all') advertises the full canonical surface", () => {
   }
 });
 
-test("essentials is the tight six-tool job-to-be-done slice", () => {
+test("essentials is the six-tool common-case slice", () => {
   const r = resolveToolProfile("essentials");
   assert.equal(r.profile, "essentials");
   assert.deepEqual(r.tools.map((t) => t.name).sort(), [...ESSENTIALS_TOOLS].sort());

--- a/test/tool-profiles.test.js
+++ b/test/tool-profiles.test.js
@@ -1,5 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import {
   TOOLS,
   ESSENTIALS_TOOLS,
@@ -67,6 +69,26 @@ test("getActiveToolProfile: cli --tools beats env, env beats default", () => {
   const dflt = getActiveToolProfile(["node", "server.js"], {});
   assert.equal(dflt.profile, "all");
   assert.equal(dflt.source, "default");
+});
+
+test("--tools with a missing operand never swallows the following option", () => {
+  for (const trailing of ["--setup", "--profile=work", "--doctor"]) {
+    const r = getActiveToolProfile(["node", "server.js", "--tools", trailing], {});
+    assert.equal(r.profile, "all", `--tools ${trailing} must not resolve a profile`);
+    assert.equal(r.source, "default", `--tools ${trailing} must not count as a cli value`);
+  }
+  // Trailing --tools with nothing after it is equally a missing operand.
+  const bare = getActiveToolProfile(["node", "server.js", "--tools"], {});
+  assert.equal(bare.source, "default");
+});
+
+test("cli rejects --tools/--profile with a missing operand instead of eating the next flag", () => {
+  const cli = fileURLToPath(new URL("../src/cli.js", import.meta.url));
+  for (const argv of [["--tools", "--setup"], ["--profile", "--setup"], ["--tools"]]) {
+    const r = spawnSync(process.execPath, [cli, ...argv], { encoding: "utf8", timeout: 20000 });
+    assert.equal(r.status, 1, `${argv.join(" ")} must exit 1`);
+    assert.match(r.stderr, /requires a value/, `${argv.join(" ")} must explain the missing value`);
+  }
 });
 
 test("essentials tool names all exist in the canonical surface (no rot)", () => {

--- a/test/tool-profiles.test.js
+++ b/test/tool-profiles.test.js
@@ -1,0 +1,77 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  TOOLS,
+  ESSENTIALS_TOOLS,
+  readOnlyToolNames,
+  resolveToolProfile,
+  getActiveToolProfile,
+} from "../lib/tools.js";
+
+test("default (empty / 'all') advertises the full canonical surface", () => {
+  for (const value of ["", "all", "  ALL ", undefined, null]) {
+    const r = resolveToolProfile(value);
+    assert.equal(r.profile, "all", `value ${JSON.stringify(value)} → all`);
+    assert.equal(r.tools.length, TOOLS.length);
+    assert.equal(r.tools, TOOLS, "returns the canonical array by reference for 'all'");
+  }
+});
+
+test("essentials is the tight six-tool job-to-be-done slice", () => {
+  const r = resolveToolProfile("essentials");
+  assert.equal(r.profile, "essentials");
+  assert.deepEqual(r.tools.map((t) => t.name).sort(), [...ESSENTIALS_TOOLS].sort());
+  assert.ok(r.tools.length < TOOLS.length, "essentials is a strict subset");
+  const names = new Set(r.tools.map((t) => t.name));
+  assert.ok(names.has("slack_send_message"), "the one JTBD write is present");
+  assert.ok(!names.has("slack_add_reaction"), "non-core writes are excluded");
+});
+
+test("read profile is exactly the read-only annotated tools", () => {
+  const r = resolveToolProfile("read");
+  assert.equal(r.profile, "read");
+  assert.deepEqual(r.tools.map((t) => t.name).sort(), readOnlyToolNames().sort());
+  assert.ok(r.tools.every((t) => t.annotations?.readOnlyHint === true));
+  assert.ok(!r.tools.some((t) => t.name === "slack_send_message"), "no write tools in read profile");
+});
+
+test("custom comma list keeps known tools in canonical order and drops unknown", () => {
+  const r = resolveToolProfile("slack_get_thread, slack_send_message, not_a_tool");
+  assert.equal(r.profile, "custom");
+  // Canonical order: send_message precedes get_thread in TOOLS.
+  assert.deepEqual(r.tools.map((t) => t.name), ["slack_send_message", "slack_get_thread"]);
+  assert.deepEqual(r.dropped, ["not_a_tool"]);
+  assert.match(r.warning, /dropped unknown tool/);
+});
+
+test("a value that matches nothing falls back to all, never to zero", () => {
+  const r = resolveToolProfile("totally_unknown_value");
+  assert.equal(r.profile, "all");
+  assert.equal(r.tools.length, TOOLS.length);
+  assert.ok(r.warning, "the fallback is surfaced, not silent");
+});
+
+test("getActiveToolProfile: cli --tools beats env, env beats default", () => {
+  const viaCli = getActiveToolProfile(["node", "server.js", "--tools=essentials"], { SLACK_MCP_TOOLS: "read" });
+  assert.equal(viaCli.profile, "essentials");
+  assert.equal(viaCli.source, "cli");
+
+  const viaCliSpace = getActiveToolProfile(["node", "server.js", "--tools", "read"], {});
+  assert.equal(viaCliSpace.profile, "read");
+  assert.equal(viaCliSpace.source, "cli");
+
+  const viaEnv = getActiveToolProfile(["node", "server.js"], { SLACK_MCP_TOOLS: "read" });
+  assert.equal(viaEnv.profile, "read");
+  assert.equal(viaEnv.source, "env");
+
+  const dflt = getActiveToolProfile(["node", "server.js"], {});
+  assert.equal(dflt.profile, "all");
+  assert.equal(dflt.source, "default");
+});
+
+test("essentials tool names all exist in the canonical surface (no rot)", () => {
+  const known = new Set(TOOLS.map((t) => t.name));
+  for (const name of ESSENTIALS_TOOLS) {
+    assert.ok(known.has(name), `${name} must exist in TOOLS`);
+  }
+});


### PR DESCRIPTION
## v4.8.0 — tool profiles and request pacing

No MCP tool contracts changed. This addresses the two running costs of a browser-session Slack server: the tool schema a client carries on every turn, and the request velocity Slack's session-anomaly detection watches.

### Tool profiles (`SLACK_MCP_TOOLS` / `--tools`)

| profile | tools | est. tokens | vs all |
|---|---|---|---|
| `all` (default) | 21 | ~3,600 | 100% |
| `read` | 15 | ~2,559 | 71% |
| `essentials` | 6 | **~985** | **27%** |

- `essentials` = unread, history, search, thread, user lookup, send.
- `--tools=slack_x,slack_y` takes an explicit set; `cli.js` threads `--tools` into the environment the way `--profile` already works.
- Default stays `all` (21), so existing installs are unchanged. The drift guard and the `21 tools` / `12 read-only` / `4 write-path` public-surface literals are untouched.
- Filtering changes what is advertised, not what is callable. An unrecognized value falls back to `all` rather than to zero, and says so on stderr.
- `npm run measure:tools` reproduces the numbers. It matches the measured baseline exactly (all=3,600, read=2,559).

### Request pacing, on by default
- Spaces outbound request starts by a minimum interval and caps concurrency, to stay under session-anomaly burst thresholds (most relevant on Enterprise Grid).
- `SLACK_MCP_MIN_REQUEST_INTERVAL_MS` (default 350; `0` disables) and `SLACK_MCP_MAX_CONCURRENCY` (default 3).
- No tool-contract change. Retries recurse back through the pacer, and a rejecting task releases its slot.

### README — "Grid, credentials, and caching"
Documents the Enterprise Grid session-anomaly risk and the pacing that mitigates it; the credential extraction path (Chrome LevelDB token, cookie SQLite database, Keychain Safe Storage, local PBKDF2 + AES-128-CBC decryption, local-only writes); its similarity to the access pattern credential stealers use; and the contents of the single user-name cache. States the local/hosted boundary: local never contacts us, hosted never receives a browser cookie.

### Review fix (CodeRabbit)
`--tools --setup` consumed `--setup` as the operand and removed it from the child args, so the wizard silently never ran. The same defect already existed on `--profile`; both are now guarded — a following `--option` means the value is missing, which exits 1 with usage. Regression coverage added for `--tools --setup`, `--tools --profile=work`, and bare `--tools`.

### Verification
- `npm test` — 69 pass / 0 fail (71 tests, 2 pre-existing platform skips). New suites: `tool-profiles` (10), `request-pacing` (5), including burst-concurrency and start-spacing proofs.
- `check-public-surface-integrity.js`, `check-public-language.sh`, `verify-generated-public-pages`, `media-manifest --check`, `verify-attribution-guardrail`, `verify-dependabot-auto-merge`, `verify-install-flow` — all pass at 4.8.0.
- Version parity: package.json, package-lock (root + workspace), server.json (version + package entry) all `4.8.0`; CLI reports `v4.8.0`.
- End-to-end: advertises `all`/21 by default, `essentials`/6 and `read`/15 when selected, falls back with a warning on a bad value.

npm publish fires on a `v4.8.0` GitHub Release, not on this merge.
