### PR TITLE
Lead with the job: catch up on Slack without reading it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM node:26-alpine
 # OCI Image Labels for registry discoverability
 LABEL maintainer="jtalk22"
 LABEL org.opencontainers.image.title="Slack MCP Server"
-LABEL org.opencontainers.image.description="Slack for AI agents: DMs, search, threads, triage, actions - browser-session or hosted OAuth."
+LABEL org.opencontainers.image.description="Catch up on Slack without reading it. Unreads, threads, search. Browser-session or hosted OAuth."
 LABEL org.opencontainers.image.source="https://github.com/jtalk22/slack-mcp-server"
 LABEL org.opencontainers.image.url="https://github.com/jtalk22/slack-mcp-server"
 LABEL org.opencontainers.image.documentation="https://github.com/jtalk22/slack-mcp-server#readme"

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-[![npm version](https://img.shields.io/npm/v/@jtalk22/slack-mcp?style=flat-square&logo=npm&logoColor=white&label=npm&labelColor=0b0b0c&color=e5482f)](https://www.npmjs.com/package/@jtalk22/slack-mcp)&nbsp;[![npm weekly downloads](https://img.shields.io/npm/dw/%40jtalk22%2Fslack-mcp?style=flat-square&label=weekly%20downloads&labelColor=0b0b0c&color=ffb224)](https://www.npmjs.com/package/@jtalk22/slack-mcp)&nbsp;[![CI](https://img.shields.io/github/actions/workflow/status/jtalk22/slack-mcp-server/ci.yml?style=flat-square&logo=githubactions&logoColor=white&label=CI&labelColor=0b0b0c)](https://github.com/jtalk22/slack-mcp-server/actions/workflows/ci.yml)&nbsp;[![npm provenance signed](https://img.shields.io/badge/provenance-signed-e5482f?style=flat-square&labelColor=0b0b0c)](#provenance-dont-take-my-word-for-it)&nbsp;[![MCP Registry](https://img.shields.io/badge/MCP_Registry-listed-ffb224?style=flat-square&labelColor=0b0b0c)](https://registry.modelcontextprotocol.io/v0/servers/io.github.jtalk22%2Fslack-mcp-server/versions/latest)
-
 <div align="center">
+
+[![npm version](https://img.shields.io/npm/v/@jtalk22/slack-mcp?style=flat-square&logo=npm&logoColor=white&label=npm&labelColor=0b0b0c&color=e5482f)](https://www.npmjs.com/package/@jtalk22/slack-mcp)&nbsp;[![npm weekly downloads](https://img.shields.io/npm/dw/%40jtalk22%2Fslack-mcp?style=flat-square&label=weekly%20downloads&labelColor=0b0b0c&color=ffb224)](https://www.npmjs.com/package/@jtalk22/slack-mcp)&nbsp;[![CI](https://img.shields.io/github/actions/workflow/status/jtalk22/slack-mcp-server/ci.yml?style=flat-square&logo=githubactions&logoColor=white&label=CI&labelColor=0b0b0c&color=28c840)](https://github.com/jtalk22/slack-mcp-server/actions/workflows/ci.yml)&nbsp;[![npm provenance signed](https://img.shields.io/badge/provenance-signed-e5482f?style=flat-square&labelColor=0b0b0c)](#provenance-dont-take-my-word-for-it)&nbsp;[![MCP Registry](https://img.shields.io/badge/MCP_Registry-listed-ffb224?style=flat-square&labelColor=0b0b0c)](https://registry.modelcontextprotocol.io/v0/servers/io.github.jtalk22%2Fslack-mcp-server/versions/latest)
 
 <img src="docs/assets/icon.svg" width="88" alt="Slack MCP channel mark">
 
-<p><strong>SLACK’S OPERATING LAYER FOR AI AGENTS</strong></p>
-
 <h1>Slack MCP Server</h1>
 
-<p>Slack for AI agents: DMs, search, threads, triage, actions — browser-session or hosted OAuth.</p>
+<p><strong>Catch up on Slack without reading it.</strong></p>
 
-</div>
+<p>Unreads, threads, and search — in your agent’s context, from the session you already have.</p>
 
 ```bash
 npx -y @jtalk22/slack-mcp --setup
 ```
+
+</div>
 
 <div align="center">
 
@@ -29,7 +29,7 @@ npx -y @jtalk22/slack-mcp --setup
 </div>
 
 <p align="center">
-  <a href="#built-past-the-demo">The moat</a> ·
+  <a href="#built-past-the-demo">How it works</a> ·
   <a href="#two-ways-into-slack">Why session auth</a> ·
   <a href="#grid-credentials-and-caching">Grid & credentials</a> ·
   <a href="#install">Install</a> ·

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Slack MCP Server — Slack’s operating layer for AI agents</title>
-  <meta name="description" content="Slack’s operating layer for AI agents: searchable workspace memory, approved actions, and typed workflows—local without an app/admin queue or hosted with permanent OAuth.">
+  <title>Slack MCP Server — Catch up on Slack without reading it</title>
+  <meta name="description" content="Catch up on Slack without reading it: unreads, threads, and search in your agent’s context, plus approved actions and typed workflows—local without an app/admin queue or hosted with permanent OAuth.">
   <link rel="canonical" href="https://jtalk22.github.io/slack-mcp-server/">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Slack MCP Server — Ask what happened. Get receipts. Close the loop.">
@@ -14,7 +14,7 @@
   <meta property="og:image:width" content="1280">
   <meta property="og:image:height" content="640">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Slack’s operating layer for AI agents">
+  <meta name="twitter:title" content="Catch up on Slack without reading it">
   <meta name="twitter:description" content="Ask what happened. Get receipts. Close the loop—locally or through permanent hosted OAuth.">
   <meta name="twitter:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
   <link rel="icon" href="https://jtalk22.github.io/slack-mcp-server/docs/assets/icon-512.png" type="image/png">
@@ -217,7 +217,7 @@
     <main>
       <div class="frame hero">
         <div class="hero-copy">
-          <p class="eyebrow reveal">Slack’s operating layer for AI agents</p>
+          <p class="eyebrow reveal">Catch up on Slack without reading it</p>
           <h1 class="reveal">Ask what happened.<br><em>Get receipts.</em><br>Close the loop.</h1>
           <p class="hero-deck reveal">Turn Slack from an interruption stream into searchable operating memory and approved action. Run the <strong>21-tool surface available today</strong> locally with no app/admin queue, or move recurring work to hosted permanent OAuth, indexing, and schedules.</p>
           <div class="command-row reveal" aria-label="Install command">

--- a/lib/public-pages.js
+++ b/lib/public-pages.js
@@ -62,7 +62,7 @@ function template(name) {
 }
 
 function replaceTokens(source, replacements) {
-  return source.replace(/\{\{([A-Z0-9_]+)\}\}/g, (match, key) => {
+  return source.replace(/\{\{([A-Z0-9_]+)\}\}/g, (_match, key) => {
     if (!(key in replacements)) {
       throw new Error(`Missing template token: ${key}`);
     }
@@ -76,7 +76,7 @@ function rootDecisionPanel() {
       <div class="decision-grid" aria-label="Self-host info">
         <article class="decision-card">
           <span class="decision-label">Self-host</span>
-          <h2>Slack's operating layer—free, local, and yours.</h2>
+          <h2>Catch up on Slack—free, local, and yours.</h2>
           <p>The current ${PUBLIC_METADATA.selfHostedToolCount}-tool surface turns DMs, search, threads, unread triage, actions, and workflows into agent-readable context without an app/admin queue.</p>
           <ul>
             <li>stdio, web, and Docker paths stay fully under your control</li>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@jtalk22/slack-mcp",
   "mcpName": "io.github.jtalk22/slack-mcp-server",
   "version": "4.8.0",
-  "description": "Slack for AI agents: DMs, search, threads, triage, actions - browser-session or hosted OAuth.",
+  "description": "Catch up on Slack without reading it. Unreads, threads, search. Browser-session or hosted OAuth.",
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/jtalk22"

--- a/public/share.html
+++ b/public/share.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Slack MCP Server</title>
-  <meta name="description" content="Slack’s operating layer for AI agents: local browser-session control or hosted permanent OAuth for recurring workflows.">
+  <meta name="description" content="Catch up on Slack without reading it: local browser-session control or hosted permanent OAuth for recurring workflows.">
   <link rel="canonical" href="https://jtalk22.github.io/slack-mcp-server/public/share.html">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Slack MCP Server — Ask what happened. Get receipts. Close the loop.">
@@ -14,7 +14,7 @@
   <meta property="og:image:width" content="1280">
   <meta property="og:image:height" content="640">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Slack’s operating layer for AI agents">
+  <meta name="twitter:title" content="Catch up on Slack without reading it">
   <meta name="twitter:description" content="Local control now. Hosted continuity when the workflow must run without you.">
   <meta name="twitter:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
   <link rel="icon" href="https://jtalk22.github.io/slack-mcp-server/docs/assets/icon-512.png" type="image/png">

--- a/scripts/check-public-surface-integrity.js
+++ b/scripts/check-public-surface-integrity.js
@@ -161,11 +161,11 @@ function main() {
   check(
     results,
     "README category thesis",
-    readme.includes("SLACK’S OPERATING LAYER FOR AI AGENTS") &&
+    readme.includes("Catch up on Slack without reading it.") &&
       readme.includes("Built past the demo") &&
       readme.includes("Two ways into Slack") &&
       readme.includes("Hosted when it must drive itself"),
-    "README must carry the category thesis, systems proof, and local/hosted value split"
+    "README must lead with the job it does, plus systems proof and the local/hosted value split"
   );
   check(
     results,

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.jtalk22/slack-mcp-server",
   "title": "Slack MCP Server",
-  "description": "Slack for AI agents: DMs, search, threads, triage, actions - browser-session or hosted OAuth.",
+  "description": "Catch up on Slack without reading it. Unreads, threads, search. Browser-session or hosted OAuth.",
   "websiteUrl": "https://mcp.revasserlabs.com",
   "icons": [
     {

--- a/templates/public-pages/index.html.tpl
+++ b/templates/public-pages/index.html.tpl
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Slack MCP Server — Slack’s operating layer for AI agents</title>
-  <meta name="description" content="Slack’s operating layer for AI agents: searchable workspace memory, approved actions, and typed workflows—local without an app/admin queue or hosted with permanent OAuth.">
+  <title>Slack MCP Server — Catch up on Slack without reading it</title>
+  <meta name="description" content="Catch up on Slack without reading it: unreads, threads, and search in your agent’s context, plus approved actions and typed workflows—local without an app/admin queue or hosted with permanent OAuth.">
   <link rel="canonical" href="{{GITHUB_PAGES_ROOT}}/">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Slack MCP Server — Ask what happened. Get receipts. Close the loop.">
@@ -14,7 +14,7 @@
   <meta property="og:image:width" content="1280">
   <meta property="og:image:height" content="640">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Slack’s operating layer for AI agents">
+  <meta name="twitter:title" content="Catch up on Slack without reading it">
   <meta name="twitter:description" content="Ask what happened. Get receipts. Close the loop—locally or through permanent hosted OAuth.">
   <meta name="twitter:image" content="{{SOCIAL_IMAGE_URL}}">
   <link rel="icon" href="{{ICON_URL}}" type="image/png">
@@ -187,7 +187,7 @@
     <main>
       <div class="frame hero">
         <div class="hero-copy">
-          <p class="eyebrow reveal">Slack’s operating layer for AI agents</p>
+          <p class="eyebrow reveal">Catch up on Slack without reading it</p>
           <h1 class="reveal">Ask what happened.<br><em>Get receipts.</em><br>Close the loop.</h1>
           <p class="hero-deck reveal">Turn Slack from an interruption stream into searchable operating memory and approved action. Run the <strong>{{SELF_HOSTED_TOOL_COUNT}}-tool surface available today</strong> locally with no app/admin queue, or move recurring work to hosted permanent OAuth, indexing, and schedules.</p>
           <div class="command-row reveal" aria-label="Install command">

--- a/templates/public-pages/share.html.tpl
+++ b/templates/public-pages/share.html.tpl
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Slack MCP Server</title>
-  <meta name="description" content="Slack’s operating layer for AI agents: local browser-session control or hosted permanent OAuth for recurring workflows.">
+  <meta name="description" content="Catch up on Slack without reading it: local browser-session control or hosted permanent OAuth for recurring workflows.">
   <link rel="canonical" href="{{GITHUB_PAGES_ROOT}}/public/share.html">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Slack MCP Server — Ask what happened. Get receipts. Close the loop.">
@@ -14,7 +14,7 @@
   <meta property="og:image:width" content="1280">
   <meta property="og:image:height" content="640">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Slack’s operating layer for AI agents">
+  <meta name="twitter:title" content="Catch up on Slack without reading it">
   <meta name="twitter:description" content="Local control now. Hosted continuity when the workflow must run without you.">
   <meta name="twitter:image" content="{{SOCIAL_IMAGE_URL}}">
   <link rel="icon" href="{{ICON_URL}}" type="image/png">


### PR DESCRIPTION
## Why

Discovery has flatlined — 60 unique repo viewers in 14 days, zero stars in August, and referrers show no Hacker News, no Reddit, no meaningful registry traffic. npm is steady, so this is not a quality problem: everyone who arrives converts, almost nobody arrives.

Two concrete causes this PR addresses.

**The hero claimed a category instead of naming a job.** It said nothing about who the reader is or why they'd install. The market already has vocabulary for this job — a major automation vendor ships a template called "Catch Up on Slack With AI", and r/AI_Agents has people trying to assemble exactly this morning digest by hand. We now use their words.

**Third-party directories are advertising copy that is no longer true.** Glama, PulseMCP, mcpservers.org, and Smithery all describe this server as needing "no OAuth" — each string is a word-for-word match to one of our own older auto-published registry descriptions (v1.1.8–v4.6.1). They scraped once and never re-synced. The official MCP Registry is correct because it auto-publishes on release, so a corrected canonical description is what re-seeds them.

## What changed

- **Header** leads with the job; badge row moves inside the centered column (it was the one element hugging the left margin while everything below it was centered).
- **CI badge** was the single palette violation in the header — it passed no `color` and rendered shields.io default green. Bound to `28c840`. Verified against the live SVG, which now carries `fill="#28c840"`.
- **Canonical description** synced across `package.json`, `server.json`, and the Dockerfile LABEL. 96 chars, inside the 100-char MCP registry cap, and it re-states hosted OAuth.
- **Landing page + share card** carried the old positioning in `<title>`, meta description, `twitter:title`, and the hero eyebrow. Updated so the README and the page it links to agree.
- **Nav label** "The moat" → "How it works".
- **`replaceTokens`** unused first callback arg → `_match`.

## Gate handling

`check-public-surface-integrity.js` gated the README on containing the old eyebrow string. Rather than drop the check, it now asserts the new lead — the gate's purpose (prevent positioning drift) is preserved.

`browser-smoke` asserts the landing H1 thesis and hero tool count. Both are deliberately untouched.

## Verification

| Gate | Result |
|---|---|
| `npm test` | 73 pass, 0 fail |
| `verify:public-surface` | exit 0 (28/28 checks) |
| `verify:public-pages` | exit 0 |
| `check-public-language.sh` | exit 0 |
| LSP diagnostics on `lib/`, changed scripts | 0 errors |
| Rendered README header | screenshotted via the GitHub markdown API and inspected |

Body prose arguing "the hard part is the operating layer underneath" is intentionally left in both README and landing page — that's a technical argument, not a hero claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Redesigned the README hero with clearer messaging, badges, setup guidance, and updated navigation.
* **Content & Metadata**
  * Updated page titles, descriptions, social previews, and server listings to emphasize catching up on Slack without reading everything.
  * Highlighted unread messages, threads, search, browser sessions, and hosted OAuth support.
  * Updated self-hosting messaging to emphasize free, local ownership.
* **Tests**
  * Refined public-content checks to validate the updated positioning and messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->