### PR TITLE
Support sending messages to user IDs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -249,7 +249,7 @@ Send a message.
 **Parameters:**
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
-| channel_id | string | *required* | Channel or DM ID |
+| channel_id | string | *required* | Channel ID, DM ID, or user ID. User IDs are resolved to a DM automatically. |
 | text | string | *required* | Message text |
 | thread_ts | string | - | Thread to reply to |
 

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -564,9 +564,21 @@ export async function handleUsersInfo(args) {
 /**
  * Send message handler
  */
-export async function handleSendMessage(args) {
-  const result = await slackAPI("chat.postMessage", {
-    channel: args.channel_id,
+export async function handleSendMessage(args, api = slackAPI) {
+  let channelId = args.channel_id;
+
+  // chat.postMessage requires a conversation ID for browser-session tokens.
+  // Resolve Slack user IDs to their DM conversation before posting.
+  if (/^[UW][A-Z0-9]+$/.test(channelId || "")) {
+    const dmResult = await api("conversations.open", { users: channelId });
+    channelId = dmResult.channel?.id;
+    if (!channelId) {
+      throw new Error("Slack did not return a DM channel for the requested user.");
+    }
+  }
+
+  const result = await api("chat.postMessage", {
+    channel: channelId,
     text: args.text,
     thread_ts: args.thread_ts
   });

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -225,7 +225,7 @@ export const TOOLS = [
       properties: {
         channel_id: {
           type: "string",
-          description: "Channel or DM ID to send to"
+          description: "Channel ID, DM ID, or user ID to send to. User IDs are resolved to a DM automatically."
         },
         text: {
           type: "string",

--- a/test/send-message.test.js
+++ b/test/send-message.test.js
@@ -1,0 +1,55 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { handleSendMessage } from "../lib/handlers.js";
+
+test("send message posts directly to an existing conversation ID", async () => {
+  const calls = [];
+  const api = async (method, params) => {
+    calls.push({ method, params });
+    return { channel: params.channel, ts: "1700000000.000001", message: { text: params.text } };
+  };
+
+  await handleSendMessage({ channel_id: "D123ABC", text: "Hello" }, api);
+
+  assert.deepEqual(calls, [{
+    method: "chat.postMessage",
+    params: { channel: "D123ABC", text: "Hello", thread_ts: undefined }
+  }]);
+});
+
+test("send message resolves a user ID to a DM before posting", async () => {
+  const calls = [];
+  const api = async (method, params) => {
+    calls.push({ method, params });
+    if (method === "conversations.open") return { channel: { id: "D456DEF" } };
+    return { channel: params.channel, ts: "1700000000.000002", message: { text: params.text } };
+  };
+
+  const result = await handleSendMessage({
+    channel_id: "U123ABC",
+    text: "Hello",
+    thread_ts: "1699999999.000001"
+  }, api);
+
+  assert.deepEqual(calls, [
+    { method: "conversations.open", params: { users: "U123ABC" } },
+    {
+      method: "chat.postMessage",
+      params: {
+        channel: "D456DEF",
+        text: "Hello",
+        thread_ts: "1699999999.000001"
+      }
+    }
+  ]);
+  assert.equal(JSON.parse(result.content[0].text).channel, "D456DEF");
+});
+
+test("send message fails clearly when Slack does not return a DM channel", async () => {
+  const api = async () => ({ channel: {} });
+
+  await assert.rejects(
+    handleSendMessage({ channel_id: "U123ABC", text: "Hello" }, api),
+    /did not return a DM channel/
+  );
+});


### PR DESCRIPTION
## Summary

- resolve Slack user IDs to DM conversation IDs before posting
- preserve the existing path for channel and DM conversation IDs
- document user-ID support and cover both paths with focused tests

## Why

Some browser-session authentication contexts return `channel_not_found` when a user ID is passed directly to `chat.postMessage`. Calling `conversations.open` first provides the DM conversation ID expected by the posting method.

## Tests

- `node --check lib/handlers.js`
- `node --check lib/tools.js`
- `node --check test/send-message.test.js`
- `node --test test/send-message.test.js test/tools-schema.test.js test/tool-profiles.test.js`

The full `npm test` suite was also run on Windows. The new and related tests pass; two existing platform-specific tests fail around Windows ESM absolute-path handling and file-removal semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - You can now send messages directly to user IDs; they are automatically resolved to a direct message conversation before sending.
  - Existing channel and conversation IDs continue to work as before.
  - Clear errors are provided when a direct message conversation cannot be opened.

- **Documentation**
  - Updated tool guidance to explain that user IDs are supported for message delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->