### PR TITLE
feat(protocol)!: speak MCP 2026-07-28, drop the hosted stubs — v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,9 @@ did any work here are gone.
   `_meta["io.modelcontextprotocol/serverInfo"]`, `Mcp-Method` is enforced
   against the body (`-32020` on disagreement), an unsupported revision is
   refused with `-32022`, and `server/discover` names the supported revision.
-  2025-era responses are byte-for-byte what they were.
+  2025-era protocol responses are byte-for-byte what they were; the one HTTP
+  change a 2025 client can observe is the `WWW-Authenticate` header on the
+  bearer `401`, noted below.
 - **`test/mcp-era.test.js`** — the proof behind the README's claim. It drives
   the real SDK client at both eras against the in-process handler, spawns
   `src/server-http.js` and `src/server.js`, and asserts every conformance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,81 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.0] - 2026-08-24
+
+### Speaks MCP 2026-07-28, drops the hosted stubs
+
+Two changes, one release. The protocol layer moves to the 2026-07-28 revision
+without breaking anything that talks to it today, and the two tools that never
+did any work here are gone.
+
+### Breaking
+
+- **`slack_smart_search` and `slack_triage` are removed.** They made no Slack
+  call; the OSS handlers returned an upgrade payload pointing at a hosted tier.
+  Every tool this package advertises now does its work on your machine. The
+  surface is **19 tools**: 12 read-only, 4 write-path, 3 local workflow tools.
+  Clients that called either name receive the same `unknown_tool` result as
+  any other unknown name. `SLACK_MCP_TOOLS=all` advertises 19 (≈3,134 estimated
+  schema tokens per turn, down from ≈3,600); `read` (12) and `essentials` (6)
+  are unchanged.
+- **HTTP mode is per-request and stateless.** `src/server-http.js` no longer
+  mints an `Mcp-Session-Id`; every `POST /mcp` is answered by a fresh server
+  instance, and `GET` / `DELETE` — the 2025 session operations — answer `405`.
+  2025-era clients are served the same way and keep working; they simply
+  never had a session here. A client that depended on the SSE `GET` stream
+  for server-initiated messages will not receive them over HTTP.
+- **`Access-Control-Allow-Headers` changed** for the HTTP entry: `mcp-session-id`
+  is gone; `MCP-Protocol-Version`, `Mcp-Method`, `Mcp-Name`, and `Accept` are
+  allowed. A browser-originated request whose `Origin` is outside
+  `SLACK_MCP_HTTP_ALLOWED_ORIGINS` is now refused with `403` on `POST`, not
+  only on preflight.
+- **`@modelcontextprotocol/sdk` (v1) is no longer a dependency.** The runtime
+  is `@modelcontextprotocol/server` 2.x and `@modelcontextprotocol/node` 2.x.
+  Nothing in the package's public surface exposed the SDK, so this matters
+  only to anyone importing internals.
+
+### Added
+
+- **MCP 2026-07-28 support, from the same binary as every 2025 revision.**
+  stdio negotiates the era per connection (`serveStdio`, default
+  `legacy: 'serve'`); HTTP serves it per request (`createMcpHandler`, default
+  `legacy: 'stateless'`). On the 2026-07-28 era, `tools/list` carries
+  `ttlMs: 60000, cacheScope: "public"` (the advertised surface is fixed for the
+  life of a process), results carry `resultType: "complete"` and
+  `_meta["io.modelcontextprotocol/serverInfo"]`, `Mcp-Method` is enforced
+  against the body (`-32020` on disagreement), an unsupported revision is
+  refused with `-32022`, and `server/discover` names the supported revision.
+  2025-era responses are byte-for-byte what they were.
+- **`test/mcp-era.test.js`** — the proof behind the README's claim. It drives
+  the real SDK client at both eras against the in-process handler, spawns
+  `src/server-http.js` and `src/server.js`, and asserts every conformance
+  detail above. `check-public-surface-integrity.js` refuses a README that says
+  "2026-07-28" without this file, an HTTP entry that mentions
+  `sessionIdGenerator`, or any import of the v1 SDK.
+- **`WWW-Authenticate` on the HTTP entry's bearer `401`** (required since the
+  2025-06-18 revision) so a client can learn how to authenticate instead of
+  dead-ending.
+- **`lib/mcp-server.js`** — one factory both transports build from. The
+  advertised tools, prompts, resources, and dispatch path can no longer drift
+  between stdio and HTTP.
+- **`workers/mcp-worker.js` is a version-parity surface.** The in-repo worker
+  had carried `4.0.0` in three places since 4.0.0 and always answered
+  `initialize` with `2024-11-05`; it now echoes the client's supported 2025
+  revision and `check-version-parity.js` fails locally when its
+  `WORKER_VERSION` disagrees with `package.json`.
+
+### Changed
+
+- The workflow-profile tool descriptions describe what runs here:
+  `summary_cadence` sets `slack_catch_me_up`'s default window;
+  `workflow_kind` sets the `output_contract` keys. The previous copy described
+  a hosted scheduler and paid tiers inside the tool schema itself.
+- README, `docs/DEPLOYMENT-MODES.md`, `docs/TROUBLESHOOTING.md`, the CLI help,
+  `--apply-template` help, and the generated public pages state 19 tools and
+  no longer describe placeholder tools or indexed retrieval as part of the
+  local package.
+
 ## [4.9.0] - 2026-08-13
 
 ### Catch-up runs locally

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ npx -y @jtalk22/slack-mcp      # package entrypoint
 docker pull ghcr.io/jtalk22/slack-mcp-server:latest
 ```
 
-## MCP Tools (21 total)
+## MCP Tools (19 total)
 
 **Slack reads (12):**
 
@@ -47,7 +47,7 @@ docker pull ghcr.io/jtalk22/slack-mcp-server:latest
 
 **Workflow primitives (2):** `slack_workflow_save`, `slack_workflows` — bind a `workflow_kind` (`incident_room`, `exec_brief`, `support_inbox`, `product_launch_watch`, `custom`) to channels + priority people + retention + cadence. Stored locally at `~/.slack-mcp-workflows.json`.
 
-**Hosted-brain upgrade stubs (3):** `slack_smart_search`, `slack_catch_me_up`, `slack_triage` — return `{signup_url, free_tier_quota, pro_value_prop}` payloads pointing at `mcp.revasserlabs.com`. No Slack write occurs from OSS.
+**Local catch-up (1):** `slack_catch_me_up` — reads a saved profile's scope and returns structured evidence (`lib/catch-up.js`). There are no hosted upgrade stubs in the package since 5.0.0; every advertised tool runs locally.
 
 ## Token Persistence Layers
 
@@ -77,9 +77,11 @@ auth-retry path never reuses stale credentials.
 
 ```text
 src/
-  server.js        MCP server entry point
+  server.js        MCP server entry point (stdio, era-negotiated via serveStdio)
+  server-http.js   Streamable HTTP entry (stateless per request, MCP 2026-07-28)
   web-server.js    REST API + Web UI
 lib/
+  mcp-server.js    shared protocol-server factory both transports build from
   token-store.js   token persistence
   slack-client.js  Slack API client and retry logic
   tools.js         MCP tool definitions
@@ -99,14 +101,20 @@ Tokens load from `~/.slack-mcp-tokens.json` or `SLACK_TOKEN`/`SLACK_COOKIE` env 
   including one-line doc fixes. Squash-merge means the feature branch is not an
   ancestor of `main` afterwards, so `git branch -d` refuses it — use `-D` once
   the PR is merged.
+- **The protocol claim is CI-gated.** `README.md` may say "2026-07-28" only
+  while `test/mcp-era.test.js` exists and passes; `src/server-http.js` must not
+  contain `sessionIdGenerator` (there is no session to mint) and nothing under
+  `src/` or `lib/` may import the retired `@modelcontextprotocol/sdk` v1
+  package. The SDK is v2 (`@modelcontextprotocol/server` + `/node`; `/client`
+  is a devDependency for the era test).
 - **Tool profiles must agree with the README's counts.** `SLACK_MCP_TOOLS`
-  selects `all` (21) / `read` (12) / `essentials` (6) or a custom list.
+  selects `all` (19) / `read` (12) / `essentials` (6) or a custom list.
   `READ_TOOLS` is an explicit list, deliberately NOT derived from the
-  `readOnlyHint` annotation — that annotation is also true of the three hosted
-  stubs, so deriving from it shipped paid-tier upsell tools to users who
+  `readOnlyHint` annotation — that annotation is a safety signal, and deriving
+  the surface from it once shipped tools that made no Slack call to users who
   narrowed their surface to save schema cost. `check-public-surface-integrity.js`
-  now gates counts, stub leakage, and name rot; `npm run measure:tools` prints
-  the schema cost per profile.
+  gates counts, name rot, and the absence of any paid-tier tool;
+  `npm run measure:tools` prints the schema cost per profile.
 - **Branch names must not contain "claude"** (or other AI-tool markers). The
   attribution guardrail scans commit messages; `gh pr update-branch` writes
   "Merge branch 'main' into <branch>", so a marker in the branch name fails CI
@@ -115,7 +123,7 @@ Tokens load from `~/.slack-mcp-tokens.json` or `SLACK_TOKEN`/`SLACK_COOKIE` env 
   directly — edit `templates/public-pages/*.tpl` + `lib/public-pages.js`, run
   `node scripts/generate-public-pages.js`, commit templates and outputs together.
 - **README claims are CI-gated.** `check-public-surface-integrity.js` greps for
-  literal "21 tools", "12 read-only", "4 write-path"; `check-public-language.sh`
+  literal "19 tools", "12 read-only", "4 write-path"; `check-public-language.sh`
   bans hype words. Run both before pushing copy changes.
 - **Demo video is reproducible.** `scripts/record-demo.js` re-captures the whole
   demo deterministically (webm master → renditions). Chapter `data-t` values in

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npx -y @jtalk22/slack-mcp --setup
   <a href="#two-ways-into-slack">Why session auth</a> ·
   <a href="#grid-credentials-and-caching">Grid & credentials</a> ·
   <a href="#install">Install</a> ·
-  <a href="#21-tools-read-act-automate">21 tools</a> ·
+  <a href="#19-tools-read-act-automate">19 tools</a> ·
   <a href="#typed-workflows-slack-in-json-out">Workflows</a> ·
   <a href="#free-local-when-youre-driving-hosted-when-it-must-drive-itself">Local vs hosted</a>
 </p>
@@ -111,7 +111,8 @@ Slack already knows who you are. The official path is a Slack-managed remote int
 | Client surface | Slack's supported partner integrations | **Any stdio MCP client** |
 | Authentication | OAuth | **Existing browser session** |
 | Credential lifetime | Managed OAuth | Rotating session with health checks and refresh |
-| Product surface | Broad Slack-native capabilities | **21 focused tools across read, act, and automate** |
+| Product surface | Broad Slack-native capabilities | **19 focused tools across read, act, and automate** |
+| Protocol | Slack-managed | **MCP 2026-07-28 and every 2025 revision, from the same binary** |
 | Runtime | Slack-managed | **MIT code on your machine** |
 
 </details>
@@ -187,11 +188,13 @@ On macOS, setup can extract from Chrome and persist the selected storage backend
 
 ---
 
-## 21 tools: read, act, automate
+## 19 tools: read, act, automate
 
-The local surface ships **21 tools** today: **12 read-only** Slack operations, **4 write-path** tools that each carry an MCP destructive annotation so clients can gate workspace writes, 3 local workflow tools including the catch-up itself, and 2 hosted-intelligence stubs that return a structured upgrade payload without making a Slack call. Four read tools accept `include_rich_message_fields: true` to surface attachments, blocks, files, reactions, and metadata—complete inputs and response contracts live in [docs/API.md](docs/API.md).
+The local surface ships **19 tools** today: **12 read-only** Slack operations, **4 write-path** tools that each carry an MCP destructive annotation so clients can gate workspace writes, and 3 local workflow tools including the catch-up itself. Every tool does its work here — reads Slack or local state — and none is a placeholder for something you would have to pay for. Four read tools accept `include_rich_message_fields: true` to surface attachments, blocks, files, reactions, and metadata—complete inputs and response contracts live in [docs/API.md](docs/API.md).
 
-**Advertising fewer tools.** A client pays for the tool schema on every turn that carries it. `SLACK_MCP_TOOLS=essentials` advertises six tools — unread, history, search, thread, user lookup, send — costing roughly **985 estimated tokens** of schema per turn against about **3,600** for all 21. `SLACK_MCP_TOOLS=read` advertises the 12 read-only Slack operations listed below, near 1,690. `--tools=slack_x,slack_y` takes an explicit set. The default stays all 21. Filtering changes what is advertised, not what is callable. Reproduce the numbers with `node scripts/measure-tool-schema.js` (a ~4-chars-per-token estimate).
+Speaks MCP **2026-07-28** and every 2025 revision from the same binary — era-negotiated over stdio, stateless per request over HTTP (no `Mcp-Session-Id`; `GET`/`DELETE` answer 405). The claim is a test, not a sentence: [`test/mcp-era.test.js`](test/mcp-era.test.js) drives the real SDK client at both eras against the real entry points.
+
+**Advertising fewer tools.** A client pays for the tool schema on every turn that carries it. `SLACK_MCP_TOOLS=essentials` advertises six tools — unread, history, search, thread, user lookup, send — costing roughly **985 estimated tokens** of schema per turn against about **3,134** for all 19. `SLACK_MCP_TOOLS=read` advertises the 12 read-only Slack operations listed below, near 1,690. `--tools=slack_x,slack_y` takes an explicit set. The default stays all 19. Filtering changes what is advertised, not what is callable. Reproduce the numbers with `node scripts/measure-tool-schema.js` (a ~4-chars-per-token estimate).
 
 <details>
 <summary><strong>The full tool inventory</strong></summary>
@@ -231,14 +234,7 @@ The local surface ships **21 tools** today: **12 read-only** Slack operations, *
 | `slack_workflows` | List saved workflow profiles |
 | `slack_catch_me_up` | Read a profile's channels since its cadence window and return structured catch-up evidence |
 
-### Discover hosted intelligence — 2 explicit stubs
-
-| Tool | Hosted result |
-|---|---|
-| `slack_smart_search` | Semantic + lexical search over indexed Slack history |
-| `slack_triage` | Prioritized action queue with routing recommendations |
-
-These two need infrastructure this package does not ship — an index and a model — so the OSS handlers return a structured upgrade payload instead of making a Slack call. `slack_catch_me_up` needs neither and runs locally. `slack_refresh_tokens` only writes local credential state.
+`slack_refresh_tokens` reads Slack and writes only local credential state.
 
 </details>
 
@@ -248,7 +244,7 @@ These two need infrastructure this package does not ship — an index and a mode
 
 Bind a workflow kind to channels, priority people, retention, and cadence. `slack_catch_me_up` then reads that scope locally and hands your agent the evidence: which threads went unanswered and for how long, what your priority people said or were pinned on, which conversations actually moved. It does the gathering; your agent writes the summary against the contract below.
 
-There is no server-side model in that path, because there does not need to be one — the client calling this server is already a language model. Hosted adds what genuinely needs infrastructure: indexed semantic retrieval, and running the same catch-up on a schedule while your laptop is shut.
+There is no server-side model in that path, because there does not need to be one — the client calling this server is already a language model. Hosted adds what genuinely needs infrastructure: running the same catch-up on a schedule while your laptop is shut, on an OAuth token that does not rotate.
 
 ```bash
 npx -y @jtalk22/slack-mcp --apply-template oncall-handoff --channels C012345,C067890
@@ -323,8 +319,7 @@ Each profile gets its own token file, Keychain entries, metadata, and lock. Add 
 When local control is enough, stop here—everything above is MIT-licensed and runs on your machine. The local product is complete, not a crippled trial: hosted earns the upgrade through continuity, intelligence, and collaboration, not by holding ordinary Slack access hostage. Hosted exists for work that must survive a rotating browser session:
 
 - permanent OAuth;
-- indexed semantic search;
-- scheduled catch-up and triage;
+- scheduled catch-up;
 - contract-validated workflow briefs;
 - shared profiles and managed workspace continuity.
 

--- a/docs/DEPLOYMENT-MODES.md
+++ b/docs/DEPLOYMENT-MODES.md
@@ -14,9 +14,9 @@ Use this guide to choose the right operating mode before rollout.
 
 | Mode | Start Command | Best For | Auth Material | Exposure | Notes |
 |------|---------------|----------|---------------|----------|-------|
-| Local MCP (`stdio`) | `npx -y @jtalk22/slack-mcp` | Individual daily usage in Claude | `SLACK_TOKEN` + `SLACK_COOKIE` via token file/env | Local process | Lowest ops burden. Free. 21 tools (16 read/write + 2 workflow profile primitives + 3 discoverable upgrade stubs to hosted). |
+| Local MCP (`stdio`) | `npx -y @jtalk22/slack-mcp` | Individual daily usage in Claude | `SLACK_TOKEN` + `SLACK_COOKIE` via token file/env | Local process | Lowest ops burden. Free. 19 tools (12 read + 4 write + 3 local workflow tools). MCP 2026-07-28 and 2025 revisions, era-negotiated per connection. |
 | Local Web UI (`web`) | `npx -y @jtalk22/slack-mcp web` | Browser-first usage, manual search/send | Same as above + generated API key | `localhost` by default | Useful when MCP is not available |
-| Hosted MCP (`http`) | `node src/server-http.js` | Controlled hosted integration | Env-injected Slack token/cookie + HTTP bearer token | Remote endpoint | `/mcp` is bearer-protected by default; configure CORS allowlist |
+| Hosted MCP (`http`) | `node src/server-http.js` | Controlled hosted integration | Env-injected Slack token/cookie + HTTP bearer token | Remote endpoint | `/mcp` is bearer-protected by default (401 carries `WWW-Authenticate`); configure CORS allowlist. Stateless per request: no `Mcp-Session-Id`, `GET`/`DELETE` answer 405. |
 | Smithery/Worker | `wrangler deploy` + Smithery publish flow | Registry distribution for hosted consumers | Query/env token handoff | Remote endpoint | Keep worker version parity with npm release |
 
 ## Team Deployment Guidance

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,6 +1,6 @@
 # Setup Guide
 
-Turn the Slack browser session you already have into 21 tools for any stdio MCP client.
+Turn the Slack browser session you already have into 19 tools for any stdio MCP client.
 
 ## Fast path
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -33,7 +33,7 @@ If `--version` fails here, the issue is install/runtime path, not Slack credenti
 
 The hosted version is live at [mcp.revasserlabs.com](https://mcp.revasserlabs.com). Free tier (no card) ships 2,000 requests/mo + 25 AI tool calls/mo + all 5 workflow profile types. Pro at $19/mo (or $190/yr) unlocks unlimited requests and AI tool calls, permanent OAuth (no 2-week token rotation), email support, and 2 workspaces. Team at $49/mo flat (or $490/yr) covers 5 workspaces with shared workflow profiles and 24h support. Safeguard at $199/mo (waitlist only) adds agent approval gates, the scheduled morning catch-up DM at 8am workspace time, and workspace memory — all *(in development)*.
 
-The OSS package keeps the local-machine path. The hosted version adds the AI brain (smart_search, catch_me_up, triage) — these tools also appear in the OSS package as discoverable upgrade stubs that point at the hosted signup.
+The OSS package keeps the local-machine path and ships no placeholder tools: every tool it advertises runs on your machine.
 
 ---
 

--- a/docs/assets/manifest.json
+++ b/docs/assets/manifest.json
@@ -130,7 +130,7 @@
       "role": "readme-diagram",
       "format": "svg",
       "size_bytes": 6290,
-      "sha256": "593cc237e1f0cbe77a6eb472c9e94d9bac68fc3ae060c5bd43b79caec6601a07",
+      "sha256": "e5c17410056d6c65253a7bf2d8942708cd4264a649027274f59d63e4824234fb",
       "width": 1280,
       "height": 720
     }

--- a/docs/images/diagram-oauth-comparison.svg
+++ b/docs/images/diagram-oauth-comparison.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-labelledby="title desc">
   <title id="title">Two ways into Slack</title>
-  <desc id="desc">The official integration path uses workspace policy, OAuth, and a managed remote MCP. Slack MCP Server uses one-command local Chrome session extraction, a Keychain-backed credential lifecycle, and 21 tools over stdio.</desc>
+  <desc id="desc">The official integration path uses workspace policy, OAuth, and a managed remote MCP. Slack MCP Server uses one-command local Chrome session extraction, a Keychain-backed credential lifecycle, and 19 tools over stdio.</desc>
   <defs>
     <marker id="arrowMuted" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#6f6c64"/>

--- a/docs/launch-posts.md
+++ b/docs/launch-posts.md
@@ -16,7 +16,7 @@ Slack’s operating layer for AI agents: ask what happened, get the receipts, an
 | Support, product, and executive teams | Typed workflows, indexing, schedules, shared profiles, continuity | A fixed tool count |
 | Business buyers | Slack as operating memory; permanent OAuth; unattended workflows | `stdio` |
 
-`21 tools` is the current inventory, not the category. Say **“21 tools today”** when the count matters. The durable promise is that Slack becomes usable operating context and approved action for an agent.
+`19 tools` is the current inventory, not the category. Say **“19 tools today”** when the count matters. The durable promise is that Slack becomes usable operating context and approved action for an agent.
 
 ---
 
@@ -36,7 +36,7 @@ I built an open-source Slack MCP server for that workflow:
 npx -y @jtalk22/slack-mcp --setup
 ```
 
-The local path uses the Slack identity Chrome already has, so there is no Slack app to register, no OAuth scope review, and no admin queue. It ships 21 tools today: DMs, channels, unread inventory, search, full histories and threads, users, rich message fields, exports, replies, reactions, read-state changes, and typed workflow profiles.
+The local path uses the Slack identity Chrome already has, so there is no Slack app to register, no OAuth scope review, and no admin queue. It ships 19 tools today: DMs, channels, unread inventory, search, full histories and threads, users, rich message fields, exports, replies, reactions, read-state changes, and typed workflow profiles.
 
 The part I spent most of the time on is underneath the demo:
 
@@ -63,7 +63,7 @@ npm: https://www.npmjs.com/package/@jtalk22/slack-mcp
 
 ## r/selfhosted
 
-**Title:** Slack for local AI agents — no app registration, Keychain-only storage, 21 tools today
+**Title:** Slack for local AI agents — no app registration, Keychain-only storage, 19 tools today
 
 **Body:**
 
@@ -102,7 +102,7 @@ That means an agent should be able to answer:
 
 Slack MCP now handles that as a real operating layer. The free open-source path gives a developer or solo operator control immediately through the Slack session already in Chrome—no app-registration project and no admin queue. The hosted path exists for the business case: permanent OAuth, indexed retrieval, scheduled incident/support/exec briefs, shared workflow profiles, and continuity across workspaces.
 
-The current local surface is 21 tools. The count will change. The job does not: turn Slack into context, decisions, and approved action without making someone live in Slack.
+The current local surface is 19 tools. The count will change. The job does not: turn Slack into context, decisions, and approved action without making someone live in Slack.
 
 The new 42-second cut starts where work actually starts: Monday, 9:07 AM, a database outage, a lying runbook, and a printer PIN that has been waiting in `#facilities` for five months.
 
@@ -126,7 +126,7 @@ Local: no Slack app/admin queue.
 
 Hosted: permanent OAuth + indexing + schedules.
 
-21 tools today. One command.
+19 tools today. One command.
 
 `npx -y @jtalk22/slack-mcp --setup`
 
@@ -153,7 +153,7 @@ Do not publish “20k+ downloads” until the public npm API crosses 20,000.
 - “Slack’s operating layer for AI agents.”
 - “Ask what happened. Get receipts. Close the loop.”
 - “No Slack app or admin queue on the local path.”
-- “The current local surface ships 21 tools today.”
+- “The current local surface ships 19 tools today.”
 - “Local gives control now; hosted gives unattended continuity.”
 - “Hosted adds permanent OAuth, indexing, scheduled intelligence, shared profiles, and managed workspaces.”
 - “Session credentials carry the same effective access as the signed-in browser user.”

--- a/docs/poster/poster.html
+++ b/docs/poster/poster.html
@@ -80,6 +80,6 @@
   </div>
   <div class="subline">unreads &rarr; <b>one morning briefing</b> &mdash; without opening Slack</div>
   <div class="play"></div>
-  <div class="footer">21 tools<span class="dot">&middot;</span>session tokens, not OAuth<span class="dot">&middot;</span>works with any MCP client</div>
+  <div class="footer">19 tools<span class="dot">&middot;</span>session tokens, not OAuth<span class="dot">&middot;</span>works with any MCP client</div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -219,7 +219,7 @@
         <div class="hero-copy">
           <p class="eyebrow reveal">Catch up on Slack without reading it</p>
           <h1 class="reveal">Ask what happened.<br><em>Get receipts.</em><br>Close the loop.</h1>
-          <p class="hero-deck reveal">Turn Slack from an interruption stream into searchable operating memory and approved action. Run the <strong>21-tool surface available today</strong> locally with no app/admin queue, or move recurring work to hosted permanent OAuth, indexing, and schedules.</p>
+          <p class="hero-deck reveal">Turn Slack from an interruption stream into searchable operating memory and approved action. Run the <strong>19-tool surface available today</strong> locally with no app/admin queue, or move recurring work to hosted permanent OAuth, indexing, and schedules.</p>
           <div class="command-row reveal" aria-label="Install command">
             <code class="command">npx -y @jtalk22/slack-mcp --setup</code>
             <button class="copy" type="button" data-copy="npx -y @jtalk22/slack-mcp --setup">Copy</button>

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -864,7 +864,7 @@ export async function handleWorkflowSave(args) {
     ok: true,
     profile_name: result.profile_name,
     profile: result.profile,
-    note: "Profile saved locally. Hosted free tier syncs profiles automatically when you connect your account; OSS-only mode keeps them on your machine.",
+    note: "Profile saved locally to ~/.slack-mcp-workflows.json. Run slack_catch_me_up with this profile_name to read its scope.",
   });
 }
 
@@ -884,36 +884,12 @@ export async function handleWorkflows(args) {
   });
 }
 
-// ============ Hosted-Only AI Tool Stubs ============
-// These three tools appear in the OSS package's MCP tool list so users
-// discover them. The handlers return a structured upgrade message —
-// actual execution happens on the hosted worker (mcp.revasserlabs.com).
-
-const HOSTED_UPGRADE_PAYLOAD = {
-  error: "tool_requires_hosted",
-  message: "This tool needs hosted mode (Vectorize + Workers AI). Get free monthly credits at mcp.revasserlabs.com — no card required.",
-  signup_url: "https://mcp.revasserlabs.com/signup",
-  upgrade_url: "https://mcp.revasserlabs.com/pricing",
-  free_tier_quota: "2,000 requests/mo + 25 AI tool calls/mo (no card)",
-  pro_value_prop: "Pro $19/mo unlocks unlimited requests and AI tool calls, permanent OAuth (no token rotation).",
-};
-
-export async function handleSmartSearch(args) {
-  return asMcpJson(
-    {
-      ...HOSTED_UPGRADE_PAYLOAD,
-      requested: { tool: "slack_smart_search", args: args || {} },
-    },
-    true
-  );
-}
-
 /**
  * Catch up on a saved workflow profile — locally, with no hosted dependency.
  *
- * This was a hosted-only stub. It runs here now because the expensive part was
- * never the summarising: the caller is already a language model. What it needed
- * was the evidence, gathered and structured. See lib/catch-up.js.
+ * The expensive part was never the summarising: the caller is already a
+ * language model. What it needed was the evidence, gathered and structured.
+ * See lib/catch-up.js.
  */
 export async function handleCatchMeUp(args) {
   const profileName = args && typeof args.profile_name === "string" ? args.profile_name.trim() : "";
@@ -958,16 +934,6 @@ export async function handleCatchMeUp(args) {
   return asMcpJson(bundle);
 }
 
-export async function handleTriage(args) {
-  return asMcpJson(
-    {
-      ...HOSTED_UPGRADE_PAYLOAD,
-      requested: { tool: "slack_triage", args: args || {} },
-    },
-    true
-  );
-}
-
 // ============ Shared Tool Dispatch Map ============
 // Single source of truth mapping every advertised tool name (lib/tools.js)
 // to its handler. Both transports — stdio (src/server.js) and HTTP
@@ -994,8 +960,5 @@ export const TOOL_HANDLERS = Object.freeze({
   // Workflow profile primitives (OSS local JSON store)
   slack_workflow_save: handleWorkflowSave,
   slack_workflows: handleWorkflows,
-  // Hosted-only AI tools (OSS = upgrade stubs)
-  slack_smart_search: handleSmartSearch,
   slack_catch_me_up: handleCatchMeUp,
-  slack_triage: handleTriage,
 });

--- a/lib/mcp-server.js
+++ b/lib/mcp-server.js
@@ -1,0 +1,209 @@
+/**
+ * Shared MCP server factory.
+ *
+ * Both transports — stdio (src/server.js) and Streamable HTTP
+ * (src/server-http.js) — build their protocol server here, so the advertised
+ * surface, the prompts, the resources, and the dispatch path cannot drift
+ * between them. The factory is also what the tests drive in-process.
+ *
+ * The server speaks MCP 2026-07-28 and every 2025 revision from the same
+ * instance: the SDK selects the era per connection (stdio) or per request
+ * (HTTP), and the handlers registered here are written once for both.
+ */
+
+import { Server } from "@modelcontextprotocol/server";
+
+import { RELEASE_VERSION } from "./public-metadata.js";
+import { getActiveToolProfile } from "./tools.js";
+import {
+  TOOL_HANDLERS,
+  handleHealthCheck,
+  handleListConversations,
+} from "./handlers.js";
+import { isAuthDeath, lifeboatResponse } from "./lifeboat.js";
+
+export const SERVER_NAME = "slack-mcp-server";
+export const SERVER_VERSION = RELEASE_VERSION;
+
+// tools/list is static for the life of a process (the profile is resolved once
+// at startup and TOOLS is a constant), so the 2026-07-28 cache hint can say so:
+// a shared cache may hold it for a minute. Responses to 2025-era requests never
+// carry cache fields, so this is invisible to older clients.
+export const TOOLS_LIST_CACHE_HINT = Object.freeze({ ttlMs: 60_000, cacheScope: "public" });
+
+// MCP Prompts - predefined prompt templates for common Slack operations
+export const PROMPTS = [
+  {
+    name: "search-recent",
+    description: "Search workspace for messages from the past week",
+    arguments: [
+      {
+        name: "query",
+        description: "Search terms to look for",
+        required: true
+      }
+    ]
+  },
+  {
+    name: "summarize-channel",
+    description: "Get recent activity from a channel for summarization",
+    arguments: [
+      {
+        name: "channel_id",
+        description: "Channel ID to summarize",
+        required: true
+      },
+      {
+        name: "days",
+        description: "Number of days to look back (default 7)",
+        required: false
+      }
+    ]
+  },
+  {
+    name: "find-messages-from",
+    description: "Find all messages from a specific user",
+    arguments: [
+      {
+        name: "username",
+        description: "Username or display name to search for",
+        required: true
+      }
+    ]
+  }
+];
+
+// MCP Resources - data sources the server provides
+export const RESOURCES = [
+  {
+    uri: "slack://workspace/info",
+    name: "Workspace Info",
+    description: "Current workspace name, team, and authenticated user",
+    mimeType: "application/json"
+  },
+  {
+    uri: "slack://conversations/list",
+    name: "Conversations",
+    description: "List of available channels and DMs",
+    mimeType: "application/json"
+  }
+];
+
+function errorResult(code, message, nextAction) {
+  return {
+    content: [{
+      type: "text",
+      text: JSON.stringify({ status: "error", code, message, next_action: nextAction }, null, 2)
+    }],
+    isError: true
+  };
+}
+
+/**
+ * Dispatch one tools/call through the shared handler map. Exported so the
+ * transports and the tests share a single failure contract.
+ */
+export async function dispatchToolCall(name, args) {
+  const handler = TOOL_HANDLERS[name];
+  if (!handler) {
+    return errorResult("unknown_tool", `Unknown tool: ${name}`, "Use tools/list to discover available tools.");
+  }
+  try {
+    return await handler(args);
+  } catch (error) {
+    // OAuth Lifeboat: dead session token → recovery guidance, not a raw error.
+    if (isAuthDeath(error)) {
+      return lifeboatResponse(error);
+    }
+    return errorResult("tool_call_failed", String(error?.message || error), "Retry the call and include full arguments.");
+  }
+}
+
+function promptMessages(name, args) {
+  switch (name) {
+    case "search-recent": {
+      const query = args?.query || "";
+      const oneWeekAgo = Math.floor(Date.now() / 1000) - (7 * 24 * 60 * 60);
+      return [{
+        role: "user",
+        content: {
+          type: "text",
+          text: `Search Slack for "${query}" from the past week. Use the slack_search_messages tool with query: "${query} after:${new Date(oneWeekAgo * 1000).toISOString().split('T')[0]}"`
+        }
+      }];
+    }
+    case "summarize-channel": {
+      const channelId = args?.channel_id || "";
+      const days = parseInt(args?.days, 10) || 7;
+      const since = Math.floor(Date.now() / 1000) - (days * 24 * 60 * 60);
+      return [{
+        role: "user",
+        content: {
+          type: "text",
+          text: `Get the last ${days} days of messages from channel ${channelId} and provide a summary. Use slack_conversations_history with channel_id: "${channelId}" and oldest: "${since}"`
+        }
+      }];
+    }
+    case "find-messages-from": {
+      const username = args?.username || "";
+      return [{
+        role: "user",
+        content: {
+          type: "text",
+          text: `Find messages from ${username}. Use slack_search_messages with query: "from:@${username}"`
+        }
+      }];
+    }
+    default:
+      throw new Error(`Unknown prompt: ${name}`);
+  }
+}
+
+async function readResource(uri) {
+  switch (uri) {
+    case "slack://workspace/info": {
+      const result = await handleHealthCheck();
+      return { contents: [{ uri, mimeType: "application/json", text: result.content[0].text }] };
+    }
+    case "slack://conversations/list": {
+      const result = await handleListConversations({ types: "im,mpim,public_channel,private_channel", limit: 50 });
+      return { contents: [{ uri, mimeType: "application/json", text: result.content[0].text }] };
+    }
+    default:
+      throw new Error(`Unknown resource: ${uri}`);
+  }
+}
+
+/**
+ * Build a protocol server carrying the advertised tool surface plus the
+ * prompts and resources. Cheap to construct — the HTTP entry builds one per
+ * request (the 2026-07-28 stateless idiom) and stdio pins one per connection.
+ *
+ * @param {object} [options]
+ * @param {Array} [options.tools] tools to advertise; defaults to the active profile
+ */
+export function createSlackMcpServer({ tools } = {}) {
+  const advertised = tools ?? getActiveToolProfile().tools;
+
+  const server = new Server(
+    { name: SERVER_NAME, version: SERVER_VERSION },
+    {
+      capabilities: { tools: {}, prompts: {}, resources: {} },
+      cacheHints: { "tools/list": TOOLS_LIST_CACHE_HINT },
+    }
+  );
+
+  server.setRequestHandler("tools/list", async () => ({ tools: advertised }));
+  server.setRequestHandler("tools/call", async (request) => {
+    const { name, arguments: args } = request.params;
+    return dispatchToolCall(name, args);
+  });
+  server.setRequestHandler("prompts/list", async () => ({ prompts: PROMPTS }));
+  server.setRequestHandler("prompts/get", async (request) => ({
+    messages: promptMessages(request.params.name, request.params.arguments)
+  }));
+  server.setRequestHandler("resources/list", async () => ({ resources: RESOURCES }));
+  server.setRequestHandler("resources/read", async (request) => readResource(request.params.uri));
+
+  return server;
+}

--- a/lib/public-metadata.js
+++ b/lib/public-metadata.js
@@ -18,5 +18,5 @@ export const PUBLIC_METADATA = Object.freeze({
   cloudSupportUrl: "https://mcp.revasserlabs.com/support",
   cloudStatusUrl: "https://mcp.revasserlabs.com/status",
   supportEmail: "support@revasserlabs.com",
-  selfHostedToolCount: 21,
+  selfHostedToolCount: 19,
 });

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -428,13 +428,12 @@ export const TOOLS = [
       openWorldHint: true
     }
   },
-  // ============ Workflow Profile Primitives (OSS) ============
-  // Local JSON storage at ~/.slack-mcp-workflows.json. Defines the
-  // structural primitive that the hosted AI brain (smart_search,
-  // catch_me_up, triage) consumes to return structured JSON.
+  // ============ Workflow Profile Primitives ============
+  // Local JSON storage at ~/.slack-mcp-workflows.json. A profile is the scope
+  // slack_catch_me_up reads: channels, priority people, and the cadence window.
   {
     name: "slack_workflow_save",
-    description: "Save or update a workflow profile that binds a workflow_kind (support_inbox | incident_room | exec_brief | product_launch_watch | custom) to channels, priority people, retention mode, and summary cadence. Stored locally at ~/.slack-mcp-workflows.json. Hosted brain reads these to return structured JSON per the workflow_kind.",
+    description: "Save or update a workflow profile that binds a workflow_kind (support_inbox | incident_room | exec_brief | product_launch_watch | custom) to channels, priority people, retention mode, and summary cadence. Stored locally at ~/.slack-mcp-workflows.json. slack_catch_me_up reads the profile by name and returns evidence shaped by its workflow_kind.",
     inputSchema: {
       type: "object",
       properties: {
@@ -445,7 +444,7 @@ export const TOOLS = [
         workflow_kind: {
           type: "string",
           enum: ["support_inbox", "incident_room", "exec_brief", "product_launch_watch", "custom"],
-          description: "Workflow kind. Determines structured JSON output shape from the hosted AI brain."
+          description: "Workflow kind. Determines the output_contract keys slack_catch_me_up returns for this profile."
         },
         channels: {
           type: "array",
@@ -460,12 +459,12 @@ export const TOOLS = [
         retention_mode: {
           type: "string",
           enum: ["ephemeral", "persistent"],
-          description: "Token retention mode for hosted execution. Default ephemeral."
+          description: "Retention preference recorded on the profile. Default ephemeral."
         },
         summary_cadence: {
           type: "string",
           enum: ["on_demand", "daily_8am", "weekly_monday"],
-          description: "When the hosted brain auto-runs slack_catch_me_up against this profile. on_demand only on hosted free; daily_8am and weekly_monday require Pro or Team."
+          description: "How often this profile expects to be caught up on. Sets slack_catch_me_up's default window: 24 hours for on_demand and daily_8am, 7 days for weekly_monday."
         }
       },
       required: ["profile_name", "workflow_kind"]
@@ -521,74 +520,6 @@ export const TOOLS = [
       idempotentHint: false,
       openWorldHint: false
     }
-  },
-  // ============ Hosted-Only AI Tools (OSS = upgrade stubs) ============
-  // These two need infrastructure this package does not ship — an index and a
-  // model. They appear in the tool list so the capability is discoverable, and
-  // the OSS handlers return a structured upgrade message rather than a Slack
-  // call. slack_catch_me_up used to live here; it does not need either, so it
-  // runs locally now (lib/catch-up.js).
-  {
-    name: "slack_smart_search",
-    description: "Semantic + lexical hybrid search across your indexed Slack history. Returns ranked results with relevance scores, channel context, thread context, and matched terms. Hosted-only (requires Vectorize + Workers AI). Free tier ships 25 AI tool calls/month (shared across the hosted AI tools); upgrade to Pro $19/mo for unlimited at mcp.revasserlabs.com/pricing.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        query: {
-          type: "string",
-          description: "Natural language or keyword query (semantic + lexical hybrid)"
-        },
-        channel_ids: {
-          type: "array",
-          items: { type: "string" },
-          description: "Optional — restrict search to these channel IDs"
-        },
-        days_back: {
-          type: "number",
-          description: "Optional — restrict search to the last N days (max 90 on Pro+, 7 on Free)"
-        },
-        limit: {
-          type: "number",
-          description: "Maximum results to return (default 10, max 50)"
-        }
-      },
-      required: ["query"]
-    },
-    annotations: {
-      title: "Smart Search (hosted)",
-      readOnlyHint: true,
-      idempotentHint: true,
-      openWorldHint: true
-    }
-  },
-  {
-    name: "slack_triage",
-    description: "Classify and route Slack threads against a workflow profile. Returns triage decisions per thread: priority (low|medium|high|urgent), suggested owner, escalation flag, time-sensitivity, and a routing recommendation. Hosted-only. Free tier ships 25 AI tool calls/month (shared across the hosted AI tools); Pro $19/mo unlocks unlimited.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        profile_name: {
-          type: "string",
-          description: "Name of a workflow profile saved via slack_workflow_save"
-        },
-        channel_ids: {
-          type: "array",
-          items: { type: "string" },
-          description: "Optional — restrict triage to these channels (defaults to profile's channels)"
-        },
-        thread_ts: {
-          type: "string",
-          description: "Optional — triage a specific thread instead of the full inbox"
-        }
-      },
-      required: ["profile_name"]
-    },
-    annotations: {
-      title: "Triage (hosted)",
-      readOnlyHint: true,
-      idempotentHint: false,
-      openWorldHint: true
-    }
   }
 ];
 
@@ -615,9 +546,9 @@ export const ESSENTIALS_TOOLS = [
 
 // The 12 read-only Slack operations, matching the README's read-only table.
 // Deliberately NOT derived from readOnlyHint: that annotation is an MCP safety
-// signal, and it is also true of the three hosted stubs, which make no Slack
-// call and return an upgrade payload. Advertising those to someone who asked
-// for a smaller read-only surface would be a paid-tier ad in every turn.
+// signal, not a surface-selection signal — it was once also true of tools that
+// made no Slack call at all, and deriving from it shipped them to people who
+// had narrowed their surface. An explicit list cannot drift that way.
 // slack_refresh_tokens is included: it reads Slack and writes only local
 // credential state.
 export const READ_TOOLS = [

--- a/lib/workflow-store.js
+++ b/lib/workflow-store.js
@@ -5,10 +5,8 @@
  * (support_inbox | incident_room | exec_brief | product_launch_watch | custom)
  * to a set of channels, priority people, retention mode, and summary cadence.
  *
- * The hosted AI brain (smart_search, catch_me_up, triage) consumes these
- * profiles and returns structured JSON per the workflow_kind. The OSS
- * package ships the profile primitives but not the AI brain — it's
- * hosted-only because it needs Vectorize + Workers AI.
+ * `slack_catch_me_up` (lib/catch-up.js) reads these profiles locally and
+ * returns structured evidence shaped by the workflow_kind.
  *
  * File: ~/.slack-mcp-workflows.json (chmod 600)
  * Atomic write pattern (temp → chmod → rename) prevents corruption from

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@jtalk22/slack-mcp",
-  "version": "4.9.0",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jtalk22/slack-mcp",
-      "version": "4.9.0",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.27.0",
+        "@modelcontextprotocol/node": "^2.0.0",
+        "@modelcontextprotocol/server": "^2.0.0",
         "express": "^5.2.1"
       },
       "bin": {
@@ -20,6 +21,7 @@
         "slack-mcp-web": "src/web-server.js"
       },
       "devDependencies": {
+        "@modelcontextprotocol/client": "^2.0.0",
         "playwright": "^1.62.1"
       },
       "engines": {
@@ -30,56 +32,81 @@
         "url": "https://github.com/sponsors/jtalk22"
       }
     },
-    "node_modules/@hono/node-server": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
-      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
+      "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/server": "^2.0.0",
+        "hono": "^4.11.4"
+      },
+      "peerDependenciesMeta": {
+        "hono": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/node/node_modules/@hono/node-server": {
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
       },
       "peerDependencies": {
         "hono": "^4"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
-      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9 || ^2.0.5",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
-        "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
       },
       "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        },
-        "zod": {
-          "optional": false
-        }
+        "node": ">=20"
       }
     },
     "node_modules/accepts": {
@@ -93,39 +120,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
       }
     },
     "node_modules/body-parser": {
@@ -243,23 +237,11 @@
         "node": ">=6.6.0"
       }
     },
-    "node_modules/cors": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -374,6 +356,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.1"
@@ -386,6 +369,7 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
       "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -433,46 +417,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "10.1.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
-      }
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
@@ -615,6 +559,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
       "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -661,15 +606,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-    "node_modules/ip-address": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
-      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -689,28 +625,18 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/jose": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
       "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -782,15 +708,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -837,6 +754,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -846,6 +764,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
@@ -935,15 +854,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -1031,6 +941,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -1043,6 +954,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1191,6 +1103,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -1215,15 +1128,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jtalk22/slack-mcp",
   "mcpName": "io.github.jtalk22/slack-mcp-server",
-  "version": "4.9.0",
+  "version": "5.0.0",
   "description": "Catch up on Slack without reading it. Unreads, threads, search. Browser-session or hosted OAuth.",
   "funding": {
     "type": "github",
@@ -98,7 +98,8 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.0",
+    "@modelcontextprotocol/node": "^2.0.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "express": "^5.2.1"
   },
   "files": [
@@ -123,6 +124,7 @@
     "smithery.yaml"
   ],
   "devDependencies": {
+    "@modelcontextprotocol/client": "^2.0.0",
     "playwright": "^1.62.1"
   },
   "overrides": {

--- a/public/demo-slack-mcp.html
+++ b/public/demo-slack-mcp.html
@@ -12,12 +12,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="author" content="@jtalk22">
   <title>Slack MCP Server — Claude Desktop Demo</title>
-  <meta name="description" content="No Slack app. No admin queue. 21 Slack tools for Claude, Cursor, Copilot, Gemini, and any stdio MCP client.">
+  <meta name="description" content="No Slack app. No admin queue. 19 Slack tools for Claude, Cursor, Copilot, Gemini, and any stdio MCP client.">
   <link rel="canonical" href="https://jtalk22.github.io/slack-mcp-server/public/demo-slack-mcp.html">
 
   <!-- Open Graph -->
   <meta property="og:title" content="Slack MCP Server — No OAuth, no admin, just your browser session">
-  <meta property="og:description" content="OAuth-free Slack MCP using your browser session. 21 tools, works with Claude, Cursor, Copilot, Gemini.">
+  <meta property="og:description" content="OAuth-free Slack MCP using your browser session. 19 tools, works with Claude, Cursor, Copilot, Gemini.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://jtalk22.github.io/slack-mcp-server/public/demo-slack-mcp.html">
   <meta property="og:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
@@ -27,7 +27,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Slack MCP Server — No OAuth, no admin, just your browser session">
-  <meta name="twitter:description" content="21 tools for Claude, Cursor, Copilot, Gemini. npx -y @jtalk22/slack-mcp --setup">
+  <meta name="twitter:description" content="19 tools for Claude, Cursor, Copilot, Gemini. npx -y @jtalk22/slack-mcp --setup">
   <meta name="twitter:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
 
   <!-- Theme -->
@@ -1371,7 +1371,7 @@
       <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md" target="_blank" rel="noopener noreferrer">Setup Guide</a>
     </div>
     <div class="note">
-      The free local path ships the current 21-tool surface with session-based auth and no app/admin queue. <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">Hosted</a> adds permanent OAuth, indexed retrieval, scheduled intelligence, and team continuity when the workflow must run without you.
+      The free local path ships the current 19-tool surface with session-based auth and no app/admin queue. <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">Hosted</a> adds permanent OAuth, indexed retrieval, scheduled intelligence, and team continuity when the workflow must run without you.
     </div>
   </div>
   <header class="page-header">
@@ -1500,7 +1500,7 @@
       <div class="input-field">Message Claude...</div>
       <div class="tools-button">
         <span class="icon">🔨</span>
-        <span>21 tools</span>
+        <span>19 tools</span>
         <div class="tools-dropdown">
           <div class="dropdown-header">
             <span>🔨</span> Available Slack Tools

--- a/public/demo-video.html
+++ b/public/demo-video.html
@@ -8,7 +8,7 @@
   <meta name="description" content="Watch 47 unread Slack messages become one prioritized briefing through real Slack MCP tool calls.">
   <meta property="og:type" content="video.other">
   <meta property="og:title" content="It’s Monday, 9:07 AM. What blew up overnight?">
-  <meta property="og:description" content="21 Slack tools. One local command. No Slack app or admin queue.">
+  <meta property="og:description" content="19 Slack tools. One local command. No Slack app or admin queue.">
   <meta property="og:url" content="https://jtalk22.github.io/slack-mcp-server/public/demo-video.html">
   <meta property="og:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
   <meta property="og:image:width" content="1280">
@@ -133,7 +133,7 @@
     <div class="chapters" id="chapters" aria-label="Full walkthrough chapters">
       <button type="button" class="chapter" data-t="0">00:00<br>Morning triage</button><button type="button" class="chapter" data-t="48">00:48<br>Search</button><button type="button" class="chapter" data-t="68">01:08<br>Decision</button><button type="button" class="chapter" data-t="94">01:34<br>Reply</button><button type="button" class="chapter" data-t="118">01:58<br>People</button><button type="button" class="chapter" data-t="150">02:30<br>Close loops</button><button type="button" class="chapter" data-t="174">02:54<br>Export</button>
     </div>
-    <div class="below"><p class="note"><strong>Use Slack interactively for free; move unattended work to hosted.</strong> The local path ships 21 tools today for DMs, search, full threads, unread triage, actions, exports, and workflows—without a Slack app or admin queue. Hosted adds permanent OAuth, indexed retrieval, scheduled intelligence, and team continuity.</p><div class="install"><code>npx -y @jtalk22/slack-mcp --setup</code><a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md">Install</a></div></div>
+    <div class="below"><p class="note"><strong>Use Slack interactively for free; move unattended work to hosted.</strong> The local path ships 19 tools today for DMs, search, full threads, unread triage, actions, exports, and workflows—without a Slack app or admin queue. Hosted adds permanent OAuth, indexed retrieval, scheduled intelligence, and team continuity.</p><div class="install"><code>npx -y @jtalk22/slack-mcp --setup</code><a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md">Install</a></div></div>
     <footer><span>Interactive demo uses simulated data. The tools and contracts are the shipped public surface.</span><span><a href="https://github.com/jtalk22/slack-mcp-server">GitHub</a> · <a href="https://www.npmjs.com/package/@jtalk22/slack-mcp" style="color:var(--muted);text-decoration:none;font-size:0.875rem">npm</a> · <a href="https://mcp.revasserlabs.com" style="color:var(--stamp);text-decoration:none;font-size:0.875rem">Hosted</a></span></footer>
   </main>
   <script>

--- a/public/demo.html
+++ b/public/demo.html
@@ -10,18 +10,18 @@
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://jtalk22.github.io/slack-mcp-server/public/demo.html">
   <meta property="og:title" content="Slack MCP Server — Interactive Demo">
-  <meta property="og:description" content="Give any stdio MCP agent useful Slack access. 21 self-hosted tools for channels, DMs, search, threads, unread triage, and actions.">
+  <meta property="og:description" content="Give any stdio MCP agent useful Slack access. 19 self-hosted tools for channels, DMs, search, threads, unread triage, and actions.">
   <meta property="og:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Slack MCP Server — Interactive Demo">
-  <meta name="twitter:description" content="21 self-hosted Slack tools for any stdio MCP client. No Slack app or admin queue.">
+  <meta name="twitter:description" content="19 self-hosted Slack tools for any stdio MCP client. No Slack app or admin queue.">
   <meta name="twitter:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
   <link rel="icon" href="https://jtalk22.github.io/slack-mcp-server/docs/assets/icon-512.png" type="image/png">
 
   <!-- SEO -->
-  <meta name="description" content="Interactive Slack MCP demo: 21 self-hosted tools for channels, DMs, search, threads, unread triage, and actions.">
+  <meta name="description" content="Interactive Slack MCP demo: 19 self-hosted tools for channels, DMs, search, threads, unread triage, and actions.">
   <style>
     @font-face { font-family: "Nyght Serif"; src: url("fonts/nyght-serif-medium.woff2") format("woff2"); font-display: swap; font-weight: 500; }
     @font-face { font-family: "Nyght Serif"; src: url("fonts/nyght-serif-medium-italic.woff2") format("woff2"); font-display: swap; font-weight: 500; font-style: italic; }
@@ -781,7 +781,7 @@
       <a href="https://github.com/jtalk22/slack-mcp-server/blob/main/docs/SETUP.md" target="_blank" rel="noopener noreferrer">Setup Guide</a>
     </div>
     <div class="cta-note">
-      The free local path ships the current 21-tool surface with session-based auth and no app/admin queue. <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">Hosted</a> adds permanent OAuth, indexed retrieval, scheduled intelligence, and team continuity when the workflow must run without you.
+      The free local path ships the current 19-tool surface with session-based auth and no app/admin queue. <a href="https://mcp.revasserlabs.com" target="_blank" rel="noopener noreferrer">Hosted</a> adds permanent OAuth, indexed retrieval, scheduled intelligence, and team continuity when the workflow must run without you.
     </div>
   </div>
 

--- a/public/proof-reel.html
+++ b/public/proof-reel.html
@@ -316,7 +316,7 @@
             <div class="diag-row"><span class="tick">✓</span><span class="diag-step">01 CHROME PROFILE</span><span class="diag-detail">LevelDB → xoxc · newest record first</span></div>
             <div class="diag-row"><span class="tick">✓</span><span class="diag-step">02 COOKIE STORE</span><span class="diag-detail">SQLite + WAL → xoxd · locked DB snapshot</span></div>
             <div class="diag-row"><span class="tick">✓</span><span class="diag-step">03 KEYCHAIN</span><span class="diag-detail">PBKDF2 + AES-128-CBC · no clipboard detour</span></div>
-            <div class="diag-row"><span class="tick">✓</span><span class="diag-step">04 LOCAL STDIO</span><span class="diag-detail">21 tools ready · DMs · search · threads · actions</span></div>
+            <div class="diag-row"><span class="tick">✓</span><span class="diag-step">04 LOCAL STDIO</span><span class="diag-detail">19 tools ready · DMs · search · threads · actions</span></div>
           </div>
           <div class="system-tags rise"><span>automatic refresh</span><span>keychain-only mode</span><span>atomic writes</span><span>cross-process locks</span><span>workspace profiles</span><span>structured failure codes</span></div>
         </section>
@@ -334,7 +334,7 @@
               <p class="kicker">Your Slack / your agent / no permission slip</p>
               <h2 class="headline">You ask once. It does the scrolling.</h2>
               <div class="final-command">npx -y @jtalk22/slack-mcp --setup</div>
-              <div class="final-foot"><span>21 Slack tools · any stdio MCP client</span><span>No app registration · no admin queue</span></div>
+              <div class="final-foot"><span>19 Slack tools · any stdio MCP client</span><span>No app registration · no admin queue</span></div>
             </div>
           </div>
         </section>
@@ -342,7 +342,7 @@
 
       <footer class="inputbar">
         <div class="input-field">Message Claude...</div>
-        <span class="tools-chip">🔨 21 tools</span>
+        <span class="tools-chip">🔨 19 tools</span>
       </footer>
     </div>
   </main>

--- a/public/share.html
+++ b/public/share.html
@@ -8,7 +8,7 @@
   <link rel="canonical" href="https://jtalk22.github.io/slack-mcp-server/public/share.html">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Slack MCP Server — Ask what happened. Get receipts. Close the loop.">
-  <meta property="og:description" content="The free local path ships 21 tools today. Hosted adds permanent OAuth, indexing, schedules, and team continuity.">
+  <meta property="og:description" content="The free local path ships 19 tools today. Hosted adds permanent OAuth, indexing, schedules, and team continuity.">
   <meta property="og:url" content="https://jtalk22.github.io/slack-mcp-server/public/share.html">
   <meta property="og:image" content="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png">
   <meta property="og:image:width" content="1280">
@@ -130,7 +130,7 @@
 <body>
   <main class="wrap">
     <h1>Slack MCP Server</h1>
-    <p class="sub">Slack for your AI agent — no OAuth, no admin, no app to register. Self-host 21 tools for free: 12 read, 4 write, 2 workflow-profile primitives, 3 hosted-brain stubs. Hosted free tier — workflow continuity + AI catch-up. Sign up no card at <a href="https://mcp.revasserlabs.com">mcp.revasserlabs.com</a>.</p>
+    <p class="sub">Slack for your AI agent — no OAuth, no admin, no app to register. Self-host 19 tools for free: 12 read, 4 write, 3 local workflow tools. Hosted free tier — workflow continuity + AI catch-up. Sign up no card at <a href="https://mcp.revasserlabs.com">mcp.revasserlabs.com</a>.</p>
 
     <a class="preview" href="https://github.com/jtalk22/slack-mcp-server" rel="noopener">
       <img src="https://jtalk22.github.io/slack-mcp-server/docs/images/social-preview-v3.png" alt="Slack MCP Server social preview card">
@@ -146,7 +146,7 @@
       <a href="https://mcp.revasserlabs.com" rel="noopener" style="background:rgba(255,178,36,0.18);border-color:rgba(255,178,36,0.45);color:var(--signal)">Hosted</a>
     </div>
 
-    <p class="note"><strong>Ask what happened. Get receipts. Close the loop.</strong> The free local path gives you the current 21-tool surface without an app/admin queue. <a href="https://mcp.revasserlabs.com">Hosted</a> adds permanent OAuth, indexing, scheduled intelligence, and team continuity when the workflow must run without you.</p>
+    <p class="note"><strong>Ask what happened. Get receipts. Close the loop.</strong> The free local path gives you the current 19-tool surface without an app/admin queue. <a href="https://mcp.revasserlabs.com">Hosted</a> adds permanent OAuth, indexing, scheduled intelligence, and team continuity when the workflow must run without you.</p>
   </main>
 </body>
 </html>

--- a/scripts/apply-template.js
+++ b/scripts/apply-template.js
@@ -42,11 +42,9 @@ function printUsage() {
   console.log("Example:");
   console.log("  slack-mcp --apply-template support-triage --channels C012345,C067890");
   console.log("");
-  console.log("Templates write to ~/.slack-mcp-workflows.json. The hosted AI brain at");
-  console.log("mcp.revasserlabs.com (free tier or Pro $19/mo) reads these profiles and");
-  console.log("returns structured JSON per the workflow_kind. The OSS package ships the");
-  console.log("profile primitives + 3 discoverable upgrade stubs (slack_smart_search,");
-  console.log("slack_catch_me_up, slack_triage). The brain is hosted-only.");
+  console.log("Templates write to ~/.slack-mcp-workflows.json. slack_catch_me_up reads a");
+  console.log("profile by name and returns structured evidence shaped by its workflow_kind,");
+  console.log("locally, against your own session.");
 }
 
 function parseFlag(flag) {

--- a/scripts/check-public-surface-integrity.js
+++ b/scripts/check-public-surface-integrity.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
-import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -186,21 +186,60 @@ function main() {
     `all=${TOOLS.length} (README ${PUBLIC_METADATA.selfHostedToolCount}), read=${READ_TOOLS.length} (README 12), essentials=${ESSENTIALS_TOOLS.length}`
   );
 
-  // slack_catch_me_up is deliberately absent: it runs locally now (lib/catch-up.js),
-  // so it is no longer an upgrade stub and no longer a leak when a narrowed
-  // profile advertises it.
-  const hostedStubs = ["slack_smart_search", "slack_triage"];
-  const narrowedLeaks = ["read", "essentials"].flatMap((profile) =>
+  // 5.0.0 removed the hosted upgrade stubs. No profile — including "all" —
+  // may advertise a tool that exists to point at a paid tier, and no handler
+  // may return an upgrade payload in place of doing the work.
+  const retiredStubs = ["slack_smart_search", "slack_triage"];
+  const stubLeaks = ["all", "read", "essentials"].flatMap((profile) =>
     resolveToolProfile(profile)
       .tools.map((tool) => tool.name)
-      .filter((name) => hostedStubs.includes(name))
+      .filter((name) => retiredStubs.includes(name))
       .map((name) => `${profile}:${name}`)
+  );
+  const paidTierDescriptions = TOOLS
+    .filter((tool) => /hosted-only|upgrade to Pro|\$19\/mo|signup|free tier/i.test(tool.description))
+    .map((tool) => tool.name);
+  const handlersSource = read("lib/handlers.js");
+  const upgradePayloadMarkers = ["tool_requires_hosted", "signup_url", "pro_value_prop"].filter((m) => handlersSource.includes(m));
+  check(
+    results,
+    "no hosted upgrade stub in any profile",
+    stubLeaks.length === 0 && paidTierDescriptions.length === 0 && upgradePayloadMarkers.length === 0,
+    [
+      stubLeaks.length ? `advertised: ${stubLeaks.join(", ")}` : "",
+      paidTierDescriptions.length ? `paid-tier copy in: ${paidTierDescriptions.join(", ")}` : "",
+      upgradePayloadMarkers.length ? `upgrade payload markers in lib/handlers.js: ${upgradePayloadMarkers.join(", ")}` : "",
+    ].filter(Boolean).join("; ") || "every advertised tool does its own work"
+  );
+
+  // The protocol claim is a test, not a sentence. The README may say
+  // 2026-07-28 only while the proof exists; the HTTP entry may not mint a
+  // session; nothing may still import the retired v1 SDK.
+  const eraTestExists = existsSync(join(ROOT, "test", "mcp-era.test.js"));
+  check(
+    results,
+    "README protocol claim is backed by test/mcp-era.test.js",
+    readme.includes("2026-07-28") && eraTestExists,
+    eraTestExists ? "claim and proof both present" : "README claims 2026-07-28 without test/mcp-era.test.js"
+  );
+  const httpSource = read("src/server-http.js");
+  check(
+    results,
+    "HTTP entry is stateless",
+    !httpSource.includes("sessionIdGenerator") && httpSource.includes("createMcpHandler"),
+    "src/server-http.js must serve per request via createMcpHandler and never mint a session"
+  );
+  const v1Importers = ["src", "lib"].flatMap((dir) =>
+    readdirSync(join(ROOT, dir))
+      .filter((name) => name.endsWith(".js"))
+      .map((name) => `${dir}/${name}`)
+      .filter((relPath) => read(relPath).includes("@modelcontextprotocol/sdk"))
   );
   check(
     results,
-    "narrowed profiles carry no hosted upgrade stub",
-    narrowedLeaks.length === 0,
-    narrowedLeaks.length === 0 ? "read and essentials are Slack-only" : narrowedLeaks.join(", ")
+    "no import of the retired @modelcontextprotocol/sdk v1 package",
+    v1Importers.length === 0 && !Object.keys(packageJson.dependencies || {}).includes("@modelcontextprotocol/sdk"),
+    v1Importers.length === 0 ? "runtime is on SDK v2" : v1Importers.join(", ")
   );
 
   const unknownProfileNames = [...READ_TOOLS, ...ESSENTIALS_TOOLS].filter(
@@ -235,7 +274,7 @@ function main() {
     results,
     "CLI client-neutral help",
     cliHelpResult.status === 0 &&
-      cliHelpResult.stdout.includes("21 tools for any stdio MCP client") &&
+      cliHelpResult.stdout.includes(`${PUBLIC_METADATA.selfHostedToolCount} tools for any stdio MCP client`) &&
       !cliHelpResult.stdout.includes("Full Slack access for Claude"),
     cliHelpResult.stdout || cliHelpResult.stderr || "no output"
   );

--- a/scripts/check-public-surface-integrity.js
+++ b/scripts/check-public-surface-integrity.js
@@ -230,7 +230,8 @@ function main() {
     "src/server-http.js must serve per request via createMcpHandler and never mint a session"
   );
   const v1Importers = ["src", "lib"].flatMap((dir) =>
-    readdirSync(join(ROOT, dir))
+    readdirSync(join(ROOT, dir), { recursive: true })
+      .map(String)
       .filter((name) => name.endsWith(".js"))
       .map((name) => `${dir}/${name}`)
       .filter((relPath) => read(relPath).includes("@modelcontextprotocol/sdk"))

--- a/scripts/check-version-parity.js
+++ b/scripts/check-version-parity.js
@@ -91,9 +91,16 @@ async function main() {
     smitheryError = String(error?.message || error);
   }
 
+  // The in-repo Cloudflare worker (workers/mcp-worker.js) is a self-contained
+  // bundle and cannot import lib/public-metadata.js, so it carries a literal.
+  // It drifted to 4.0.0 once and stayed there for months; gate it here.
+  const workerSource = readFileSync(join(repoRoot, "workers", "mcp-worker.js"), "utf8");
+  const workerVersion = workerSource.match(/const WORKER_VERSION = "([^"]+)"/)?.[1] || null;
+
   const parityChecks = [
     { name: "package.json vs server.json", ok: localVersion === localServerVersion },
     { name: "package.json vs server.json package", ok: localVersion === localServerPkgVersion },
+    { name: "package.json vs workers/mcp-worker.js WORKER_VERSION", ok: workerVersion === localVersion },
     { name: "npm latest", ok: npmVersion === localVersion },
     { name: "MCP registry latest", ok: mcpRegistryVersion === localVersion },
     { name: "MCP registry websiteUrl", ok: mcpRegistryWebsiteUrl === expectedWebsiteUrl },
@@ -141,6 +148,12 @@ async function main() {
       "server.json (package entry)",
       localServerPkgVersion,
       localServerPkgVersion === localVersion ? "ok" : "mismatch"
+    ),
+    row(
+      "workers/mcp-worker.js WORKER_VERSION",
+      workerVersion,
+      workerVersion === localVersion ? "ok" : "mismatch",
+      "self-contained worker bundle carries a literal"
     ),
     row(
       "npm dist-tag latest",

--- a/scripts/setup-wizard.js
+++ b/scripts/setup-wizard.js
@@ -606,7 +606,7 @@ async function showHelp() {
   print(`${colors.bold}Tool selection:${colors.reset}`);
   print("  --tools essentials (or SLACK_MCP_TOOLS=essentials) advertises the six");
   print("  core tools to cut per-turn schema cost; 'read' advertises the 12");
-  print("  read-only Slack operations; 'all' is the default (21). Every handler");
+  print(`  read-only Slack operations; 'all' is the default (${PUBLIC_METADATA.selfHostedToolCount}). Every handler`);
   print("  stays callable whichever surface is advertised.");
   print();
   print(`${colors.bold}Request pacing:${colors.reset}`);

--- a/scripts/setup-wizard.js
+++ b/scripts/setup-wizard.js
@@ -25,7 +25,7 @@ import {
   setPersistedStorageMode,
   ACTIVE_PROFILE,
 } from "../lib/token-store.js";
-import { RELEASE_VERSION } from "../lib/public-metadata.js";
+import { PUBLIC_METADATA, RELEASE_VERSION } from "../lib/public-metadata.js";
 
 const IS_MACOS = platform() === 'darwin';
 
@@ -588,7 +588,7 @@ async function runDoctor() {
 async function showHelp() {
   print(`${colors.bold}slack-mcp-server v${VERSION}${colors.reset}`);
   print();
-  print("Turn your existing Slack browser session into 21 tools for any stdio MCP client.");
+  print(`Turn your existing Slack browser session into ${PUBLIC_METADATA.selfHostedToolCount} tools for any stdio MCP client.`);
   print();
   print(`${colors.bold}Usage:${colors.reset}`);
   print("  npx -y @jtalk22/slack-mcp             Start MCP server (stdio)");

--- a/server.json
+++ b/server.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/jtalk22/slack-mcp-server",
     "source": "github"
   },
-  "version": "4.9.0",
+  "version": "5.0.0",
   "remotes": [
     {
       "type": "streamable-http",
@@ -28,7 +28,7 @@
     {
       "registryType": "npm",
       "identifier": "@jtalk22/slack-mcp",
-      "version": "4.9.0",
+      "version": "5.0.0",
       "transport": {
         "type": "stdio"
       },

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -2,7 +2,7 @@
 # https://smithery.ai/docs/build/project-config/smithery-yaml
 # Slack's operating layer for AI agents: local browser-session auth with no app/admin queue,
 # or hosted permanent OAuth for indexed AI workflows, schedules, and team continuity.
-# The current local surface ships 21 tools; the product is positioned around the jobs, not a fixed count.
+# The current local surface ships 19 tools; the product is positioned around the jobs, not a fixed count.
 
 startCommand:
   type: stdio

--- a/src/server-http.js
+++ b/src/server-http.js
@@ -95,8 +95,24 @@ const mcpHandler = createMcpHandler(
 );
 const handleMcp = toNodeHandler(mcpHandler);
 
-// Create HTTP server
-const httpServer = http.createServer(async (req, res) => {
+// Create HTTP server. The whole request path is guarded: a rejection that
+// escaped here would be an unhandled promise rejection, which terminates the
+// process in Node — one malformed request must never take the server down.
+const httpServer = http.createServer((req, res) => {
+  handleHttpRequest(req, res).catch((error) => {
+    console.error(`request failed: ${error?.stack || error}`);
+    if (!res.headersSent) {
+      res.writeHead(500, { "Content-Type": "application/json" });
+    }
+    if (!res.writableEnded) {
+      res.end(JSON.stringify(
+        structuredError("internal_error", "The request could not be served.", "Retry; if it persists, check the server log.")
+      ));
+    }
+  });
+});
+
+async function handleHttpRequest(req, res) {
   const allowOrigin = applyCors(req, res);
 
   if (req.method === 'OPTIONS') {
@@ -170,7 +186,7 @@ const httpServer = http.createServer(async (req, res) => {
 
   res.writeHead(404);
   res.end('Not found');
-});
+}
 
 httpServer.listen(PORT, () => {
   console.log(`${SERVER_NAME} v${SERVER_VERSION} HTTP server running on port ${PORT}`);

--- a/src/server-http.js
+++ b/src/server-http.js
@@ -4,22 +4,21 @@
  *
  * Streamable HTTP version for hosted deployments (Smithery, etc.)
  * Tokens provided via environment variables.
+ *
+ * Per-request and stateless, per MCP 2026-07-28: every POST is answered by a
+ * fresh server instance, there is no `Mcp-Session-Id`, and GET/DELETE answer
+ * 405. 2025-era clients are served the same way (the SDK's stateless legacy
+ * idiom), so nothing older breaks — it just never minted a session here.
  */
 
 import http from 'node:http';
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
+import { createMcpHandler } from "@modelcontextprotocol/server";
+import { toNodeHandler } from "@modelcontextprotocol/node";
 
 import { getActiveToolProfile } from "../lib/tools.js";
-import { TOOL_HANDLERS } from "../lib/handlers.js";
 import { RELEASE_VERSION } from "../lib/public-metadata.js";
-import { isAuthDeath, lifeboatResponse } from "../lib/lifeboat.js";
+import { createSlackMcpServer, SERVER_NAME } from "../lib/mcp-server.js";
 
-const SERVER_NAME = "slack-mcp-server";
 const SERVER_VERSION = RELEASE_VERSION;
 const PORT = process.env.PORT || 3000;
 const HTTP_INSECURE = process.env.SLACK_MCP_HTTP_INSECURE === "1";
@@ -30,6 +29,11 @@ const HTTP_ALLOWED_ORIGINS = new Set(
     .map(origin => origin.trim())
     .filter(Boolean)
 );
+
+// The headers a 2026-07-28 client sends on every request, plus the ones a
+// 2025-era client still sends. There is no session header to allow because
+// there is no session.
+const MCP_ALLOWED_HEADERS = "Content-Type, Authorization, Accept, MCP-Protocol-Version, Mcp-Method, Mcp-Name";
 
 function structuredError(code, message, nextAction = null, details = null) {
   const payload = {
@@ -61,9 +65,20 @@ function applyCors(req, res) {
     res.setHeader("Access-Control-Allow-Origin", allowOrigin);
     if (allowOrigin !== "*") res.setHeader("Vary", "Origin");
   }
-  res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, mcp-session-id");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", MCP_ALLOWED_HEADERS);
   return allowOrigin;
+}
+
+function denyOrigin(res) {
+  res.writeHead(403, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(
+    structuredError(
+      "cors_origin_denied",
+      "Origin is not allowed.",
+      "Set SLACK_MCP_HTTP_ALLOWED_ORIGINS to a comma-separated allowlist."
+    )
+  ));
 }
 
 // Resolve the advertised tool surface once (SLACK_MCP_TOOLS narrows it; default
@@ -71,67 +86,14 @@ function applyCors(req, res) {
 const ACTIVE_TOOLS = getActiveToolProfile();
 if (ACTIVE_TOOLS.warning) console.warn(`Tool profile: ${ACTIVE_TOOLS.warning}`);
 
-// Create MCP server
-const server = new Server(
-  { name: SERVER_NAME, version: SERVER_VERSION },
-  { capabilities: { tools: {} } }
+// One handler for the process; one server instance per request. The factory
+// is the same one the stdio entry uses, so both transports advertise and
+// dispatch identically.
+const mcpHandler = createMcpHandler(
+  () => createSlackMcpServer({ tools: ACTIVE_TOOLS.tools }),
+  { onerror: (error) => console.error(`mcp: ${error?.message || error}`) }
 );
-
-// Register tool list handler
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: ACTIVE_TOOLS.tools
-}));
-
-// Register tool call handler
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  const { name, arguments: args } = request.params;
-
-  try {
-    // Shared dispatch map keeps this transport in lockstep with the stdio
-    // server and the advertised TOOLS list.
-    const handler = TOOL_HANDLERS[name];
-    if (!handler) {
-      return {
-        content: [{
-          type: "text",
-          text: JSON.stringify({
-            status: "error",
-            code: "unknown_tool",
-            message: `Unknown tool: ${name}`,
-            next_action: "Call tools/list to inspect available tool names."
-          }, null, 2)
-        }],
-        isError: true
-      };
-    }
-    return await handler(args);
-  } catch (error) {
-    // OAuth Lifeboat: dead session token → recovery guidance, not a raw error.
-    if (isAuthDeath(error)) {
-      return lifeboatResponse(error);
-    }
-    return {
-      content: [{
-        type: "text",
-        text: JSON.stringify({
-          status: "error",
-          code: "tool_call_failed",
-          message: String(error?.message || error),
-          next_action: "Retry with validated input payload."
-        }, null, 2)
-      }],
-      isError: true
-    };
-  }
-});
-
-// Create HTTP transport
-const transport = new StreamableHTTPServerTransport({
-  sessionIdGenerator: () => crypto.randomUUID(),
-});
-
-// Connect server to transport
-await server.connect(transport);
+const handleMcp = toNodeHandler(mcpHandler);
 
 // Create HTTP server
 const httpServer = http.createServer(async (req, res) => {
@@ -139,14 +101,7 @@ const httpServer = http.createServer(async (req, res) => {
 
   if (req.method === 'OPTIONS') {
     if (!HTTP_INSECURE && req.headers?.origin && !allowOrigin) {
-      res.writeHead(403, { "Content-Type": "application/json" });
-      res.end(JSON.stringify(
-        structuredError(
-          "cors_origin_denied",
-          "CORS origin is not allowed.",
-          "Set SLACK_MCP_HTTP_ALLOWED_ORIGINS to a comma-separated allowlist."
-        )
-      ));
+      denyOrigin(res);
       return;
     }
     res.writeHead(204);
@@ -169,6 +124,13 @@ const httpServer = http.createServer(async (req, res) => {
 
   // MCP endpoint
   if (req.url === '/mcp' || req.url === '/') {
+    // A browser-originated request from an origin outside the allowlist is
+    // refused before it reaches the protocol layer (DNS-rebinding guard).
+    if (!HTTP_INSECURE && req.headers?.origin && !allowOrigin) {
+      denyOrigin(res);
+      return;
+    }
+
     if (!HTTP_INSECURE) {
       if (!HTTP_AUTH_TOKEN) {
         res.writeHead(503, { "Content-Type": "application/json" });
@@ -184,7 +146,13 @@ const httpServer = http.createServer(async (req, res) => {
 
       const bearer = parseBearerToken(req);
       if (bearer !== HTTP_AUTH_TOKEN) {
-        res.writeHead(401, { "Content-Type": "application/json" });
+        // A 401 without a challenge dead-ends a client that could otherwise
+        // discover how to authenticate; the spec has required the header
+        // since 2025-06-18.
+        res.writeHead(401, {
+          "Content-Type": "application/json",
+          "WWW-Authenticate": 'Bearer realm="slack-mcp", error="invalid_token"'
+        });
         res.end(JSON.stringify(
           structuredError(
             "unauthorized",
@@ -196,7 +164,7 @@ const httpServer = http.createServer(async (req, res) => {
       }
     }
 
-    await transport.handleRequest(req, res);
+    await handleMcp(req, res);
     return;
   }
 
@@ -206,7 +174,7 @@ const httpServer = http.createServer(async (req, res) => {
 
 httpServer.listen(PORT, () => {
   console.log(`${SERVER_NAME} v${SERVER_VERSION} HTTP server running on port ${PORT}`);
-  console.log(`MCP endpoint: http://localhost:${PORT}/mcp`);
+  console.log(`MCP endpoint: http://localhost:${PORT}/mcp (stateless; MCP 2026-07-28 and 2025 revisions)`);
   console.log(`Tool profile: ${ACTIVE_TOOLS.profile} (${ACTIVE_TOOLS.tools.length} tools, source: ${ACTIVE_TOOLS.source})`);
   if (HTTP_INSECURE) {
     console.warn("WARNING: SLACK_MCP_HTTP_INSECURE=1 enabled. /mcp is unauthenticated and CORS is wildcard.");
@@ -224,3 +192,10 @@ httpServer.listen(PORT, () => {
     }
   }
 });
+
+const shutdown = async () => {
+  try { await mcpHandler.close(); } catch {}
+  httpServer.close(() => process.exit(0));
+};
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);

--- a/src/server.js
+++ b/src/server.js
@@ -11,251 +11,29 @@
  * - Network error retry with exponential backoff
  * - Background token health monitoring
  *
+ * Speaks MCP 2026-07-28 and every 2025 revision over the same stdio pipe:
+ * the SDK's stdio entry reads the client's opening message, selects the era,
+ * and pins one server instance for the life of the connection.
  */
 
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { serveStdio } from "@modelcontextprotocol/server/stdio";
 import { pathToFileURL } from "node:url";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-  ListPromptsRequestSchema,
-  GetPromptRequestSchema,
-  ListResourcesRequestSchema,
-  ReadResourceRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
 
 import { loadTokensReadOnly } from "../lib/token-store.js";
-import { RELEASE_VERSION } from "../lib/public-metadata.js";
 import { checkTokenHealth } from "../lib/slack-client.js";
 import { getActiveToolProfile } from "../lib/tools.js";
-import {
-  TOOL_HANDLERS,
-  handleHealthCheck,
-  handleListConversations,
-} from "../lib/handlers.js";
-import { isAuthDeath, lifeboatResponse } from "../lib/lifeboat.js";
+import { RELEASE_VERSION } from "../lib/public-metadata.js";
+import { createSlackMcpServer, SERVER_NAME } from "../lib/mcp-server.js";
+
+const SERVER_VERSION = RELEASE_VERSION;
 
 // Background refresh interval (4 hours)
 const BACKGROUND_REFRESH_INTERVAL = 4 * 60 * 60 * 1000;
-
-// Package info
-const SERVER_NAME = "slack-mcp-server";
-const SERVER_VERSION = RELEASE_VERSION;
-
-// MCP Prompts - predefined prompt templates for common Slack operations
-const PROMPTS = [
-  {
-    name: "search-recent",
-    description: "Search workspace for messages from the past week",
-    arguments: [
-      {
-        name: "query",
-        description: "Search terms to look for",
-        required: true
-      }
-    ]
-  },
-  {
-    name: "summarize-channel",
-    description: "Get recent activity from a channel for summarization",
-    arguments: [
-      {
-        name: "channel_id",
-        description: "Channel ID to summarize",
-        required: true
-      },
-      {
-        name: "days",
-        description: "Number of days to look back (default 7)",
-        required: false
-      }
-    ]
-  },
-  {
-    name: "find-messages-from",
-    description: "Find all messages from a specific user",
-    arguments: [
-      {
-        name: "username",
-        description: "Username or display name to search for",
-        required: true
-      }
-    ]
-  }
-];
-
-// MCP Resources - data sources the server provides
-const RESOURCES = [
-  {
-    uri: "slack://workspace/info",
-    name: "Workspace Info",
-    description: "Current workspace name, team, and authenticated user",
-    mimeType: "application/json"
-  },
-  {
-    uri: "slack://conversations/list",
-    name: "Conversations",
-    description: "List of available channels and DMs",
-    mimeType: "application/json"
-  }
-];
 
 // Resolve the advertised tool surface once per process. SLACK_MCP_TOOLS (or
 // --tools=…) can narrow it to cut per-turn schema cost; the default is the full
 // surface. Handlers stay fully wired regardless of what is advertised.
 const ACTIVE_TOOLS = getActiveToolProfile();
-
-// Initialize server
-const server = new Server(
-  { name: SERVER_NAME, version: SERVER_VERSION },
-  { capabilities: { tools: {}, prompts: {}, resources: {} } }
-);
-
-// Register tool list handler
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: ACTIVE_TOOLS.tools
-}));
-
-// Register prompts handlers
-server.setRequestHandler(ListPromptsRequestSchema, async () => ({
-  prompts: PROMPTS
-}));
-
-server.setRequestHandler(GetPromptRequestSchema, async (request) => {
-  const { name, arguments: args } = request.params;
-
-  switch (name) {
-    case "search-recent": {
-      const query = args?.query || "";
-      const oneWeekAgo = Math.floor(Date.now() / 1000) - (7 * 24 * 60 * 60);
-      return {
-        messages: [
-          {
-            role: "user",
-            content: {
-              type: "text",
-              text: `Search Slack for "${query}" from the past week. Use the slack_search_messages tool with query: "${query} after:${new Date(oneWeekAgo * 1000).toISOString().split('T')[0]}"`
-            }
-          }
-        ]
-      };
-    }
-    case "summarize-channel": {
-      const channelId = args?.channel_id || "";
-      const days = parseInt(args?.days, 10) || 7;
-      const since = Math.floor(Date.now() / 1000) - (days * 24 * 60 * 60);
-      return {
-        messages: [
-          {
-            role: "user",
-            content: {
-              type: "text",
-              text: `Get the last ${days} days of messages from channel ${channelId} and provide a summary. Use slack_conversations_history with channel_id: "${channelId}" and oldest: "${since}"`
-            }
-          }
-        ]
-      };
-    }
-    case "find-messages-from": {
-      const username = args?.username || "";
-      return {
-        messages: [
-          {
-            role: "user",
-            content: {
-              type: "text",
-              text: `Find messages from ${username}. Use slack_search_messages with query: "from:@${username}"`
-            }
-          }
-        ]
-      };
-    }
-    default:
-      throw new Error(`Unknown prompt: ${name}`);
-  }
-});
-
-// Register resources handlers
-server.setRequestHandler(ListResourcesRequestSchema, async () => ({
-  resources: RESOURCES
-}));
-
-server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
-  const { uri } = request.params;
-
-  switch (uri) {
-    case "slack://workspace/info": {
-      const result = await handleHealthCheck();
-      return {
-        contents: [
-          {
-            uri,
-            mimeType: "application/json",
-            text: result.content[0].text
-          }
-        ]
-      };
-    }
-    case "slack://conversations/list": {
-      const result = await handleListConversations({ types: "im,mpim,public_channel,private_channel", limit: 50 });
-      return {
-        contents: [
-          {
-            uri,
-            mimeType: "application/json",
-            text: result.content[0].text
-          }
-        ]
-      };
-    }
-    default:
-      throw new Error(`Unknown resource: ${uri}`);
-  }
-});
-
-// Register tool call handler
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  const { name, arguments: args } = request.params;
-
-  try {
-    // Shared dispatch map (lib/handlers.js) keeps this transport in lockstep
-    // with the HTTP server and the advertised TOOLS list.
-    const handler = TOOL_HANDLERS[name];
-    if (!handler) {
-      return {
-        content: [{
-          type: "text",
-          text: JSON.stringify({
-            status: "error",
-            code: "unknown_tool",
-            message: `Unknown tool: ${name}`,
-            next_action: "Use tools/list to discover available tools."
-          }, null, 2)
-        }],
-        isError: true
-      };
-    }
-    return await handler(args);
-  } catch (error) {
-    // OAuth Lifeboat: dead session token → recovery guidance, not a raw error.
-    if (isAuthDeath(error)) {
-      return lifeboatResponse(error);
-    }
-    return {
-      content: [{
-        type: "text",
-        text: JSON.stringify({
-          status: "error",
-          code: "tool_call_failed",
-          message: String(error?.message || error),
-          next_action: "Retry the call and include full arguments."
-        }, null, 2)
-      }],
-      isError: true
-    };
-  }
-});
 
 // Main entry point
 async function main() {
@@ -275,7 +53,7 @@ async function main() {
   }
 
   // Background token health check (every 4 hours)
-  // unref() alone doesn't prevent StdioServerTransport from keeping the event
+  // unref() alone doesn't prevent the stdio transport from keeping the event
   // loop alive after the MCP client disconnects — we add explicit shutdown
   // handlers below to kill zombie processes on stdin EOF and signals.
   const backgroundTimer = setInterval(async () => {
@@ -294,7 +72,7 @@ async function main() {
 
   // Explicit shutdown path prevents the zombie-process pileup we were seeing
   // when Claude Code or another MCP client disconnected without signalling.
-  // StdioServerTransport doesn't exit the event loop on its own when stdin EOFs.
+  // The stdio transport doesn't exit the event loop on its own when stdin EOFs.
   let shuttingDown = false;
   const shutdown = (reason) => {
     if (shuttingDown) return;
@@ -316,9 +94,11 @@ async function main() {
     `Tool profile: ${ACTIVE_TOOLS.profile} (${ACTIVE_TOOLS.tools.length} tools, source: ${ACTIVE_TOOLS.source})`
   );
 
-  // Start server
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+  // Start server. The entry owns the transport and the era decision; the
+  // default `legacy: 'serve'` keeps every 2025-era client working unchanged.
+  serveStdio(() => createSlackMcpServer({ tools: ACTIVE_TOOLS.tools }), {
+    onerror: (error) => console.error(`stdio transport: ${error?.message || error}`),
+  });
   console.error(`${SERVER_NAME} v${SERVER_VERSION} running`);
 }
 
@@ -343,5 +123,5 @@ if (isDirectExecution()) {
  * Returns a server instance with mock config for tool discovery
  */
 export function createSandboxServer() {
-  return server;
+  return createSlackMcpServer({ tools: ACTIVE_TOOLS.tools });
 }

--- a/templates/public-pages/share.html.tpl
+++ b/templates/public-pages/share.html.tpl
@@ -100,7 +100,7 @@
 <body>
   <main class="wrap">
     <h1>Slack MCP Server</h1>
-    <p class="sub">Slack for your AI agent — no OAuth, no admin, no app to register. Self-host {{SELF_HOSTED_TOOL_COUNT}} tools for free: 12 read, 4 write, 2 workflow-profile primitives, 3 hosted-brain stubs. Hosted free tier — workflow continuity + AI catch-up. Sign up no card at <a href="{{CANONICAL_SITE_URL}}">mcp.revasserlabs.com</a>.</p>
+    <p class="sub">Slack for your AI agent — no OAuth, no admin, no app to register. Self-host {{SELF_HOSTED_TOOL_COUNT}} tools for free: 12 read, 4 write, 3 local workflow tools. Hosted free tier — workflow continuity + AI catch-up. Sign up no card at <a href="{{CANONICAL_SITE_URL}}">mcp.revasserlabs.com</a>.</p>
 
     <a class="preview" href="{{GITHUB_REPO_URL}}" rel="noopener">
       <img src="{{SOCIAL_IMAGE_URL}}" alt="Slack MCP Server social preview card">

--- a/test/mcp-era.test.js
+++ b/test/mcp-era.test.js
@@ -1,0 +1,301 @@
+/**
+ * Proof for the README's protocol claim: this server speaks MCP 2026-07-28
+ * and every 2025 revision from the same binary.
+ *
+ * Three layers, each against the real SDK, no mocks:
+ *   1. In-process Streamable HTTP — the same handler src/server-http.js
+ *      serves — driven by a legacy client, a pinned 2026-07-28 client, and
+ *      raw wire requests that check the 2026-07-28 conformance details
+ *      (`resultType`, cache fields, `_meta` serverInfo, `Mcp-Method`
+ *      enforcement, unsupported-version rejection, 405 on GET/DELETE,
+ *      202 on notifications).
+ *   2. The real HTTP entry (src/server-http.js) spawned on a port: 405 on
+ *      GET, a spec-shaped 401 with `WWW-Authenticate`, a legacy initialize.
+ *   3. The real stdio entry (src/server.js) spawned as a child, opened by a
+ *      legacy client and by an auto-negotiating client.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createMcpHandler } from "@modelcontextprotocol/server";
+import { Client, StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
+
+import { createSlackMcpServer, SERVER_NAME, TOOLS_LIST_CACHE_HINT } from "../lib/mcp-server.js";
+import { RELEASE_VERSION } from "../lib/public-metadata.js";
+import { TOOLS } from "../lib/tools.js";
+
+const MODERN = "2026-07-28";
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const URL_ = "http://slack-mcp.test/mcp";
+
+// A hermetic child environment: no credential file, no Keychain probe, no
+// tool-profile narrowing inherited from the developer's shell.
+function childEnv() {
+  const env = { ...process.env };
+  delete env.SLACK_TOKEN;
+  delete env.SLACK_COOKIE;
+  delete env.SLACK_MCP_TOOLS;
+  env.HOME = mkdtempSync(join(tmpdir(), "slack-mcp-era-"));
+  env.SLACK_MCP_PROFILE = "mcp-era-test";
+  env.SLACK_MCP_TOKEN_STORAGE = "file";
+  env.SLACK_NO_AUTO_REFRESH = "true";
+  return env;
+}
+
+function inProcessHandler() {
+  return createMcpHandler(() => createSlackMcpServer({ tools: TOOLS }));
+}
+
+function fetchVia(handler) {
+  return async (input, init) => handler.fetch(input instanceof Request ? input : new Request(input, init));
+}
+
+async function connect(handler, clientOptions) {
+  const client = new Client({ name: "mcp-era-test", version: "0.0.0" }, clientOptions);
+  const transport = new StreamableHTTPClientTransport(new URL(URL_), { fetch: fetchVia(handler) });
+  await client.connect(transport);
+  return client;
+}
+
+const MODERN_META = {
+  "io.modelcontextprotocol/protocolVersion": MODERN,
+  "io.modelcontextprotocol/clientInfo": { name: "mcp-era-test", version: "0.0.0" },
+  "io.modelcontextprotocol/clientCapabilities": {},
+};
+
+async function post(handler, headers, body) {
+  const res = await handler.fetch(new Request(URL_, {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "application/json, text/event-stream", ...headers },
+    body: JSON.stringify(body),
+  }));
+  const text = await res.text();
+  let json = null;
+  try { json = JSON.parse(text); } catch {}
+  return { status: res.status, headers: res.headers, text, json };
+}
+
+test("legacy (2025-era) client: plain initialize, full surface, no cache fields", async () => {
+  const handler = inProcessHandler();
+  try {
+    const client = await connect(handler, {});
+    assert.equal(client.getProtocolEra(), "legacy");
+    assert.match(client.getNegotiatedProtocolVersion(), /^2025-/);
+    const list = await client.listTools();
+    assert.equal(list.tools.length, TOOLS.length);
+    assert.equal(list.ttlMs, undefined, "2025-era results never carry cache fields");
+    assert.equal(list._meta, undefined);
+    const call = await client.callTool({ name: "not_a_tool", arguments: {} });
+    assert.equal(call.isError, true);
+    assert.match(call.content[0].text, /unknown_tool/);
+    await client.close();
+  } finally {
+    await handler.close();
+  }
+});
+
+test("2026-07-28 client: modern era, cache hint, serverInfo in _meta", async () => {
+  const handler = inProcessHandler();
+  try {
+    const client = await connect(handler, { versionNegotiation: { mode: { pin: MODERN } } });
+    assert.equal(client.getProtocolEra(), "modern");
+    assert.equal(client.getNegotiatedProtocolVersion(), MODERN);
+    const list = await client.listTools();
+    assert.equal(list.tools.length, TOOLS.length);
+    assert.equal(list.ttlMs, TOOLS_LIST_CACHE_HINT.ttlMs);
+    assert.equal(list.cacheScope, TOOLS_LIST_CACHE_HINT.cacheScope);
+    assert.deepEqual(list._meta?.["io.modelcontextprotocol/serverInfo"], { name: SERVER_NAME, version: RELEASE_VERSION });
+    const call = await client.callTool({ name: "not_a_tool", arguments: {} });
+    assert.equal(call.isError, true);
+    await client.close();
+  } finally {
+    await handler.close();
+  }
+});
+
+test("auto-negotiating client discovers the modern era", async () => {
+  const handler = inProcessHandler();
+  try {
+    const client = await connect(handler, { versionNegotiation: { mode: "auto" } });
+    assert.equal(client.getProtocolEra(), "modern");
+    await client.close();
+  } finally {
+    await handler.close();
+  }
+});
+
+test("2026-07-28 wire conformance on the raw handler", async () => {
+  const handler = inProcessHandler();
+  try {
+    const modernHeaders = { "mcp-protocol-version": MODERN, "mcp-method": "tools/list" };
+    const listReq = { jsonrpc: "2.0", id: 1, method: "tools/list", params: { _meta: MODERN_META } };
+
+    const ok = await post(handler, modernHeaders, listReq);
+    assert.equal(ok.status, 200);
+    assert.equal(ok.json.result.resultType, "complete");
+    assert.equal(ok.json.result.ttlMs, TOOLS_LIST_CACHE_HINT.ttlMs);
+    assert.equal(ok.json.result.cacheScope, "public");
+    assert.equal(ok.json.result.tools.length, TOOLS.length);
+    assert.equal(ok.json.result._meta["io.modelcontextprotocol/serverInfo"].name, SERVER_NAME);
+
+    // Header/body disagreement is a 400 with the typed -32020 error.
+    const mismatch = await post(handler, { ...modernHeaders, "mcp-method": "tools/call" }, listReq);
+    assert.equal(mismatch.status, 400);
+    assert.equal(mismatch.json.error.code, -32020);
+
+    // A modern request without Mcp-Method is the same class of error.
+    const missing = await post(handler, { "mcp-protocol-version": MODERN }, listReq);
+    assert.equal(missing.status, 400);
+    assert.equal(missing.json.error.code, -32020);
+
+    // An unsupported revision is refused with -32022 naming what is supported.
+    const unsupported = await post(
+      handler,
+      { "mcp-protocol-version": "2027-01-01", "mcp-method": "tools/list" },
+      { ...listReq, params: { _meta: { ...MODERN_META, "io.modelcontextprotocol/protocolVersion": "2027-01-01" } } }
+    );
+    assert.equal(unsupported.status, 400);
+    assert.equal(unsupported.json.error.code, -32022);
+    assert.deepEqual(unsupported.json.error.data.supported, [MODERN]);
+
+    // server/discover names the modern revision.
+    const discover = await post(
+      handler,
+      { "mcp-protocol-version": MODERN, "mcp-method": "server/discover" },
+      { jsonrpc: "2.0", id: 2, method: "server/discover", params: { _meta: MODERN_META } }
+    );
+    assert.equal(discover.status, 200);
+    assert.deepEqual(discover.json.result.supportedVersions, [MODERN]);
+    assert.ok(discover.json.result.capabilities.tools);
+
+    // Notifications are accepted, not answered.
+    const note = await post(
+      handler,
+      { "mcp-protocol-version": MODERN, "mcp-method": "notifications/initialized" },
+      { jsonrpc: "2.0", method: "notifications/initialized", params: { _meta: MODERN_META } }
+    );
+    assert.equal(note.status, 202);
+
+    // No sessions: the 2025 session operations are not allowed here.
+    const get = await handler.fetch(new Request(URL_, { method: "GET", headers: { accept: "text/event-stream" } }));
+    assert.equal(get.status, 405);
+    const del = await handler.fetch(new Request(URL_, { method: "DELETE" }));
+    assert.equal(del.status, 405);
+
+    // A 2025-era initialize still answers, echoing the requested revision.
+    const legacy = await post(handler, {}, {
+      jsonrpc: "2.0", id: 3, method: "initialize",
+      params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "old", version: "0" } },
+    });
+    assert.equal(legacy.status, 200);
+    assert.match(legacy.text, /"protocolVersion":"2025-03-26"/);
+    assert.equal(legacy.headers.get("mcp-session-id"), null, "stateless: no session is ever minted");
+  } finally {
+    await handler.close();
+  }
+});
+
+async function spawnHttpEntry(extraEnv) {
+  const env = { ...childEnv(), ...extraEnv };
+  const child = spawn(process.execPath, [join(ROOT, "src/server-http.js")], { env, stdio: ["ignore", "pipe", "pipe"] });
+  let out = "";
+  const port = await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`server-http did not announce a port:\n${out}`)), 20000);
+    child.stdout.on("data", (chunk) => {
+      out += chunk;
+      const m = out.match(/running on port (\d+)/);
+      if (m) { clearTimeout(timer); resolve(Number(m[1])); }
+    });
+    child.stderr.on("data", (chunk) => { out += chunk; });
+    child.on("exit", (code) => { clearTimeout(timer); reject(new Error(`server-http exited ${code}:\n${out}`)); });
+  });
+  return { child, port, base: `http://127.0.0.1:${port}` };
+}
+
+test("src/server-http.js: stateless entry — 405 on GET, 401 challenges, legacy initialize answers", async () => {
+  // The entry logs the configured PORT, so pick a free one up front.
+  const { createServer } = await import("node:net");
+  const freePort = await new Promise((resolve) => {
+    const s = createServer(); s.listen(0, "127.0.0.1", () => { const p = s.address().port; s.close(() => resolve(p)); });
+  });
+  const { child, base } = await spawnHttpEntry({ PORT: String(freePort), SLACK_MCP_HTTP_AUTH_TOKEN: "secret-token" });
+  try {
+    const health = await fetch(`${base}/health`).then((r) => r.json());
+    assert.equal(health.version, RELEASE_VERSION);
+
+    const unauth = await fetch(`${base}/mcp`, { method: "POST", headers: { "content-type": "application/json" }, body: "{}" });
+    assert.equal(unauth.status, 401);
+    assert.match(unauth.headers.get("www-authenticate") || "", /^Bearer /, "401 must carry a WWW-Authenticate challenge");
+
+    const auth = { authorization: "Bearer secret-token" };
+    const get = await fetch(`${base}/mcp`, { method: "GET", headers: { ...auth, accept: "text/event-stream" } });
+    assert.equal(get.status, 405);
+    const del = await fetch(`${base}/mcp`, { method: "DELETE", headers: auth });
+    assert.equal(del.status, 405);
+
+    const init = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: { ...auth, "content-type": "application/json", accept: "application/json, text/event-stream" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "old", version: "0" } } }),
+    });
+    assert.equal(init.status, 200);
+    assert.equal(init.headers.get("mcp-session-id"), null);
+    assert.match(await init.text(), /"protocolVersion":"2025-06-18"/);
+
+    const modern = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: { ...auth, "content-type": "application/json", accept: "application/json, text/event-stream", "mcp-protocol-version": MODERN, "mcp-method": "tools/list" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: { _meta: MODERN_META } }),
+    });
+    assert.equal(modern.status, 200);
+    const body = await modern.json();
+    assert.equal(body.result.resultType, "complete");
+    assert.equal(body.result.tools.length, TOOLS.length);
+
+    const badOrigin = await fetch(`${base}/mcp`, { method: "POST", headers: { ...auth, origin: "https://evil.example", "content-type": "application/json" }, body: "{}" });
+    assert.equal(badOrigin.status, 403, "an origin outside the allowlist is refused before the protocol layer");
+  } finally {
+    child.kill("SIGTERM");
+  }
+});
+
+async function connectStdio(clientOptions) {
+  const client = new Client({ name: "mcp-era-test", version: "0.0.0" }, clientOptions);
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [join(ROOT, "src/server.js")],
+    env: childEnv(),
+    stderr: "ignore",
+  });
+  await client.connect(transport);
+  return client;
+}
+
+test("src/server.js over stdio: legacy client and auto-negotiating client both work", async () => {
+  const legacy = await connectStdio({});
+  try {
+    assert.equal(legacy.getProtocolEra(), "legacy");
+    const list = await legacy.listTools();
+    assert.equal(list.tools.length, TOOLS.length);
+    assert.ok(!list.tools.some((t) => /smart_search|triage/.test(t.name)), "no hosted stubs on the wire");
+  } finally {
+    await legacy.close();
+  }
+
+  const modern = await connectStdio({ versionNegotiation: { mode: "auto" } });
+  try {
+    assert.equal(modern.getProtocolEra(), "modern");
+    assert.equal(modern.getNegotiatedProtocolVersion(), MODERN);
+    const list = await modern.listTools();
+    assert.equal(list.tools.length, TOOLS.length);
+    assert.equal(list.cacheScope, "public");
+  } finally {
+    await modern.close();
+  }
+});

--- a/test/tool-profiles.test.js
+++ b/test/tool-profiles.test.js
@@ -38,20 +38,20 @@ test("read profile is the 12 read-only Slack operations", () => {
   assert.ok(!r.tools.some((t) => t.name === "slack_send_message"), "no write tools in read profile");
 });
 
-test("no profile advertises a hosted upgrade stub except 'all'", () => {
-  // The hosted stubs make no Slack call and return an upgrade payload. Anyone
-  // narrowing their surface to save schema cost must not be handed paid-tier
-  // advertising in every turn.
-  const stubs = ["slack_smart_search", "slack_catch_me_up", "slack_triage"];
-  for (const profile of ["read", "essentials"]) {
+test("no profile advertises a hosted upgrade stub — the surface is Slack-only", () => {
+  // 5.0.0 removed the two tools that made no Slack call and returned an
+  // upgrade payload. Nothing in any profile may point at a paid tier again.
+  const retired = ["slack_smart_search", "slack_triage"];
+  for (const profile of ["all", "read", "essentials"]) {
     const names = resolveToolProfile(profile).tools.map((t) => t.name);
-    for (const stub of stubs) {
+    for (const stub of retired) {
       assert.ok(!names.includes(stub), `${profile} must not advertise ${stub}`);
     }
   }
-  // They remain in the default surface, where discovery is the point.
-  const all = resolveToolProfile("all").tools.map((t) => t.name);
-  for (const stub of stubs) assert.ok(all.includes(stub), `all still advertises ${stub}`);
+  assert.equal(TOOLS.length, 19, "19 tools: 12 read + 4 write + 3 local workflow");
+  for (const tool of TOOLS) {
+    assert.ok(!/hosted-only|upgrade to Pro|\$19\/mo|signup/i.test(tool.description), `${tool.name} description must not advertise a paid tier`);
+  }
 });
 
 test("read profile excludes every tool that writes to the workspace", () => {

--- a/workers/mcp-worker.js
+++ b/workers/mcp-worker.js
@@ -5,6 +5,15 @@
  * User credentials passed via headers or session.
  */
 
+// Release version. The worker is a self-contained bundle (no lib/ import), so
+// this literal is gated by scripts/check-version-parity.js against package.json.
+const WORKER_VERSION = "5.0.0";
+
+// 2025-era revisions this hand-rolled JSON-RPC endpoint speaks. A client's
+// requested revision is echoed when supported; otherwise the oldest common one.
+const SUPPORTED_PROTOCOL_VERSIONS = ["2025-06-18", "2025-03-26", "2024-11-05"];
+const DEFAULT_PROTOCOL_VERSION = "2025-03-26";
+
 // MCP Prompts
 const PROMPTS = [
   {
@@ -672,13 +681,15 @@ async function handleMcpRequest(request, env, queryParams) {
     const { method, params, id } = req;
 
     switch (method) {
-      case "initialize":
+      case "initialize": {
+        const requested = params?.protocolVersion;
         responses.push(jsonRpcResponse(id, {
-          protocolVersion: "2024-11-05",
+          protocolVersion: SUPPORTED_PROTOCOL_VERSIONS.includes(requested) ? requested : DEFAULT_PROTOCOL_VERSION,
           capabilities: { tools: {}, prompts: {}, resources: {} },
-          serverInfo: { name: "slack-mcp-server", version: "4.0.0" }
+          serverInfo: { name: "slack-mcp-server", version: WORKER_VERSION }
         }));
         break;
+      }
 
       case "tools/list":
         responses.push(jsonRpcResponse(id, { tools: TOOLS }));
@@ -755,7 +766,7 @@ export default {
     // Health check
     if (url.pathname === '/health') {
       return Response.json(
-        { status: 'ok', server: 'slack-mcp-server', version: '4.0.0' },
+        { status: 'ok', server: 'slack-mcp-server', version: WORKER_VERSION },
         { headers: corsHeaders }
       );
     }
@@ -765,7 +776,7 @@ export default {
       return Response.json({
         serverInfo: {
           name: "Slack MCP",
-          version: "4.0.0"
+          version: WORKER_VERSION
         },
         authentication: {
           required: false


### PR DESCRIPTION
## What

- **SDK v2** (`@modelcontextprotocol/server` + `/node`; `/client` as a devDependency for the era test). `@modelcontextprotocol/sdk` v1 removed.
- **stdio**: `serveStdio(() => createSlackMcpServer())` — era negotiated per connection, `legacy: 'serve'` default keeps every 2025 client unchanged.
- **HTTP**: `createMcpHandler` + `toNodeHandler` — per-request, stateless, no `Mcp-Session-Id`, `GET`/`DELETE` → 405. `WWW-Authenticate` on the bearer 401. Non-allowlisted `Origin` refused on POST.
- **One factory** (`lib/mcp-server.js`) builds the server for both transports.
- **2026-07-28 on the wire**: `tools/list` `ttlMs: 60000, cacheScope: "public"`; `resultType`; `_meta` serverInfo; `Mcp-Method` enforcement (-32020); unsupported revision (-32022); `server/discover`.
- **BREAKING**: `slack_smart_search` and `slack_triage` removed (they returned an upgrade payload, never called Slack). Surface is **19 tools**: 12 read, 4 write, 3 local workflow. All counts, CLI help, docs, generated pages updated; `all` profile ≈3,134 est. tokens (was ≈3,600).
- `workers/mcp-worker.js`: single `WORKER_VERSION` literal (was `4.0.0` ×3) gated by `check-version-parity.js`; `initialize` echoes the client's supported 2025 revision instead of hard-coding `2024-11-05`.

## Proof

- `test/mcp-era.test.js` (6 tests): legacy client, pinned 2026-07-28 client, auto-negotiating client, raw-wire conformance, spawned `src/server-http.js`, spawned `src/server.js` over stdio.
- New CI gates in `check-public-surface-integrity.js`: README may say "2026-07-28" only while the era test exists; `src/server-http.js` must not contain `sessionIdGenerator`; nothing in `src/`/`lib/` may import the v1 SDK; no tool description may carry paid-tier copy; no upgrade-payload markers in `lib/handlers.js`.
- Local run: `npm test` 96 pass / 0 fail; `verify:public-surface` 45/45; `check-public-language` pass; generated pages + media manifest in sync; `verify:version-parity --allow-propagation` local pass (npm/registry at 4.9.0 until release); `verify-install-flow` pass; `@modelcontextprotocol/inspector --cli … tools/list` → 19.

## Not in this PR

Pricing page, product name, Stripe prices, Slack app manifest, hosted worker copy — unchanged by design. `lib/lifeboat.js` still points a dead-session recovery at hosted OAuth (recovery guidance, not a tool); left as is.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for MCP protocol revisions through 2026-07-28, including automatic compatibility negotiation.
  * Added local catch-up workflows using saved profiles.
  * HTTP access is now stateless, with stronger origin protection and clearer authentication responses.
  * Added MCP prompts and resources for supported Slack information.

* **Changes**
  * Reduced the available toolset from 21 to 19 by removing hosted search and triage tools.
  * Updated displayed documentation and product messaging to reflect the 19-tool offering.

* **Bug Fixes**
  * Improved handling of unsupported protocol versions, invalid methods, unauthorized requests, and disallowed origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->