### PR TITLE
Add the npm search terms the package already promises

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,11 @@
     "windsurf",
     "gemini-cli",
     "codex-cli",
-    "remote-mcp"
+    "remote-mcp",
+    "triage",
+    "catch-up",
+    "unread",
+    "standup"
   ],
   "author": {
     "name": "Revasser",


### PR DESCRIPTION
The package description says **triage**. The new lead says **catch up**. Neither was an npm keyword, so the two highest-intent search terms for this package were unsearchable.

Added: `triage`, `catch-up`, `unread`, `standup`.

Keyword competition on these is real but winnable — `triage` has ~128 competing packages. Contrast the terms already held: `slack` (2,264 packages, this one ranks ~113), `mcp` (65,808, unranked), `mcp-server` (7,703, ~138), `model-context-protocol` (32,982, unranked) — all saturated by official SDKs and large frameworks, and not winnable at any effort. Worth noting the one already owned outright: `slack-mcp` has only 3 packages total and this is #1.

Keywords only refresh on publish, so this rides 4.9.0 rather than waiting for the release after it.

Verified: 90 tests pass, `verify:public-surface` exit 0.