### PR TITLE
fix(pkg): ship the measurement script the README tells people to run

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "scripts/setup-wizard.js",
     "scripts/token-cli.js",
     "scripts/apply-template.js",
+    "scripts/measure-tool-schema.js",
     "templates/workflow-profiles/",
     "docs/SETUP.md",
     "docs/API.md",

--- a/scripts/check-public-surface-integrity.js
+++ b/scripts/check-public-surface-integrity.js
@@ -210,6 +210,23 @@ function main() {
     unknownProfileNames.length === 0 ? "no rotted names" : unknownProfileNames.join(", ")
   );
 
+  // A script the public docs invite people to run must actually ship in the
+  // package. The token-cost claim is only as good as the reader's ability to
+  // reproduce it from what they installed.
+  const publishedScripts = (packageJson.files || []).filter((entry) => entry.startsWith("scripts/"));
+  const docInvitedScripts = Array.from(
+    new Set(Array.from(readme.matchAll(/scripts\/([a-z0-9-]+\.js)/g), (match) => `scripts/${match[1]}`))
+  );
+  const unshippedInvited = docInvitedScripts.filter((path) => !publishedScripts.includes(path));
+  check(
+    results,
+    "README-invited scripts ship in the package",
+    unshippedInvited.length === 0,
+    unshippedInvited.length === 0
+      ? `${docInvitedScripts.length} referenced, all in files[]`
+      : `not published: ${unshippedInvited.join(", ")}`
+  );
+
   const cliHelpResult = runNode(["src/cli.js", "--help"]);
   check(
     results,


### PR DESCRIPTION
Found by installing the actual 4.8.0 tarball and trying to do what the docs say.

## The gap

The README and the launch copy both invite readers to reproduce the tool-schema token figures with `scripts/measure-tool-schema.js`. The npm `files` whitelist excluded it, so the claim was reproducible from a git clone but not from what people actually install. A verifiable number that can't be verified from the artifact is a weak number — and this one is the headline of the release.

## The fix

- `scripts/measure-tool-schema.js` added to `files[]`.
- `check-public-surface-integrity.js` now extracts every `scripts/*.js` path the README references and asserts each is published.

## Verification

- Gate proven by removing the entry — fails with `not published: scripts/measure-tool-schema.js` — then restoring, passes with `1 referenced, all in files[]`.
- Packed the tarball, installed it into a clean directory, and ran the script from inside `node_modules/@jtalk22/slack-mcp`: reproduces **3,600 / 1,690 / 985**.
- Also confirmed from the packed install: version `4.8.0`, `--help` shows tool selection, and all four profile paths resolve (`default`→21, `essentials`→6, `read`→12, unknown→21 with a warning).
- `npm test` 72 pass / 0 fail.