### PR TITLE
harden(release): allowlist the commands release-preflight can spawn

### DIFF
--- a/scripts/release-preflight.js
+++ b/scripts/release-preflight.js
@@ -12,13 +12,15 @@ const REPORT_PATH = process.env.PREPUBLISH_REPORT_PATH
   : resolve(ROOT, "output", "release-health", "prepublish-dry-run.md");
 
 function run(command, args = [], options = {}) {
-  return spawnSync(command, args, {
-    cwd: ROOT,
-    encoding: "utf8",
-    env: process.env,
-    maxBuffer: 20 * 1024 * 1024,
-    ...options
-  });
+  const opts = { cwd: ROOT, encoding: "utf8", env: process.env, maxBuffer: 20 * 1024 * 1024, shell: false, ...options };
+  switch (command) {
+    case "git":  return spawnSync("git", args, opts);
+    case "bash": return spawnSync("bash", args, opts);
+    case "rg":   return spawnSync("rg", args, opts);
+    case "node": return spawnSync("node", args, opts);
+    case "npm":  return spawnSync("npm", args, opts);
+    default: throw new Error(`Disallowed command: ${command}`);
+  }
 }
 
 function gitConfig(key) {


### PR DESCRIPTION
Restricts `scripts/release-preflight.js`'s `run()` helper to the five commands it actually invokes (git, bash, rg, node, npm) with `shell: false`, and throws on anything else. Flagged by a semgrep detect-child-process rule; no behavior change, since every call site already uses one of the five.

Smoke: `node scripts/release-preflight.js` runs clean (exit 0, report written) after the change.

Lands the fix from #217 under maintainer identity (the attribution guardrail requires it); closes that PR with credit to the contributor.

Closes #217.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Restricted release preflight operations to approved command-line tools.
  * Blocked unsupported executable commands to improve execution safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->