### PR TITLE
fix(pacing): gate spacing on actual start times, not nominal wake times

### DIFF
--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -75,7 +75,7 @@ export function createRequestPacer({
 } = {}) {
   const cap = maxConcurrency > 0 ? maxConcurrency : Infinity;
   let active = 0;
-  let nextAllowedStart = 0;
+  let lastStart = Number.NEGATIVE_INFINITY;
   const waiters = [];
 
   function acquire() {
@@ -99,13 +99,22 @@ export function createRequestPacer({
     await acquire();
     try {
       if (minIntervalMs > 0) {
-        // Reserve a distinct start slot synchronously (no await before the
-        // assignment) so concurrent callers are spaced, not bunched.
-        const t = now();
-        const start = Math.max(t, nextAllowedStart);
-        nextAllowedStart = start + minIntervalMs;
-        const wait = start - t;
-        if (wait > 0) await sleepFn(wait);
+        // Gate on the ACTUAL previous start, re-checking after every sleep.
+        // Reserving nominal wake times instead would bunch requests whenever
+        // the event loop stalls longer than the interval (synchronous PBKDF2
+        // during token extraction can do exactly that): several sleeps would
+        // expire together and fire at once — the burst this exists to prevent.
+        // The check and the claim below sit in one synchronous block, so two
+        // callers waking in the same tick cannot both pass.
+        for (;;) {
+          const t = now();
+          const earliest = lastStart + minIntervalMs;
+          if (t >= earliest) {
+            lastStart = t;
+            break;
+          }
+          await sleepFn(earliest - t);
+        }
       }
       return await fn();
     } finally {

--- a/test/request-pacing.test.js
+++ b/test/request-pacing.test.js
@@ -34,6 +34,35 @@ test("spaces request starts by at least minIntervalMs even under concurrency", a
   }
 });
 
+test("an event-loop stall does not bunch the queued starts", async () => {
+  // Reserving nominal wake times lets several sleeps expire together after a
+  // stall and fire at once — the exact burst pacing exists to prevent, and
+  // synchronous PBKDF2 during Chrome token extraction can stall this long.
+  // Spacing must be measured against ACTUAL previous starts.
+  const interval = 50;
+  const pacer = createRequestPacer({ minIntervalMs: interval, maxConcurrency: Infinity });
+  const starts = [];
+  const runs = Array.from({ length: 4 }, () => pacer(async () => { starts.push(Date.now()); }));
+
+  // Let every task claim its place and begin waiting BEFORE the stall — that
+  // ordering is what reproduces the bug. Stalling first would simply delay all
+  // four equally and prove nothing.
+  await new Promise((resolve) => setImmediate(resolve));
+
+  // Now stall past several pending wake times, so their timers all come due at
+  // once. Nominal-time reservation fires them together here; actual-time gating
+  // re-spaces them.
+  const blockUntil = Date.now() + interval * 3.5;
+  while (Date.now() < blockUntil) { /* deliberate synchronous stall */ }
+
+  await Promise.all(runs);
+  starts.sort((a, b) => a - b);
+  for (let i = 1; i < starts.length; i++) {
+    const gap = starts[i] - starts[i - 1];
+    assert.ok(gap >= interval - 8, `start ${i} came ${gap}ms after the previous (need ~>=${interval}ms)`);
+  }
+});
+
 test("interval of 0 disables spacing (near-instant)", async () => {
   const pacer = createRequestPacer({ minIntervalMs: 0, maxConcurrency: Infinity });
   const t0 = Date.now();


### PR DESCRIPTION
Found by an independent cross-model review pass run before the immutable npm publish. Four earlier passes — CodeRabbit, two of my own reads, and a local model — all missed it.

## The defect

`createRequestPacer` reserved a slot at a computed future timestamp and slept until it. If the event loop stalls longer than the interval, several pending sleeps come due in the same timer phase and their requests fire simultaneously — the exact burst the feature exists to prevent.

This is reachable here, not theoretical: Chrome token extraction runs **synchronous PBKDF2**, which can block the loop well past a 350 ms interval.

## The fix

Spacing is now measured against the previous **actual** start, re-checked after every sleep. The check and the claim sit in one synchronous block, so two callers waking in the same tick cannot both pass.

## Proof it discriminates

The regression test queues four tasks, waits for all of them to claim a slot and begin waiting, *then* stalls the loop past several wake times — that ordering is what reproduces it; stalling first just delays everything equally and proves nothing.

- Against the old logic: **fails** — `start 2 came 0ms after the previous (need ~>=50ms)`
- Against the fix: **passes**, gaps hold at the interval

(My first attempt at this test passed on both, which made it worthless as evidence — caught by running it against the reverted implementation rather than trusting a green result.)

## Verification

`npm test` 73 pass / 0 fail (75 tests, 2 platform skips). Public-surface gate green. No tool-contract or configuration change — `SLACK_MCP_MIN_REQUEST_INTERVAL_MS` and `SLACK_MCP_MAX_CONCURRENCY` behave as documented, and `0` still disables spacing.