### PR TITLE
slack_catch_me_up runs locally (v4.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,60 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.9.0] - 2026-08-13
+
+### Catch-up runs locally
+
+`slack_catch_me_up` was a hosted-only stub: it advertised a rich contract in
+every client's tool list and returned an upgrade payload. It runs locally now,
+against your own session, with no hosted account and no server-side model.
+
+The reason it can is structural. An MCP server is always called by something
+that is already a language model, so summarising was never the part that needed
+hosting — gathering was. This release does the gathering deterministically and
+returns evidence for the caller to compose.
+
+### Added
+
+- **`slack_catch_me_up`, local** (`lib/catch-up.js`) — reads a saved workflow
+  profile's channels since its cadence window (24h for `on_demand` and
+  `daily_8am`, 7 days for `weekly_monday`, or an explicit `since`), expands
+  active threads, and returns structured evidence:
+  - `signals.unanswered_threads` — messages nobody replied to, plus threads
+    where the only reply came from the person who opened it, ordered
+    oldest-first with an age in hours.
+  - `signals.priority_activity` and `signals.mentions_of_priority_people` —
+    what the profile's priority people said, and where they were pinned.
+  - `signals.busiest_conversations`, `signals.total_messages`.
+  - `output_contract` — the keys to compose for this `workflow_kind`. They are
+    deliberately **not** pre-filled; the payload is evidence, not a summary.
+  - `truncation` — every cap that bound the run, reported rather than applied
+    silently. A profile that names channels reads them even when Slack marks
+    nothing unread, because silence in `#incidents` is itself an answer.
+  - Work is bounded (12 conversations, 30 messages each, 8 expanded threads)
+    because outbound calls are paced by default; an unbounded sweep of a busy
+    workspace would take minutes.
+
+### Changed
+
+- **Positioning** — the hero led with a category claim. It now leads with the
+  job, and the canonical short description carries hosted OAuth, which several
+  third-party directories still deny because they scraped an older description
+  and never re-synced. Landing page, share card, and registry metadata follow.
+- **Tool inventory** — unchanged at 21 total (12 read-only, 4 write-path), but
+  the local workflow group grows to 3 and the hosted stub group shrinks to 2.
+  `slack_smart_search` and `slack_triage` remain hosted: an index and a model
+  are infrastructure this package genuinely does not ship.
+- `check-public-surface-integrity.js` no longer treats `slack_catch_me_up` as an
+  upgrade stub, so narrowed profiles may advertise it without tripping the
+  leak gate.
+
+### Fixed
+
+- `replaceTokens` in `lib/public-pages.js` declared an unused callback argument.
+- The CI badge passed no `color` and rendered shields.io default green, the one
+  palette violation in the README header.
+
 ## [4.8.0] - 2026-08-07
 
 ### Tool profiles and request pacing

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ On macOS, setup can extract from Chrome and persist the selected storage backend
 
 ## 21 tools: read, act, automate
 
-The local surface ships **21 tools** today: **12 read-only** Slack operations, **4 write-path** tools that each carry an MCP destructive annotation so clients can gate workspace writes, 2 local workflow primitives, and 3 hosted-intelligence stubs that return a structured upgrade payload without making a Slack call. Four read tools accept `include_rich_message_fields: true` to surface attachments, blocks, files, reactions, and metadata—complete inputs and response contracts live in [docs/API.md](docs/API.md).
+The local surface ships **21 tools** today: **12 read-only** Slack operations, **4 write-path** tools that each carry an MCP destructive annotation so clients can gate workspace writes, 3 local workflow tools including the catch-up itself, and 2 hosted-intelligence stubs that return a structured upgrade payload without making a Slack call. Four read tools accept `include_rich_message_fields: true` to surface attachments, blocks, files, reactions, and metadata—complete inputs and response contracts live in [docs/API.md](docs/API.md).
 
 **Advertising fewer tools.** A client pays for the tool schema on every turn that carries it. `SLACK_MCP_TOOLS=essentials` advertises six tools — unread, history, search, thread, user lookup, send — costing roughly **985 estimated tokens** of schema per turn against about **3,600** for all 21. `SLACK_MCP_TOOLS=read` advertises the 12 read-only Slack operations listed below, near 1,690. `--tools=slack_x,slack_y` takes an explicit set. The default stays all 21. Filtering changes what is advertised, not what is callable. Reproduce the numbers with `node scripts/measure-tool-schema.js` (a ~4-chars-per-token estimate).
 
@@ -223,22 +223,22 @@ The local surface ships **21 tools** today: **12 read-only** Slack operations, *
 | `slack_remove_reaction` | Remove an emoji reaction | destructive |
 | `slack_conversations_mark` | Mark a conversation read | destructive |
 
-### Automate locally — 2 workflow primitives
+### Automate locally — 3 workflow tools
 
 | Tool | Purpose |
 |---|---|
 | `slack_workflow_save` | Save a typed workflow profile to `~/.slack-mcp-workflows.json` |
 | `slack_workflows` | List saved workflow profiles |
+| `slack_catch_me_up` | Read a profile's channels since its cadence window and return structured catch-up evidence |
 
-### Discover hosted intelligence — 3 explicit stubs
+### Discover hosted intelligence — 2 explicit stubs
 
 | Tool | Hosted result |
 |---|---|
 | `slack_smart_search` | Semantic + lexical search over indexed Slack history |
-| `slack_catch_me_up` | Structured catch-up against a saved workflow profile |
 | `slack_triage` | Prioritized action queue with routing recommendations |
 
-The OSS stubs make the hosted capability discoverable; they do not make a Slack call. `slack_refresh_tokens` only writes local credential state.
+These two need infrastructure this package does not ship — an index and a model — so the OSS handlers return a structured upgrade payload instead of making a Slack call. `slack_catch_me_up` needs neither and runs locally. `slack_refresh_tokens` only writes local credential state.
 
 </details>
 
@@ -246,7 +246,9 @@ The OSS stubs make the hosted capability discoverable; they do not make a Slack 
 
 ## Typed workflows: Slack in, JSON out
 
-Bind a workflow kind to channels, priority people, retention, and cadence. The local profile primitives are free; hosted performs the indexed retrieval and contract-validated summarization that turn profiles into durable scheduled operations.
+Bind a workflow kind to channels, priority people, retention, and cadence. `slack_catch_me_up` then reads that scope locally and hands your agent the evidence: which threads went unanswered and for how long, what your priority people said or were pinned on, which conversations actually moved. It does the gathering; your agent writes the summary against the contract below.
+
+There is no server-side model in that path, because there does not need to be one — the client calling this server is already a language model. Hosted adds what genuinely needs infrastructure: indexed semantic retrieval, and running the same catch-up on a schedule while your laptop is shut.
 
 ```bash
 npx -y @jtalk22/slack-mcp --apply-template oncall-handoff --channels C012345,C067890

--- a/lib/catch-up.js
+++ b/lib/catch-up.js
@@ -1,0 +1,290 @@
+/**
+ * Local catch-up assembly.
+ *
+ * `slack_catch_me_up` used to be a hosted-only stub that returned an upgrade
+ * payload. It runs locally now, and it does so WITHOUT any server-side model:
+ * an MCP server is always called by something that is already a language model,
+ * so the useful division of labour is that this module gathers and structures
+ * the evidence deterministically and the calling model writes the prose.
+ *
+ * Everything here composes calls the server already makes elsewhere
+ * (conversations.list / .history / .replies). No new Slack surface, no new
+ * dependency, no network egress beyond Slack.
+ *
+ * Work is explicitly bounded. Outbound calls are paced by default
+ * (SLACK_MCP_MIN_REQUEST_INTERVAL_MS), so an unbounded sweep across a busy
+ * workspace would take minutes. Every cap below is reported back in
+ * `truncation` rather than silently applied — a catch-up that quietly dropped
+ * half the workspace would be worse than no catch-up at all.
+ */
+
+export const CATCH_UP_CAPS = Object.freeze({
+  maxConversations: 12,
+  maxMessagesPerConversation: 30,
+  maxThreadsExpanded: 8,
+  maxRepliesPerThread: 20,
+  conversationScanLimit: 200,
+});
+
+const CADENCE_LOOKBACK_HOURS = Object.freeze({
+  on_demand: 24,
+  daily_8am: 24,
+  weekly_monday: 168,
+});
+
+const MENTION_PATTERN = /<@([A-Z0-9]+)>/g;
+
+/**
+ * Decide the window this catch-up covers.
+ *
+ * An explicit `since` always wins. Otherwise the profile's cadence picks the
+ * lookback, which is what makes a `weekly_monday` profile actually reach back a
+ * week instead of quietly reporting one day of activity.
+ */
+export function resolveSince({ since, profile, now = new Date() }) {
+  if (typeof since === "string" && since.trim()) {
+    const parsed = new Date(since);
+    if (Number.isNaN(parsed.getTime())) {
+      return { ok: false, error: `since must be an ISO 8601 timestamp; received "${since}"` };
+    }
+    return { ok: true, iso: parsed.toISOString(), epoch: parsed.getTime() / 1000, source: "explicit" };
+  }
+  const cadence = (profile && profile.summary_cadence) || "on_demand";
+  const hours = CADENCE_LOOKBACK_HOURS[cadence] ?? CADENCE_LOOKBACK_HOURS.on_demand;
+  const computed = new Date(now.getTime() - hours * 3600 * 1000);
+  return {
+    ok: true,
+    iso: computed.toISOString(),
+    epoch: computed.getTime() / 1000,
+    source: `cadence:${cadence}`,
+    lookback_hours: hours,
+  };
+}
+
+export function extractMentions(text) {
+  if (typeof text !== "string") return [];
+  const found = new Set();
+  for (const match of text.matchAll(MENTION_PATTERN)) found.add(match[1]);
+  return Array.from(found);
+}
+
+function hoursSince(tsSeconds, now) {
+  return Math.round(((now.getTime() / 1000 - Number(tsSeconds)) / 3600) * 10) / 10;
+}
+
+/**
+ * Derive the facts a summariser would otherwise have to infer message by
+ * message. These are computed, not judged — every one of them is checkable
+ * against the `conversations` payload in the same response.
+ */
+export function computeSignals({ conversations, priorityPeople = [], now = new Date() }) {
+  const priority = new Set(priorityPeople);
+  const unansweredThreads = [];
+  const priorityActivity = [];
+  const mentionsOfPriority = [];
+
+  for (const convo of conversations) {
+    for (const msg of convo.messages || []) {
+      if (msg.user_id && priority.has(msg.user_id)) {
+        priorityActivity.push({
+          conversation: convo.name,
+          conversation_id: convo.id,
+          ts: msg.ts,
+          user: msg.user,
+          text: msg.text,
+        });
+      }
+
+      const mentioned = extractMentions(msg.text).filter((id) => priority.has(id));
+      if (mentioned.length) {
+        mentionsOfPriority.push({
+          conversation: convo.name,
+          conversation_id: convo.id,
+          ts: msg.ts,
+          mentioned_user_ids: mentioned,
+          text: msg.text,
+        });
+      }
+
+      // "Unanswered" is deliberately mechanical: either nobody replied at all,
+      // or a thread exists and its last reply is still the person who opened
+      // it. Anything softer would be a judgement call, which is the caller's
+      // job, not this module's.
+      const replies = msg.thread ? msg.thread.replies || [] : [];
+      const noReplies = !msg.thread && !msg.has_thread;
+      const lastReply = replies.length ? replies[replies.length - 1] : null;
+      const onlyOpenerSpoke = lastReply && lastReply.user_id && lastReply.user_id === msg.user_id;
+
+      if (noReplies || onlyOpenerSpoke) {
+        unansweredThreads.push({
+          conversation: convo.name,
+          conversation_id: convo.id,
+          ts: msg.ts,
+          user: msg.user,
+          text: msg.text,
+          reply_count: replies.length,
+          age_hours: hoursSince(msg.ts, now),
+        });
+      }
+    }
+  }
+
+  unansweredThreads.sort((a, b) => b.age_hours - a.age_hours);
+
+  const busiest = conversations
+    .map((c) => ({ conversation: c.name, conversation_id: c.id, message_count: (c.messages || []).length }))
+    .filter((c) => c.message_count > 0)
+    .sort((a, b) => b.message_count - a.message_count);
+
+  return {
+    unanswered_threads: unansweredThreads,
+    oldest_unanswered_age_hours: unansweredThreads.length ? unansweredThreads[0].age_hours : null,
+    priority_activity: priorityActivity,
+    mentions_of_priority_people: mentionsOfPriority,
+    busiest_conversations: busiest,
+    total_messages: conversations.reduce((sum, c) => sum + (c.messages || []).length, 0),
+  };
+}
+
+/**
+ * Pick which conversations this run will read.
+ *
+ * A profile that names channels is authoritative — those channels are read
+ * whether or not Slack marks them unread, because "nothing new in #incidents"
+ * is itself an answer. A profile with no channels falls back to whatever
+ * currently carries unreads.
+ */
+export function selectConversations({ channels, profileChannels = [], caps = CATCH_UP_CAPS }) {
+  const scoped = profileChannels.length
+    ? channels.filter((c) => profileChannels.includes(c.id) || profileChannels.includes(c.name))
+    : channels.filter((c) => c.unread_count > 0);
+
+  const ordered = [...scoped].sort((a, b) => b.unread_count - a.unread_count);
+  return {
+    selected: ordered.slice(0, caps.maxConversations),
+    dropped: Math.max(0, ordered.length - caps.maxConversations),
+    matched: ordered.length,
+  };
+}
+
+/**
+ * Assemble the bundle.
+ *
+ * `deps` carries the Slack surface so this is unit-testable against fixtures
+ * without a live workspace or a network stub.
+ */
+export async function assembleCatchUp({ profile, since, deps, caps = CATCH_UP_CAPS, now = new Date() }) {
+  const { slackAPI, resolveUser, structuredKeys } = deps;
+
+  const listed = await slackAPI("conversations.list", {
+    types: "im,mpim,public_channel,private_channel",
+    limit: caps.conversationScanLimit,
+    exclude_archived: true,
+  });
+
+  const channels = [];
+  for (const c of listed.channels || []) {
+    channels.push({
+      id: c.id,
+      name: c.is_im && c.user ? await resolveUser(c.user) : c.name,
+      type: c.is_im ? "dm" : c.is_mpim ? "group_dm" : c.is_private ? "private_channel" : "public_channel",
+      unread_count: c.unread_count_display || c.unread_count || 0,
+    });
+  }
+
+  const { selected, dropped, matched } = selectConversations({
+    channels,
+    profileChannels: profile.channels || [],
+    caps,
+  });
+
+  let threadsExpanded = 0;
+  let messagesDropped = 0;
+  const conversations = [];
+
+  for (const convo of selected) {
+    const history = await slackAPI("conversations.history", {
+      channel: convo.id,
+      oldest: String(since.epoch),
+      limit: caps.maxMessagesPerConversation,
+      inclusive: true,
+    });
+
+    const raw = history.messages || [];
+    if (history.has_more) messagesDropped += 1;
+
+    const messages = [];
+    for (const msg of raw) {
+      const entry = {
+        ts: msg.ts,
+        user_id: msg.user || null,
+        user: msg.user ? await resolveUser(msg.user) : null,
+        text: msg.text || "",
+        age_hours: hoursSince(msg.ts, now),
+        has_thread: Boolean(msg.thread_ts && msg.reply_count > 0),
+        reply_count: msg.reply_count || 0,
+      };
+
+      if (entry.has_thread && threadsExpanded < caps.maxThreadsExpanded) {
+        threadsExpanded += 1;
+        const thread = await slackAPI("conversations.replies", {
+          channel: convo.id,
+          ts: msg.thread_ts || msg.ts,
+          limit: caps.maxRepliesPerThread,
+        });
+        const replies = [];
+        for (const reply of (thread.messages || []).slice(1)) {
+          replies.push({
+            ts: reply.ts,
+            user_id: reply.user || null,
+            user: reply.user ? await resolveUser(reply.user) : null,
+            text: reply.text || "",
+          });
+        }
+        entry.thread = { reply_count: replies.length, replies };
+      }
+
+      messages.push(entry);
+    }
+
+    messages.sort((a, b) => Number(a.ts) - Number(b.ts));
+    conversations.push({ ...convo, message_count: messages.length, messages });
+  }
+
+  const signals = computeSignals({
+    conversations,
+    priorityPeople: profile.priority_people || [],
+    now,
+  });
+
+  return {
+    profile_name: profile.profile_name,
+    workflow_kind: profile.workflow_kind,
+    since: since.iso,
+    since_source: since.source,
+    generated_at: now.toISOString(),
+    scope: {
+      channels_in_profile: (profile.channels || []).length,
+      conversations_matched: matched,
+      conversations_read: conversations.length,
+      priority_people: profile.priority_people || [],
+    },
+    signals,
+    conversations,
+    output_contract: {
+      workflow_kind: profile.workflow_kind,
+      expected_keys: structuredKeys,
+      note:
+        "This payload is evidence, not a summary. Compose the keys above from `signals` and " +
+        "`conversations`, citing conversation names and timestamps. Every claim you make should " +
+        "be checkable against a message in this response.",
+    },
+    truncation: {
+      conversations_dropped: dropped,
+      conversations_with_more_history: messagesDropped,
+      threads_expanded: threadsExpanded,
+      thread_expansion_capped: threadsExpanded >= caps.maxThreadsExpanded,
+      caps,
+    },
+  };
+}

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -19,8 +19,11 @@ import { slackAPI, resolveUser, formatTimestamp, sleep, checkTokenHealth, getUse
 import {
   saveProfile as workflowSaveProfile,
   listProfiles as workflowListProfiles,
+  getProfile as workflowGetProfile,
+  structuredKeysFor,
   ALLOWED_WORKFLOW_KINDS_LIST,
 } from "./workflow-store.js";
+import { assembleCatchUp, resolveSince } from "./catch-up.js";
 import { withRichMessageFields } from "./rich-message-fields.js";
 import { isAuthDeath, lifeboatResponse } from "./lifeboat.js";
 
@@ -905,14 +908,54 @@ export async function handleSmartSearch(args) {
   );
 }
 
+/**
+ * Catch up on a saved workflow profile — locally, with no hosted dependency.
+ *
+ * This was a hosted-only stub. It runs here now because the expensive part was
+ * never the summarising: the caller is already a language model. What it needed
+ * was the evidence, gathered and structured. See lib/catch-up.js.
+ */
 export async function handleCatchMeUp(args) {
-  return asMcpJson(
-    {
-      ...HOSTED_UPGRADE_PAYLOAD,
-      requested: { tool: "slack_catch_me_up", args: args || {} },
-    },
-    true
-  );
+  const profileName = args && typeof args.profile_name === "string" ? args.profile_name.trim() : "";
+  if (!profileName) {
+    return asMcpJson(
+      {
+        status: "error",
+        code: "invalid_arguments",
+        message: "profile_name is required.",
+        next_action: "Run slack_workflows to list saved profiles, or slack_workflow_save to create one.",
+      },
+      true
+    );
+  }
+
+  const profile = workflowGetProfile(profileName);
+  if (!profile) {
+    const known = workflowListProfiles();
+    return asMcpJson(
+      {
+        status: "error",
+        code: "profile_not_found",
+        message: `No saved workflow profile named "${profileName}".`,
+        available_profiles: known.ok ? known.profiles.map((p) => p.profile_name) : [],
+        next_action: "Create it with slack_workflow_save, or apply a starter template with --apply-template.",
+      },
+      true
+    );
+  }
+
+  const since = resolveSince({ since: args.since, profile });
+  if (!since.ok) {
+    return asMcpJson({ status: "error", code: "invalid_arguments", message: since.error }, true);
+  }
+
+  const bundle = await assembleCatchUp({
+    profile,
+    since,
+    deps: { slackAPI, resolveUser, structuredKeys: structuredKeysFor(profile.workflow_kind) },
+  });
+
+  return asMcpJson(bundle);
 }
 
 export async function handleTriage(args) {

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -498,10 +498,36 @@ export const TOOLS = [
       openWorldHint: false
     }
   },
+  {
+    name: "slack_catch_me_up",
+    description: "Catch up on a saved workflow profile. Reads the profile's channels (or everything currently unread if the profile names none), pulls messages since the cadence window or an explicit `since`, expands active threads, and returns structured evidence: which threads are unanswered and for how long, what the profile's priority people said or were pinned on, and which conversations moved most. Runs locally against your own session — no hosted account, no server-side model. The response carries an `output_contract` naming the keys to compose for this workflow_kind; write the summary from the returned `signals` and `conversations`, citing conversation names and timestamps.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        profile_name: {
+          type: "string",
+          description: "Name of a workflow profile saved via slack_workflow_save (list them with slack_workflows)"
+        },
+        since: {
+          type: "string",
+          description: "Optional ISO 8601 timestamp — only consider messages newer than this. Defaults to the profile's cadence window: 24 hours for on_demand and daily_8am, 7 days for weekly_monday."
+        }
+      },
+      required: ["profile_name"]
+    },
+    annotations: {
+      title: "Catch Me Up",
+      readOnlyHint: true,
+      idempotentHint: false,
+      openWorldHint: false
+    }
+  },
   // ============ Hosted-Only AI Tools (OSS = upgrade stubs) ============
-  // These tool definitions appear in every MCP client's tool list so users
-  // discover them. The OSS handlers return a structured upgrade message
-  // pointing at mcp.revasserlabs.com — the hosted worker actually runs them.
+  // These two need infrastructure this package does not ship — an index and a
+  // model. They appear in the tool list so the capability is discoverable, and
+  // the OSS handlers return a structured upgrade message rather than a Slack
+  // call. slack_catch_me_up used to live here; it does not need either, so it
+  // runs locally now (lib/catch-up.js).
   {
     name: "slack_smart_search",
     description: "Semantic + lexical hybrid search across your indexed Slack history. Returns ranked results with relevance scores, channel context, thread context, and matched terms. Hosted-only (requires Vectorize + Workers AI). Free tier ships 25 AI tool calls/month (shared across the hosted AI tools); upgrade to Pro $19/mo for unlimited at mcp.revasserlabs.com/pricing.",
@@ -532,30 +558,6 @@ export const TOOLS = [
       title: "Smart Search (hosted)",
       readOnlyHint: true,
       idempotentHint: true,
-      openWorldHint: true
-    }
-  },
-  {
-    name: "slack_catch_me_up",
-    description: "Run a structured catch-up against a saved workflow profile. Returns structured JSON per the profile's workflow_kind: support_inbox returns {open_threads, ack_lag, owner_gaps, escalations, next_actions}; incident_room returns {incident_summary, timeline, open_risks, owner_gaps, next_actions}; exec_brief returns {summary, decisions, risks, asks, action_items}; product_launch_watch returns {launch_signals, feedback_themes, blockers, metrics, next_actions}; custom returns {summary, highlights, open_questions, next_actions}. Hosted-only. Free tier ships 25 AI tool calls/month (shared across the hosted AI tools); Pro $19/mo unlocks unlimited.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        profile_name: {
-          type: "string",
-          description: "Name of a workflow profile saved via slack_workflow_save (or use --apply-template at install time to seed one)"
-        },
-        since: {
-          type: "string",
-          description: "Optional ISO8601 timestamp — only consider Slack messages newer than this. Default: 24 hours ago for daily-cadence profiles, 7 days for weekly."
-        }
-      },
-      required: ["profile_name"]
-    },
-    annotations: {
-      title: "Catch Me Up (hosted)",
-      readOnlyHint: true,
-      idempotentHint: false,
       openWorldHint: true
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jtalk22/slack-mcp",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jtalk22/slack-mcp",
-      "version": "4.8.0",
+      "version": "4.9.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jtalk22/slack-mcp",
   "mcpName": "io.github.jtalk22/slack-mcp-server",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "description": "Catch up on Slack without reading it. Unreads, threads, search. Browser-session or hosted OAuth.",
   "funding": {
     "type": "github",

--- a/scripts/check-public-surface-integrity.js
+++ b/scripts/check-public-surface-integrity.js
@@ -186,7 +186,10 @@ function main() {
     `all=${TOOLS.length} (README ${PUBLIC_METADATA.selfHostedToolCount}), read=${READ_TOOLS.length} (README 12), essentials=${ESSENTIALS_TOOLS.length}`
   );
 
-  const hostedStubs = ["slack_smart_search", "slack_catch_me_up", "slack_triage"];
+  // slack_catch_me_up is deliberately absent: it runs locally now (lib/catch-up.js),
+  // so it is no longer an upgrade stub and no longer a leak when a narrowed
+  // profile advertises it.
+  const hostedStubs = ["slack_smart_search", "slack_triage"];
   const narrowedLeaks = ["read", "essentials"].flatMap((profile) =>
     resolveToolProfile(profile)
       .tools.map((tool) => tool.name)

--- a/server.json
+++ b/server.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/jtalk22/slack-mcp-server",
     "source": "github"
   },
-  "version": "4.8.0",
+  "version": "4.9.0",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
     {
       "registryType": "npm",
       "identifier": "@jtalk22/slack-mcp",
-      "version": "4.8.0",
+      "version": "4.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/test/catch-up.test.js
+++ b/test/catch-up.test.js
@@ -1,0 +1,343 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  CATCH_UP_CAPS,
+  assembleCatchUp,
+  computeSignals,
+  extractMentions,
+  resolveSince,
+  selectConversations,
+} from "../lib/catch-up.js";
+
+const NOW = new Date("2026-08-13T12:00:00.000Z");
+const HOUR = 3600;
+const NOW_EPOCH = NOW.getTime() / 1000;
+
+function ts(hoursAgo) {
+  return String(NOW_EPOCH - hoursAgo * HOUR);
+}
+
+// ---------------------------------------------------------------- since
+
+test("explicit since wins over the profile cadence", () => {
+  const r = resolveSince({
+    since: "2026-08-01T00:00:00Z",
+    profile: { summary_cadence: "weekly_monday" },
+    now: NOW,
+  });
+  assert.equal(r.ok, true);
+  assert.equal(r.source, "explicit");
+  assert.equal(r.iso, "2026-08-01T00:00:00.000Z");
+});
+
+test("cadence picks the lookback when since is absent", () => {
+  const weekly = resolveSince({ profile: { summary_cadence: "weekly_monday" }, now: NOW });
+  assert.equal(weekly.lookback_hours, 168, "weekly reaches back a week, not a day");
+
+  const daily = resolveSince({ profile: { summary_cadence: "daily_8am" }, now: NOW });
+  assert.equal(daily.lookback_hours, 24);
+
+  const missing = resolveSince({ profile: {}, now: NOW });
+  assert.equal(missing.lookback_hours, 24, "absent cadence falls back to 24h, never to zero");
+});
+
+test("an unparseable since is rejected rather than silently defaulted", () => {
+  const r = resolveSince({ since: "last tuesday", profile: {}, now: NOW });
+  assert.equal(r.ok, false);
+  assert.match(r.error, /ISO 8601/);
+});
+
+// ---------------------------------------------------------------- mentions
+
+test("extractMentions pulls unique user ids and tolerates junk", () => {
+  assert.deepEqual(extractMentions("hey <@U1> and <@U2> and <@U1> again"), ["U1", "U2"]);
+  assert.deepEqual(extractMentions("no mentions here"), []);
+  assert.deepEqual(extractMentions(null), []);
+});
+
+// ---------------------------------------------------------------- selection
+
+test("a profile that names channels reads them even when nothing is unread", () => {
+  const channels = [
+    { id: "C1", name: "incidents", unread_count: 0 },
+    { id: "C2", name: "random", unread_count: 40 },
+  ];
+  const { selected } = selectConversations({ channels, profileChannels: ["C1"] });
+  assert.deepEqual(
+    selected.map((c) => c.id),
+    ["C1"],
+    "silence in a scoped channel is itself an answer"
+  );
+});
+
+test("a profile with no channels falls back to whatever is unread", () => {
+  const channels = [
+    { id: "C1", name: "quiet", unread_count: 0 },
+    { id: "C2", name: "loud", unread_count: 40 },
+  ];
+  const { selected } = selectConversations({ channels, profileChannels: [] });
+  assert.deepEqual(selected.map((c) => c.id), ["C2"]);
+});
+
+test("over-cap selection truncates and reports how much it dropped", () => {
+  const channels = Array.from({ length: 20 }, (_, i) => ({
+    id: `C${i}`,
+    name: `c${i}`,
+    unread_count: i + 1,
+  }));
+  const { selected, dropped, matched } = selectConversations({ channels, profileChannels: [] });
+  assert.equal(selected.length, CATCH_UP_CAPS.maxConversations);
+  assert.equal(matched, 20);
+  assert.equal(dropped, 20 - CATCH_UP_CAPS.maxConversations, "truncation is reported, not silent");
+  assert.equal(selected[0].unread_count, 20, "busiest first");
+});
+
+// ---------------------------------------------------------------- signals
+
+test("a message nobody replied to counts as unanswered", () => {
+  const signals = computeSignals({
+    now: NOW,
+    conversations: [
+      {
+        id: "C1",
+        name: "support",
+        messages: [{ ts: ts(5), user_id: "U9", user: "ana", text: "can someone look at this?", has_thread: false }],
+      },
+    ],
+  });
+  assert.equal(signals.unanswered_threads.length, 1);
+  assert.equal(signals.oldest_unanswered_age_hours, 5);
+});
+
+test("a thread where only the opener spoke still counts as unanswered", () => {
+  const signals = computeSignals({
+    now: NOW,
+    conversations: [
+      {
+        id: "C1",
+        name: "support",
+        messages: [
+          {
+            ts: ts(3),
+            user_id: "U9",
+            user: "ana",
+            text: "anyone?",
+            has_thread: true,
+            thread: { reply_count: 1, replies: [{ ts: ts(2), user_id: "U9", user: "ana", text: "bumping" }] },
+          },
+        ],
+      },
+    ],
+  });
+  assert.equal(signals.unanswered_threads.length, 1, "self-bump is not an answer");
+});
+
+test("a genuinely answered thread is not reported as unanswered", () => {
+  const signals = computeSignals({
+    now: NOW,
+    conversations: [
+      {
+        id: "C1",
+        name: "support",
+        messages: [
+          {
+            ts: ts(3),
+            user_id: "U9",
+            user: "ana",
+            text: "anyone?",
+            has_thread: true,
+            thread: { reply_count: 1, replies: [{ ts: ts(2), user_id: "U7", user: "bo", text: "on it" }] },
+          },
+        ],
+      },
+    ],
+  });
+  assert.equal(signals.unanswered_threads.length, 0);
+  assert.equal(signals.oldest_unanswered_age_hours, null);
+});
+
+test("priority people are tracked both as authors and as mention targets", () => {
+  const signals = computeSignals({
+    now: NOW,
+    priorityPeople: ["UBOSS"],
+    conversations: [
+      {
+        id: "C1",
+        name: "exec",
+        messages: [
+          { ts: ts(2), user_id: "UBOSS", user: "boss", text: "shipping friday", has_thread: false },
+          { ts: ts(1), user_id: "U2", user: "dev", text: "<@UBOSS> need a decision", has_thread: false },
+        ],
+      },
+    ],
+  });
+  assert.equal(signals.priority_activity.length, 1);
+  assert.equal(signals.priority_activity[0].user, "boss");
+  assert.equal(signals.mentions_of_priority_people.length, 1);
+  assert.deepEqual(signals.mentions_of_priority_people[0].mentioned_user_ids, ["UBOSS"]);
+});
+
+test("unanswered threads are ordered oldest-first", () => {
+  const signals = computeSignals({
+    now: NOW,
+    conversations: [
+      {
+        id: "C1",
+        name: "support",
+        messages: [
+          { ts: ts(1), user_id: "U1", user: "a", text: "new", has_thread: false },
+          { ts: ts(30), user_id: "U2", user: "b", text: "stale", has_thread: false },
+        ],
+      },
+    ],
+  });
+  assert.equal(signals.unanswered_threads[0].text, "stale", "the thing rotting longest surfaces first");
+  assert.equal(signals.oldest_unanswered_age_hours, 30);
+});
+
+// ---------------------------------------------------------------- assembly
+
+function fakeDeps({ channels, history = {}, replies = {} }) {
+  const calls = [];
+  return {
+    calls,
+    deps: {
+      structuredKeys: ["summary", "highlights", "open_questions", "next_actions"],
+      resolveUser: async (id) => `user:${id}`,
+      slackAPI: async (method, params) => {
+        calls.push({ method, params });
+        if (method === "conversations.list") return { channels };
+        if (method === "conversations.history") return history[params.channel] || { messages: [] };
+        if (method === "conversations.replies") return replies[params.ts] || { messages: [] };
+        throw new Error(`unexpected method ${method}`);
+      },
+    },
+  };
+}
+
+test("assembleCatchUp returns evidence plus the contract, and never invents prose", async () => {
+  const { deps } = fakeDeps({
+    channels: [{ id: "C1", name: "incidents", unread_count: 3 }],
+    history: {
+      C1: {
+        messages: [
+          { ts: ts(4), user: "U1", text: "db is down", reply_count: 0 },
+          { ts: ts(2), user: "U2", text: "<@U1> looking", reply_count: 0 },
+        ],
+      },
+    },
+  });
+
+  const bundle = await assembleCatchUp({
+    profile: {
+      profile_name: "oncall",
+      workflow_kind: "custom",
+      channels: ["C1"],
+      priority_people: ["U1"],
+      summary_cadence: "on_demand",
+    },
+    since: resolveSince({ profile: { summary_cadence: "on_demand" }, now: NOW }),
+    deps,
+    now: NOW,
+  });
+
+  assert.equal(bundle.profile_name, "oncall");
+  assert.equal(bundle.conversations.length, 1);
+  assert.equal(bundle.conversations[0].message_count, 2);
+  assert.deepEqual(bundle.output_contract.expected_keys, [
+    "summary",
+    "highlights",
+    "open_questions",
+    "next_actions",
+  ]);
+  // The contract keys must NOT be pre-filled — composing them is the caller's job.
+  for (const key of bundle.output_contract.expected_keys) {
+    assert.equal(bundle[key], undefined, `${key} must not be fabricated server-side`);
+  }
+  assert.equal(bundle.signals.mentions_of_priority_people.length, 1);
+  assert.equal(bundle.signals.total_messages, 2);
+});
+
+test("messages come back oldest-first so a timeline reads in order", async () => {
+  const { deps } = fakeDeps({
+    channels: [{ id: "C1", name: "incidents", unread_count: 2 }],
+    history: {
+      C1: {
+        messages: [
+          { ts: ts(1), user: "U1", text: "newest", reply_count: 0 },
+          { ts: ts(9), user: "U1", text: "oldest", reply_count: 0 },
+        ],
+      },
+    },
+  });
+  const bundle = await assembleCatchUp({
+    profile: { profile_name: "p", workflow_kind: "custom", channels: ["C1"], priority_people: [] },
+    since: resolveSince({ profile: {}, now: NOW }),
+    deps,
+    now: NOW,
+  });
+  assert.deepEqual(bundle.conversations[0].messages.map((m) => m.text), ["oldest", "newest"]);
+});
+
+test("thread expansion is capped, and the cap is reported", async () => {
+  const messages = Array.from({ length: 12 }, (_, i) => ({
+    ts: ts(i + 1),
+    thread_ts: ts(i + 1),
+    user: "U1",
+    text: `m${i}`,
+    reply_count: 2,
+  }));
+  const replies = {};
+  for (const m of messages) {
+    replies[m.ts] = { messages: [{ ts: m.ts, user: "U1", text: m.text }, { ts: m.ts, user: "U2", text: "reply" }] };
+  }
+  const { deps, calls } = fakeDeps({
+    channels: [{ id: "C1", name: "busy", unread_count: 12 }],
+    history: { C1: { messages } },
+    replies,
+  });
+
+  const bundle = await assembleCatchUp({
+    profile: { profile_name: "p", workflow_kind: "custom", channels: ["C1"], priority_people: [] },
+    since: resolveSince({ profile: {}, now: NOW }),
+    deps,
+    now: NOW,
+  });
+
+  const replyCalls = calls.filter((c) => c.method === "conversations.replies").length;
+  assert.equal(replyCalls, CATCH_UP_CAPS.maxThreadsExpanded, "pacing budget is respected");
+  assert.equal(bundle.truncation.threads_expanded, CATCH_UP_CAPS.maxThreadsExpanded);
+  assert.equal(bundle.truncation.thread_expansion_capped, true, "the caller is told coverage was bounded");
+});
+
+test("has_more history is surfaced rather than passed off as complete", async () => {
+  const { deps } = fakeDeps({
+    channels: [{ id: "C1", name: "firehose", unread_count: 900 }],
+    history: { C1: { messages: [{ ts: ts(1), user: "U1", text: "x", reply_count: 0 }], has_more: true } },
+  });
+  const bundle = await assembleCatchUp({
+    profile: { profile_name: "p", workflow_kind: "custom", channels: [], priority_people: [] },
+    since: resolveSince({ profile: {}, now: NOW }),
+    deps,
+    now: NOW,
+  });
+  assert.equal(bundle.truncation.conversations_with_more_history, 1);
+});
+
+test("the since window is passed to Slack as an epoch oldest bound", async () => {
+  const { deps, calls } = fakeDeps({
+    channels: [{ id: "C1", name: "c", unread_count: 1 }],
+    history: { C1: { messages: [] } },
+  });
+  const since = resolveSince({ profile: { summary_cadence: "weekly_monday" }, now: NOW });
+  await assembleCatchUp({
+    profile: { profile_name: "p", workflow_kind: "custom", channels: ["C1"], priority_people: [] },
+    since,
+    deps,
+    now: NOW,
+  });
+  const historyCall = calls.find((c) => c.method === "conversations.history");
+  assert.equal(historyCall.params.oldest, String(since.epoch));
+  assert.equal(Number(historyCall.params.oldest), NOW_EPOCH - 168 * HOUR);
+});


### PR DESCRIPTION
## The problem

`slack_catch_me_up` was a hosted-only stub. It advertised a rich JSON contract in every MCP client's tool list and returned `{signup_url, free_tier_quota, pro_value_prop}`.

That was defensible while the README led with a category claim. It stopped being defensible the moment the README started leading with **"Catch up on Slack without reading it"** (#225) — the one tool named after the headline feature was an advertisement. Install on that promise, call the obvious tool, get a signup link.

There's also precedent: #220 already removed these stubs from the `read` profile, on the reasoning that shipping paid-tier upsell tools to people who narrowed their surface to save schema cost was wrong. The same reasoning reaches the default profile.

## Why it can run locally

Structural, not generous. **An MCP server is always called by something that is already a language model.** Summarising was never the part that needed hosting — gathering was.

So `lib/catch-up.js` does the gathering deterministically and returns evidence for the caller to compose. It uses calls this server already makes (`conversations.list`, `.history`, `.replies`). No new Slack surface, no new dependency, no egress beyond Slack, no model.

## What it returns

| Field | Meaning |
|---|---|
| `signals.unanswered_threads` | Nobody replied, **or** the only reply came from whoever opened it. Ordered oldest-first with an age in hours. |
| `signals.priority_activity` / `mentions_of_priority_people` | What the profile's priority people said, and where they were pinned. |
| `signals.busiest_conversations`, `total_messages` | Volume, for triage. |
| `output_contract.expected_keys` | The keys to compose for this `workflow_kind` — **deliberately not pre-filled.** |
| `truncation` | Every cap that bound the run. |

Two decisions worth flagging for review:

**"Unanswered" is mechanical on purpose.** No reply, or a thread whose last reply is the opener self-bumping. Anything softer would be a judgement call, and judgement is the caller's job.

**The contract keys are left empty.** Fabricating a summary server-side is the thing being removed, not relocated. A test asserts they stay `undefined`.

**Silence counts.** A profile that names channels reads them even when Slack marks nothing unread — "nothing new in #incidents" is an answer.

**Work is bounded** (12 conversations / 30 messages / 8 threads) because outbound calls are paced by default; an unbounded sweep of a busy workspace would take minutes. Caps are *reported* in `truncation`, never applied silently.

## Inventory

Still **21 tools** — 12 read-only, 4 write-path, all CI-gated strings unchanged. Local workflow tools 2 → 3; hosted stubs 3 → 2. `slack_smart_search` and `slack_triage` stay hosted because an index and a model are infrastructure this package genuinely does not ship.

## Verification

- **90 tests pass** (17 new), 0 fail.
- **Mutation-tested**, because a test that passes on broken code proves nothing. Breaking self-bump detection → that test fails. Breaking truncation reporting → that test fails. Both restored.
- **Live run against a real workspace**: 3 channels, 24 messages, **16 unanswered threads** (oldest 1,658h), thread cap hit and reported, contract keys unfilled, messages chronological, 4.75s.
- `verify:public-surface`, `verify:public-pages`, `check-public-language.sh` all exit 0. LSP: 0 diagnostics.

## Why the version bump

`check-version-parity` currently reports MCP-registry description drift, and says so itself: registry metadata for an existing version **cannot be republished**. The corrected description from #225 — which Glama, PulseMCP, mcpservers.org, and Smithery all currently contradict with stale "no OAuth needed" copy scraped months ago — only propagates on a new release. Hence 4.9.0.
