### PR TITLE
Code of conduct, issue routing, and the browser-ops deletion trap

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or setup help
+    url: https://github.com/jtalk22/slack-mcp-server/discussions
+    about: Ask in Discussions — setup, client configuration, and "how do I…" questions get answered faster there than in an issue.
+  - name: Token extraction or connection troubleshooting
+    url: https://github.com/jtalk22/slack-mcp-server/blob/main/docs/TROUBLESHOOTING.md
+    about: Run `npx -y @jtalk22/slack-mcp --doctor` first. The troubleshooting guide covers the common token, Keychain, and client-restart failures.
+  - name: Security vulnerability
+    url: https://github.com/jtalk22/slack-mcp-server/security/policy
+    about: Report privately by email. Do not open a public issue for anything involving credentials or session tokens.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,3 +134,19 @@ Tokens load from `~/.slack-mcp-tokens.json` or `SLACK_TOKEN`/`SLACK_COOKIE` env 
   admin panel — repo `.dockerignore`/Dockerfile changes don't affect it. Build
   failures there are usually their builder's infra; re-run via admin → Dockerfile
   → Build & Release.
+- **`workers/browser-ops/` is NOT dead code — do not delete it.** It looks
+  abandoned from inside this repo: no workflow references it, nothing runs
+  `wrangler deploy`, and the only commits since it was added are Dependabot
+  bumps. It is nevertheless **deployed** as the `slack-browser-ops` Worker and
+  consumed **cross-repo** by `revereveal/portfolio` → `grant-brief`, which binds
+  it as a service (`BROWSER_OPS_KEY`, header `x-browser-key`) and budgets
+  "5–20 browser-ops calls" per agent run for portal status checks. Deleting it
+  breaks the grant pipeline. Its `@cloudflare/puppeteer` → `extract-zip` alert
+  (#51, CVE-2026-56876) was dismissed as `not_used`, not fixed: `extract-zip`
+  only loads via puppeteer's Node launcher classes, while `index.js` calls
+  `puppeteer.launch(env.BROWSER)` through the Workers entry point to remote
+  Browser Rendering, and `workerd` cannot spawn processes or unzip anyway.
+  `workers/` is absent from the npm `files` whitelist, so it never ships to
+  package consumers. Re-open the alert if this ever runs under Node.
+  (`scripts/cloudflare-browser-tool.js` is a separate path — it calls
+  Cloudflare's REST Browser Rendering API directly and is unaffected.)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainer responsible for enforcement at
+**support@revasserlabs.com**.
+
+All complaints will be reviewed and investigated promptly and fairly. This is
+the same address used for security reports (see [SECURITY.md](SECURITY.md)); a
+report reaches the maintainer directly and is not visible publicly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+[homepage]: https://www.contributor-covenant.org
+[mozilla]: https://github.com/mozilla/diversity
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.


### PR DESCRIPTION
## Why

Two unrelated gaps, both hygiene, both cheap.

**Community profile was at 85%** — `code_of_conduct` and `issue_template` reported missing by `repos/.../community/profile`.

**A High-severity Dependabot alert (#51) needed triage**, and the triage produced a finding worth writing down permanently.

## The browser-ops trap

`workers/browser-ops/` reads as dead code from inside this repo: no workflow references it, nothing anywhere runs `wrangler deploy`, and every commit since it was added is a Dependabot bump. The obvious cleanup is to delete it.

That would break the grant pipeline. It is deployed as the `slack-browser-ops` Worker and consumed **cross-repo** by `revereveal/portfolio` → `grant-brief`, which binds it as a service (`BROWSER_OPS_KEY`, header `x-browser-key`) and budgets "5–20 browser-ops calls" per agent run for portal status checks.

So the maintainer doc now says so explicitly. That note is the durable half of this work — the alert is transient, the delete-during-cleanup risk is permanent.

## Alert #51 disposition

Dismissed as `not_used`, not fixed, because there is nothing to fix:

- `extract-zip`'s vulnerable symlink extraction only loads via puppeteer's Node launcher classes (`node/ChromeLauncher.js`, `node/FirefoxLauncher.js`, `node/PuppeteerNode.js`).
- `workers/browser-ops/index.js` calls `puppeteer.launch(env.BROWSER)`, which routes through the Workers entry point (`puppeteer-cloudflare.js`) to Cloudflare's remote Browser Rendering service — those launchers never load.
- `workerd` cannot spawn child processes or perform the local download/unzip that machinery requires.
- `workers/` is absent from the npm `files` whitelist, so no consumer of the package ever receives it.
- Upstream `first_patched_version` is `null`.

Open Dependabot alerts: **0** (verified live). The dismissal comment records the condition that would make it real again — browser-ops running under Node instead of workerd.

## Community files

- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1, enforcement contact `support@revasserlabs.com` so it shares SECURITY.md's private reporting path rather than opening a second one.
- `.github/ISSUE_TEMPLATE/config.yml` — blank issues off; routes setup questions to Discussions (enabled but sitting unused), connection failures to `TROUBLESHOOTING.md` behind a `--doctor` run, and anything credential-related to the private security policy.

## Verification

`npm test` 73 pass / 0 fail · `check-public-language.sh` exit 0 · `check-public-surface-integrity.js` exit 0 · `config.yml` parses, 3 contact links.
